### PR TITLE
Improve SIDHistory Cleanup by removing not working code

### DIFF
--- a/CleanupMonster.psd1
+++ b/CleanupMonster.psd1
@@ -8,7 +8,7 @@
     Description          = 'This module provides an easy way to cleanup Active Directory from dead/old objects based on various criteria. It can also disable, move or delete objects. It can utilize Azure AD, Intune and Jamf to get additional information about objects before deleting them.'
     FunctionsToExport    = @('Invoke-ADComputersCleanup', 'Invoke-ADSIDHistoryCleanup')
     GUID                 = 'cd1f9987-6242-452c-a7db-6337d4a6b639'
-    ModuleVersion        = '3.1.0'
+    ModuleVersion        = '3.1.1'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Private/Remove-ADSIDHistory.ps1
+++ b/Private/Remove-ADSIDHistory.ps1
@@ -35,145 +35,65 @@
 
         $ProcessedObjects++
 
-        if ($LimitPerSID) {
-            # Process individual SIDs for this object
-            foreach ($SID in $Object.SIDHistory) {
-                $CurrentDate = Get-Date
-                if ($PSCmdlet.ShouldProcess("$($Object.Name) ($($Object.Domain))", "Remove SID History entry $SID")) {
-                    Write-Color -Text "[i] ", "Removing SID History entry $SID from ", $Object.Name -Color Yellow, White, Green
-                    try {
-                        Set-ADObject -Identity $Object.DistinguishedName -Remove @{ SIDHistory = $SID } -Server $QueryServer -ErrorAction Stop
-                        $Result = [PSCustomObject]@{
-                            ObjectName   = $Object.Name
-                            ObjectDomain = $Object.Domain
-                            Enabled      = $Object.Enabled
-                            SID          = $SID
-                            Action       = 'RemovePerSID'
-                            ActionDate   = $CurrentDate
-                            ActionStatus = 'Success'
-                            ActionError  = ''
-                            ObjectDN     = $Object.DistinguishedName
-                        }
-                        $CurrentRunObject.Action = 'RemovePerSID'
-                        $CurrentRunObject.ActionDate = $CurrentDate
-                        $CurrentRunObject.ActionStatus = 'Success'
-                        $CurrentRunObject.ActionError = ''
-                        $CurrentRunObject.SIDRemoved += $SID
-                        Write-Color -Text "[+] ", "Removed SID History entry $SID from ", $Object.Name -Color Yellow, White, Green
-                    } catch {
-                        Write-Color -Text "[!] ", "Failed to remove SID History entry $SID from ", $Object.Name, " exception: ", $_.Exception.Message -Color Yellow, White, Red
-                        $Result = [PSCustomObject]@{
-                            ObjectName   = $Object.Name
-                            ObjectDomain = $Object.Domain
-                            SID          = $SID
-                            Action       = 'RemovePerSID'
-                            ActionDate   = $CurrentDate
-                            ActionStatus = 'Failed'
-                            ActionError  = $_.Exception.Message
-                            ObjectDN     = $Object.DistinguishedName
-                        }
-                        $CurrentRunObject.Action = 'RemovePerSID'
-                        $CurrentRunObject.ActionDate = $CurrentDate
-                        $CurrentRunObject.ActionStatus = 'Failed'
-                        $CurrentRunObject.ActionError = $_.Exception.Message
-                    }
-                } else {
-                    Write-Color -Text "[i] ", "Would have removed SID History entry $SID from ", $Object.Name -Color Yellow, White, Green
+        # Process individual SIDs for this object
+        foreach ($SID in $Object.SIDHistory) {
+            $CurrentDate = Get-Date
+            if ($PSCmdlet.ShouldProcess("$($Object.Name) ($($Object.Domain))", "Remove SID History entry $SID")) {
+                Write-Color -Text "[i] ", "Removing SID History entry $SID from ", $Object.Name -Color Yellow, White, Green
+                try {
+                    Set-ADObject -Identity $Object.DistinguishedName -Remove @{ SIDHistory = $SID } -Server $QueryServer -ErrorAction Stop
                     $Result = [PSCustomObject]@{
                         ObjectName   = $Object.Name
                         ObjectDomain = $Object.Domain
+                        Enabled      = $Object.Enabled
                         SID          = $SID
                         Action       = 'RemovePerSID'
-                        ActionDate   = Get-Date
-                        ActionStatus = 'WhatIf'
-                        ActionError  = ''
-                        ObjectDN     = $Object.DistinguishedName
-                    }
-                    $CurrentRunObject.SIDRemoved += $SID
-                    $CurrentRunObject.Action = 'RemovePerSID'
-                    $CurrentRunObject.ActionDate = $CurrentDate
-                    $CurrentRunObject.ActionStatus = 'WhatIf'
-                    $CurrentRunObject.ActionError = ''
-                }
-                $null = $Export.History.Add($Result)
-
-                try {
-                    $RefreshedObject = Get-ADObject -Identity $Object.DistinguishedName -Properties SIDHistory -Server $QueryServer -ErrorAction Stop
-                } catch {
-                    Write-Color -Text "[!] ", "Failed to refresh object ", $Object.Name, " exception: ", $_.Exception.Message -Color Yellow, White, Red, Red
-                    $RefreshedObject = $null
-                }
-                if ($RefreshedObject -and $RefreshedObject.SIDHistory) {
-                    $CurrentRunObject.SIDAfter = $RefreshedObject.SIDHistory -join ", "
-                } else {
-                    $CurrentRunObject.SIDAfter = $null
-                }
-
-                $CurrentRunObject.SIDAfterCount = $RefreshedObject.SIDHistory.Count
-                $Export.CurrentRun.Add($CurrentRunObject)
-                $GlobalLimitSID++
-                $ProcessedSIDs++
-
-                if ($GlobalLimitSID -ge $RemoveLimitSID) {
-                    Write-Color -Text "[i] ", "Reached SID limit of ", $RemoveLimitSID, ". Stopping processing." -Color Yellow, White, Green, White
-                    break TopLoop
-                }
-            }
-        } else {
-            $CurrentDate = Get-Date
-            # Process all SIDs for this object at once
-            if ($PSCmdlet.ShouldProcess("$($Object.Name) ($($Object.Domain))", "Remove all SID History entries")) {
-                Write-Color -Text "[i] ", "Removing all SID History entries from ", $Object.Name -Color Yellow, White, Green
-                try {
-                    Set-ADObject -Identity $Object.DistinguishedName -Clear SIDHistory -Server $QueryServer -ErrorAction Stop
-                    $Result = [PSCustomObject]@{
-                        ObjectName   = $Object.Name
-                        ObjectDomain = $Object.Domain
-                        SID          = $Object.SIDHistory -join ", "
-                        Action       = 'RemoveAll'
                         ActionDate   = $CurrentDate
                         ActionStatus = 'Success'
                         ActionError  = ''
                         ObjectDN     = $Object.DistinguishedName
                     }
+                    $CurrentRunObject.Action = 'RemovePerSID'
+                    $CurrentRunObject.ActionDate = $CurrentDate
                     $CurrentRunObject.ActionStatus = 'Success'
                     $CurrentRunObject.ActionError = ''
-                    Write-Color -Text "[+] ", "Removed all SID History entries from ", $Object.Name -Color Yellow, White, Green
+                    $CurrentRunObject.SIDRemoved += $SID
+                    Write-Color -Text "[+] ", "Removed SID History entry $SID from ", $Object.Name -Color Yellow, White, Green
                 } catch {
-                    Write-Color -Text "[!] ", "Failed to remove SID History entries from ", $Object.Name, " exception: ", $_.Exception.Message -Color Yellow, White, Red
+                    Write-Color -Text "[!] ", "Failed to remove SID History entry $SID from ", $Object.Name, " exception: ", $_.Exception.Message -Color Yellow, White, Red
                     $Result = [PSCustomObject]@{
                         ObjectName   = $Object.Name
                         ObjectDomain = $Object.Domain
-                        SID          = $Object.SIDHistory -join ", "
-                        Action       = 'RemoveAll'
+                        SID          = $SID
+                        Action       = 'RemovePerSID'
                         ActionDate   = $CurrentDate
                         ActionStatus = 'Failed'
                         ActionError  = $_.Exception.Message
                         ObjectDN     = $Object.DistinguishedName
                     }
+                    $CurrentRunObject.Action = 'RemovePerSID'
+                    $CurrentRunObject.ActionDate = $CurrentDate
                     $CurrentRunObject.ActionStatus = 'Failed'
                     $CurrentRunObject.ActionError = $_.Exception.Message
                 }
             } else {
-                Write-Color -Text "[i] ", "Would have removed all SID History entries from ", $Object.Name -Color Yellow, White, Green
+                Write-Color -Text "[i] ", "Would have removed SID History entry $SID from ", $Object.Name -Color Yellow, White, Green
                 $Result = [PSCustomObject]@{
                     ObjectName   = $Object.Name
                     ObjectDomain = $Object.Domain
-                    SID          = $Object.SIDHistory -join ", "
-                    Action       = 'RemoveAll'
-                    ActionDate   = $CurrentDate
+                    SID          = $SID
+                    Action       = 'RemovePerSID'
+                    ActionDate   = Get-Date
                     ActionStatus = 'WhatIf'
                     ActionError  = ''
                     ObjectDN     = $Object.DistinguishedName
                 }
+                $CurrentRunObject.SIDRemoved += $SID
+                $CurrentRunObject.Action = 'RemovePerSID'
+                $CurrentRunObject.ActionDate = $CurrentDate
                 $CurrentRunObject.ActionStatus = 'WhatIf'
                 $CurrentRunObject.ActionError = ''
             }
-            $CurrentRunObject.SIDRemoved += $Object.SIDHistory
-            $CurrentRunObject.Action = 'RemoveAll'
-            $CurrentRunObject.ActionDate = $CurrentDate
-            $CurrentRunObject.ActionError = ''
-
             $null = $Export.History.Add($Result)
 
             try {
@@ -190,7 +110,13 @@
 
             $CurrentRunObject.SIDAfterCount = $RefreshedObject.SIDHistory.Count
             $Export.CurrentRun.Add($CurrentRunObject)
-            $ProcessedSIDs += $Object.SIDHistory.Count
+            $GlobalLimitSID++
+            $ProcessedSIDs++
+
+            if ($GlobalLimitSID -ge $RemoveLimitSID) {
+                Write-Color -Text "[i] ", "Reached SID limit of ", $RemoveLimitSID, ". Stopping processing." -Color Yellow, White, Green, White
+                break TopLoop
+            }
         }
     }
     $Export['ProcessedObjects'] = $ProcessedObjects


### PR DESCRIPTION
This pull request includes a version update and a significant refactor to the `Remove-ADSIDHistory` function in the `CleanupMonster` module. The refactor simplifies the logic by removing the handling of processing all SIDs at once.

Version update:

* [`CleanupMonster.psd1`](diffhunk://#diff-3b9e7a883c7cf54637b6294057fa2013c9b07fb09c16c16663fdac55f2af28aaL11-R11): Updated `ModuleVersion` from '3.1.0' to '3.1.1'.

Refactor:

* [`Remove-ADSIDHistory.ps1`](diffhunk://#diff-13e108710a5da3ee4fee6ebc811e77be97a44750679cdad17e28d218ecab55acL38): Removed the code block that processed all SIDs for an object at once (wasn't working), including the associated `ShouldProcess` checks and error handling. The function now only processes individual SIDs. [[1]](diffhunk://#diff-13e108710a5da3ee4fee6ebc811e77be97a44750679cdad17e28d218ecab55acL38) [[2]](diffhunk://#diff-13e108710a5da3ee4fee6ebc811e77be97a44750679cdad17e28d218ecab55acL122-L194)