### PR TITLE
Fix missing Today parameter in ConvertTo-PreparedComputer

### DIFF
--- a/Private/ConvertTo-PreparedComputer.ps1
+++ b/Private/ConvertTo-PreparedComputer.ps1
@@ -1,4 +1,4 @@
-﻿function ConvertTo-PreparedComputer {
+function ConvertTo-PreparedComputer {
     [CmdletBinding()]
     param(
         [Microsoft.ActiveDirectory.Management.ADComputer[]] $Computers,
@@ -6,7 +6,8 @@
         [System.Collections.IDictionary] $JamfInformationCache,
         [switch] $IncludeAzureAD,
         [switch] $IncludeIntune,
-        [switch] $IncludeJamf
+        [switch] $IncludeJamf,
+        [DateTime] $Today = (Get-Date)
     )
 
     foreach ($Computer in $Computers) {


### PR DESCRIPTION
## Summary
- add missing Today parameter in `ConvertTo-PreparedComputer`

## Testing
- `pwsh -c "Get-Help"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f408a3978832ea9f15bfafe513652