### PR TITLE
feat: remove protection flag before disabling computers

### DIFF
--- a/Examples/DeleteComputersWithMoveAndEmail.ps1
+++ b/Examples/DeleteComputersWithMoveAndEmail.ps1
@@ -75,7 +75,7 @@ $invokeADComputersCleanupSplat = @{
     WhatIfMove                          = $true
     WhatIfDelete                        = $true
     ShowHTML                            = $true
-
+    RemoveProtectedFromAccidentalDeletionFlag = $true
     DontWriteToEventLog                 = $true
 }
 

--- a/Private/Request-ADComputersDisable.ps1
+++ b/Private/Request-ADComputersDisable.ps1
@@ -49,11 +49,11 @@
             } else {
                 $Success = $true
                 if ($DisableAndMoveOrder -eq 'DisableAndMove') {
-                    $Success = Disable-WinADComputer -Success $Success -WhatIfDisable:$WhatIfDisable -DontWriteToEventLog:$DontWriteToEventLog -Computer $Computer -Server $Server
+                    $Success = Disable-WinADComputer -Success $Success -WhatIfDisable:$WhatIfDisable -DontWriteToEventLog:$DontWriteToEventLog -Computer $Computer -Server $Server -RemoveProtectedFromAccidentalDeletionFlag:$RemoveProtectedFromAccidentalDeletionFlag.IsPresent
                     $Success = Move-WinADComputer -Success $Success -DisableAndMove $DisableAndMove -OrganizationalUnit $OrganizationalUnit -Computer $Computer -WhatIfDisable:$WhatIfDisable -DontWriteToEventLog:$DontWriteToEventLog -Server $Server -RemoveProtectedFromAccidentalDeletionFlag:$RemoveProtectedFromAccidentalDeletionFlag.IsPresent
                 } else {
                     $Success = Move-WinADComputer -Success $Success -DisableAndMove $DisableAndMove -OrganizationalUnit $OrganizationalUnit -Computer $Computer -WhatIfDisable:$WhatIfDisable -DontWriteToEventLog:$DontWriteToEventLog -Server $Server -RemoveProtectedFromAccidentalDeletionFlag:$RemoveProtectedFromAccidentalDeletionFlag.IsPresent
-                    $Success = Disable-WinADComputer -Success $Success -WhatIfDisable:$WhatIfDisable -DontWriteToEventLog:$DontWriteToEventLog -Computer $Computer -Server $Server
+                    $Success = Disable-WinADComputer -Success $Success -WhatIfDisable:$WhatIfDisable -DontWriteToEventLog:$DontWriteToEventLog -Computer $Computer -Server $Server -RemoveProtectedFromAccidentalDeletionFlag:$RemoveProtectedFromAccidentalDeletionFlag.IsPresent
                 }
                 if ($Success) {
                     if ($DisableModifyDescription -eq $true) {

--- a/Public/Invoke-ADComputersCleanup.ps1
+++ b/Public/Invoke-ADComputersCleanup.ps1
@@ -394,7 +394,7 @@
     This feature is only nessecary if you have specific requirments per domain/forest rather than using the automatic detection.
 
     .PARAMETER RemoveProtectedFromAccidentalDeletionFlag
-    Remove the ProtectedFromAccidentalDeletion flag from the computer object before deleting it.
+    Remove the ProtectedFromAccidentalDeletion flag from the computer object before disabling, moving, or deleting it.
     By default it will not remove the flag, and require it to be removed manually.
 
     .PARAMETER ADQueryMaxRetries

--- a/Tests/Disable-WinADComputer.Tests.ps1
+++ b/Tests/Disable-WinADComputer.Tests.ps1
@@ -1,0 +1,28 @@
+Describe 'Disable-WinADComputer' {
+    BeforeAll {
+        . "$PSScriptRoot/../Private/Disable-WinADComputer.ps1"
+    }
+
+    It 'removes ProtectedFromAccidentalDeletion when requested' {
+        $computer = [pscustomobject]@{
+            SamAccountName                   = 'TEST$'
+            DistinguishedName                = 'CN=Test,CN=Computers,DC=example,DC=com'
+            Enabled                          = $true
+            OperatingSystem                  = 'Windows'
+            LastLogonDate                    = Get-Date
+            LastLogonDays                    = 0
+            PasswordLastSet                  = Get-Date
+            PasswordLastChangedDays          = 0
+            ProtectedFromAccidentalDeletion  = $true
+        }
+        $global:FlagRemoved = $false
+        function Set-ADObject { param([Parameter(ValueFromRemainingArguments)][object[]]$Args) $global:FlagRemoved = $true }
+        function Disable-ADAccount { param([Parameter(ValueFromRemainingArguments)][object[]]$Args) }
+        function Write-Color { param([Parameter(ValueFromRemainingArguments)][object[]]$Args) }
+        function Write-Event { param([Parameter(ValueFromRemainingArguments)][object[]]$Args) }
+
+        Disable-WinADComputer -Success $true -Computer $computer -Server 'server' -WhatIfDisable:$false -DontWriteToEventLog -RemoveProtectedFromAccidentalDeletionFlag
+        $global:FlagRemoved | Should -Be $true
+    }
+}
+


### PR DESCRIPTION
## Summary
- add option to clear ProtectedFromAccidentalDeletion before disabling
- pass flag removal switch through disabling pipeline
- cover Disable-WinADComputer with Pester test and document flag removal parameter

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path ./Tests"`
- `pwsh -NoLogo -NoProfile -File Build/Build-Module.ps1` *(fails: The term 'Invoke-ModuleBuild' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_689510850fdc832ea16b76d72934acb7