### PR TITLE
Add staged cloud device cleanup workflow

### DIFF
--- a/CleanupMonster.psd1
+++ b/CleanupMonster.psd1
@@ -5,10 +5,10 @@
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'
-    Description          = 'This module provides an easy way to cleanup Active Directory from dead/old objects based on various criteria. It can also disable, move or delete objects. It can utilize Azure AD, Intune and Jamf to get additional information about objects before deleting them.'
-    FunctionsToExport    = @('Invoke-ADComputersCleanup', 'Invoke-ADSIDHistoryCleanup', 'Invoke-ADServiceAccountsCleanup')
+    Description          = 'This module provides an easy way to cleanup Active Directory and cloud devices from dead/old objects based on various criteria. It can also disable, move, retire or delete objects. It can utilize Azure AD, Intune and Jamf to get additional information about objects before deleting them.'
+    FunctionsToExport    = @('Invoke-ADComputersCleanup', 'Invoke-ADSIDHistoryCleanup', 'Invoke-ADServiceAccountsCleanup', 'Invoke-CloudDevicesCleanup')
     GUID                 = 'cd1f9987-6242-452c-a7db-6337d4a6b639'
-    ModuleVersion        = '3.1.7'
+    ModuleVersion        = '3.1.10'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Docs/Invoke-CloudDevicesCleanup.md
+++ b/Docs/Invoke-CloudDevicesCleanup.md
@@ -1,0 +1,57 @@
+---
+external help file: CleanupMonster-help.xml
+Module Name: CleanupMonster
+online version:
+schema: 2.0.0
+---
+
+# Invoke-CloudDevicesCleanup
+
+## SYNOPSIS
+Stages cleanup for stale AzureAD registered mobile devices from Microsoft Entra ID and Intune.
+
+## DESCRIPTION
+`Invoke-CloudDevicesCleanup` is the cloud-side companion to AD computer cleanup.
+It targets AzureAD registered mobile devices, builds a combined Entra and Intune inventory,
+classifies records as matched or orphaned, and supports staged actions:
+
+- `Retire` for Intune-managed devices
+- `Disable` for Microsoft Entra device objects
+- `Delete` for final record cleanup
+
+The workflow keeps its own pending datastore so actions can be separated across multiple runs.
+
+Orphan records are still discovered by default, but actioning them is intentionally explicit:
+
+- `-RetireIncludeIntuneOnly`
+- `-DisableIncludeEntraOnly`
+- `-DeleteIncludeEntraOnly`
+- `-DeleteIncludeIntuneOnly`
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Invoke-CloudDevicesCleanup -Retire -ReportOnly -WhatIf -ShowHTML
+```
+
+Preview stale cloud-device candidates without making changes.
+
+### Example 2
+```powershell
+Invoke-CloudDevicesCleanup `
+    -Retire `
+    -Disable `
+    -Delete `
+    -RetireLastSeenIntuneMoreThan 120 `
+    -DisableListProcessedMoreThan 30 `
+    -DeleteListProcessedMoreThan 30
+```
+
+Run the staged lifecycle for stale mobile devices with explicit grace periods.
+
+## NOTES
+
+- Designed primarily for `iOS` and `Android` AzureAD registered devices.
+- Inventory includes `Matched`, `EntraOnly`, and `IntuneOnly` record states.
+- Default behavior excludes company-owned devices unless explicitly included.

--- a/Docs/Readme.md
+++ b/Docs/Readme.md
@@ -14,3 +14,6 @@ Locale: en-US
 ### [Invoke-ADComputersCleanup](Invoke-ADComputersCleanup.md)
 {{ Fill in the Synopsis }}
 
+### [Invoke-CloudDevicesCleanup](Invoke-CloudDevicesCleanup.md)
+Staged cleanup of stale AzureAD registered mobile devices from Microsoft Entra ID and Intune.
+

--- a/Examples/CleanupCloudDevicesPreview.ps1
+++ b/Examples/CleanupCloudDevicesPreview.ps1
@@ -1,0 +1,46 @@
+<#
+.SYNOPSIS
+Preview stale AzureAD registered mobile devices from the cloud side.
+
+.DESCRIPTION
+This example builds a report for iOS and Android devices using the new
+cloud-device cleanup workflow. It is intentionally non-destructive and
+is the recommended starting point before enabling retire, disable, or delete.
+
+The report distinguishes between:
+- matched devices present in both Entra and Intune
+- Entra-only records
+- Intune-only orphan records
+
+Discovery includes orphan records by default, but action stages require
+explicit orphan-inclusion switches before those records can be actioned.
+#>
+
+Import-Module .\CleanupMonster.psd1 -Force
+
+Connect-MgGraph -Scopes `
+    Device.Read.All, `
+    Device.ReadWrite.All, `
+    DeviceManagementManagedDevices.Read.All, `
+    DeviceManagementManagedDevices.ReadWrite.All, `
+    DeviceManagementManagedDevices.PrivilegedOperations.All
+
+$configuration = @{
+    Retire                        = $true
+    Disable                       = $true
+    Delete                        = $true
+    ReportOnly                    = $true
+    WhatIfRetire                  = $true
+    WhatIfDisable                 = $true
+    WhatIfDelete                  = $true
+    IncludeOperatingSystem        = @('iOS*', 'Android*')
+    DataStorePath                 = "$PSScriptRoot\ProcessedCloudDevices.xml"
+    ReportPath                    = "$PSScriptRoot\Reports\CleanupCloudDevicesPreview_$((Get-Date).ToString('yyyy-MM-dd_HH_mm_ss')).html"
+    LogPath                       = "$PSScriptRoot\Logs\CleanupCloudDevicesPreview_$((Get-Date).ToString('yyyy-MM-dd_HH_mm_ss')).log"
+    ShowHTML                      = $true
+    SafetyEntraLimit              = 10
+    SafetyIntuneLimit             = 10
+}
+
+$output = Invoke-CloudDevicesCleanup @configuration
+$output

--- a/Examples/CleanupCloudDevicesStaged.ps1
+++ b/Examples/CleanupCloudDevicesStaged.ps1
@@ -1,0 +1,71 @@
+<#
+.SYNOPSIS
+Baseline staged lifecycle for AzureAD registered mobile devices.
+
+.DESCRIPTION
+This example uses a conservative sequence:
+- retire stale managed devices after 120 days
+- disable Entra device objects after 30 days on the pending list
+- delete only after an additional 30-day grace period
+
+This layout is aimed at production automation where you want reviewable,
+incremental changes with low action limits and reusable datastore/history.
+
+Orphan records are discovered and reported automatically, but this example
+keeps orphan actioning disabled by default. Enable the stage-specific
+switches only after you review the report and decide which orphan states
+you want to process in production.
+#>
+
+Import-Module .\CleanupMonster.psd1 -Force
+
+Connect-MgGraph -Scopes `
+    Device.Read.All, `
+    Device.ReadWrite.All, `
+    DeviceManagementManagedDevices.Read.All, `
+    DeviceManagementManagedDevices.ReadWrite.All, `
+    DeviceManagementManagedDevices.PrivilegedOperations.All
+
+$configuration = @{
+    Retire                        = $true
+    RetireLastSeenIntuneMoreThan  = 120
+    RetireLimit                   = 10
+
+    Disable                       = $true
+    DisableListProcessedMoreThan  = 30
+    DisableLastSeenEntraMoreThan  = 150
+    DisableLimit                  = 10
+
+    Delete                        = $true
+    DeleteListProcessedMoreThan   = 30
+    DeleteLastSeenIntuneMoreThan  = 180
+    DeleteLastSeenEntraMoreThan   = 180
+    DeleteRemoveIntuneRecord      = $true
+    DeleteLimit                   = 5
+
+    # Optional orphan handling:
+    # RetireIncludeIntuneOnly     = $true
+    # DisableIncludeEntraOnly     = $true
+    # DeleteIncludeEntraOnly      = $true
+    # DeleteIncludeIntuneOnly     = $true
+
+    IncludeOperatingSystem        = @('iOS*', 'Android*')
+    Exclusions                    = @(
+        'Shared-*'
+    )
+
+    DataStorePath                 = "$PSScriptRoot\ProcessedCloudDevices.xml"
+    ReportPath                    = "$PSScriptRoot\Reports\CleanupCloudDevices_$((Get-Date).ToString('yyyy-MM-dd_HH_mm_ss')).html"
+    LogPath                       = "$PSScriptRoot\Logs\CleanupCloudDevices_$((Get-Date).ToString('yyyy-MM-dd_HH_mm_ss')).log"
+    ShowHTML                      = $true
+
+    WhatIfRetire                  = $true
+    WhatIfDisable                 = $true
+    WhatIfDelete                  = $true
+
+    SafetyEntraLimit              = 10
+    SafetyIntuneLimit             = 10
+}
+
+$output = Invoke-CloudDevicesCleanup @configuration
+$output

--- a/Private/Assert-CloudDeviceCleanupSettings.ps1
+++ b/Private/Assert-CloudDeviceCleanupSettings.ps1
@@ -2,6 +2,18 @@ function Assert-CloudDeviceCleanupSettings {
     [CmdletBinding()]
     param()
 
+    $moduleAvailable = Get-Module -Name GraphEssentials -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+    if (-not $moduleAvailable) {
+        Write-Color -Text '[e] ', "'GraphEssentials' module is required for cloud-device cleanup but is not available. Terminating." -Color Yellow, Red
+        return $false
+    }
+
+    $minimumVersion = [version] '0.0.56'
+    if ($moduleAvailable.Version -lt $minimumVersion) {
+        Write-Color -Text '[e] ', "'GraphEssentials' module is outdated for cloud-device cleanup. Please update to minimum version '$minimumVersion'. Terminating." -Color Yellow, Red
+        return $false
+    }
+
     $requiredCommands = @(
         'Get-MyDevice'
         'Get-MyDeviceIntune'

--- a/Private/Assert-CloudDeviceCleanupSettings.ps1
+++ b/Private/Assert-CloudDeviceCleanupSettings.ps1
@@ -1,0 +1,26 @@
+function Assert-CloudDeviceCleanupSettings {
+    [CmdletBinding()]
+    param()
+
+    $requiredCommands = @(
+        'Get-MyDevice'
+        'Get-MyDeviceIntune'
+        'Invoke-MyDeviceRetire'
+        'Disable-MyDevice'
+        'Remove-MyDevice'
+        'Remove-MyDeviceIntuneRecord'
+    )
+
+    $missingCommands = foreach ($commandName in $requiredCommands) {
+        if (-not (Get-Command -Name $commandName -ErrorAction SilentlyContinue)) {
+            $commandName
+        }
+    }
+
+    if ($missingCommands.Count -gt 0) {
+        Write-Color -Text '[e] ', 'GraphEssentials cloud-device commands are missing: ', ($missingCommands -join ', '), '. Terminating.' -Color Yellow, Red, Yellow, Red
+        return $false
+    }
+
+    $true
+}

--- a/Private/Find-ProcessedCloudDeviceRecord.ps1
+++ b/Private/Find-ProcessedCloudDeviceRecord.ps1
@@ -1,0 +1,62 @@
+function Find-ProcessedCloudDeviceRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSObject] $Device,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $ProcessedDevices
+    )
+
+    $currentDeviceKeys = @(Get-CloudDeviceRecordKeys -Device $Device)
+
+    foreach ($candidateKey in $currentDeviceKeys) {
+        if ($ProcessedDevices.Contains($candidateKey)) {
+            return [PSCustomObject] @{
+                CurrentDeviceKey         = $currentDeviceKeys[0]
+                CurrentDeviceKeys        = $currentDeviceKeys
+                MatchedProcessedDeviceKey = $candidateKey
+                ProcessedDevice          = $ProcessedDevices[$candidateKey]
+            }
+        }
+    }
+
+    foreach ($processedDeviceKey in @($ProcessedDevices.Keys)) {
+        $processedDevice = $ProcessedDevices[$processedDeviceKey]
+        $processedDeviceKeys = @()
+
+        if ($processedDevice.PSObject.Properties['ProcessedDeviceKeys'] -and $processedDevice.ProcessedDeviceKeys) {
+            $processedDeviceKeys = @($processedDevice.ProcessedDeviceKeys)
+        } else {
+            $processedDeviceKeys = @(
+                if ($processedDevice.PSObject.Properties['ManagedDeviceId'] -and $processedDevice.ManagedDeviceId) {
+                    "intune:$($processedDevice.ManagedDeviceId)"
+                }
+                if ($processedDevice.PSObject.Properties['EntraDeviceObjectId'] -and $processedDevice.EntraDeviceObjectId) {
+                    "entra:$($processedDevice.EntraDeviceObjectId)"
+                }
+                if ($processedDevice.PSObject.Properties['DeviceId'] -and $processedDevice.DeviceId) {
+                    "device:$($processedDevice.DeviceId)"
+                }
+            )
+        }
+
+        foreach ($candidateKey in $currentDeviceKeys) {
+            if ($processedDeviceKeys -contains $candidateKey) {
+                return [PSCustomObject] @{
+                    CurrentDeviceKey         = $currentDeviceKeys[0]
+                    CurrentDeviceKeys        = $currentDeviceKeys
+                    MatchedProcessedDeviceKey = $processedDeviceKey
+                    ProcessedDevice          = $processedDevice
+                }
+            }
+        }
+    }
+
+    [PSCustomObject] @{
+        CurrentDeviceKey         = $currentDeviceKeys[0]
+        CurrentDeviceKeys        = $currentDeviceKeys
+        MatchedProcessedDeviceKey = $null
+        ProcessedDevice          = $null
+    }
+}

--- a/Private/Get-CloudDeviceRecordKey.ps1
+++ b/Private/Get-CloudDeviceRecordKey.ps1
@@ -5,16 +5,16 @@ function Get-CloudDeviceRecordKey {
         [PSObject] $Device
     )
 
+    if ($Device.PSObject.Properties['ManagedDeviceId'] -and $Device.ManagedDeviceId) {
+        return "intune:$($Device.ManagedDeviceId)"
+    }
+
     if ($Device.PSObject.Properties['EntraDeviceObjectId'] -and $Device.EntraDeviceObjectId) {
         return "entra:$($Device.EntraDeviceObjectId)"
     }
 
     if ($Device.PSObject.Properties['DeviceId'] -and $Device.DeviceId) {
         return "device:$($Device.DeviceId)"
-    }
-
-    if ($Device.PSObject.Properties['ManagedDeviceId'] -and $Device.ManagedDeviceId) {
-        return "intune:$($Device.ManagedDeviceId)"
     }
 
     throw "Get-CloudDeviceRecordKey - Unable to build a stable key for device '$($Device.Name)'."

--- a/Private/Get-CloudDeviceRecordKey.ps1
+++ b/Private/Get-CloudDeviceRecordKey.ps1
@@ -1,0 +1,21 @@
+function Get-CloudDeviceRecordKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSObject] $Device
+    )
+
+    if ($Device.PSObject.Properties['EntraDeviceObjectId'] -and $Device.EntraDeviceObjectId) {
+        return "entra:$($Device.EntraDeviceObjectId)"
+    }
+
+    if ($Device.PSObject.Properties['DeviceId'] -and $Device.DeviceId) {
+        return "device:$($Device.DeviceId)"
+    }
+
+    if ($Device.PSObject.Properties['ManagedDeviceId'] -and $Device.ManagedDeviceId) {
+        return "intune:$($Device.ManagedDeviceId)"
+    }
+
+    throw "Get-CloudDeviceRecordKey - Unable to build a stable key for device '$($Device.Name)'."
+}

--- a/Private/Get-CloudDeviceRecordKey.ps1
+++ b/Private/Get-CloudDeviceRecordKey.ps1
@@ -5,17 +5,5 @@ function Get-CloudDeviceRecordKey {
         [PSObject] $Device
     )
 
-    if ($Device.PSObject.Properties['ManagedDeviceId'] -and $Device.ManagedDeviceId) {
-        return "intune:$($Device.ManagedDeviceId)"
-    }
-
-    if ($Device.PSObject.Properties['EntraDeviceObjectId'] -and $Device.EntraDeviceObjectId) {
-        return "entra:$($Device.EntraDeviceObjectId)"
-    }
-
-    if ($Device.PSObject.Properties['DeviceId'] -and $Device.DeviceId) {
-        return "device:$($Device.DeviceId)"
-    }
-
-    throw "Get-CloudDeviceRecordKey - Unable to build a stable key for device '$($Device.Name)'."
+    @(Get-CloudDeviceRecordKeys -Device $Device)[0]
 }

--- a/Private/Get-CloudDeviceRecordKeys.ps1
+++ b/Private/Get-CloudDeviceRecordKeys.ps1
@@ -1,0 +1,32 @@
+function Get-CloudDeviceRecordKeys {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSObject] $Device
+    )
+
+    $keys = [System.Collections.Generic.List[string]]::new()
+    $seenKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    foreach ($candidateKey in @(
+            if ($Device.PSObject.Properties['ManagedDeviceId'] -and $Device.ManagedDeviceId) {
+                "intune:$($Device.ManagedDeviceId)"
+            }
+            if ($Device.PSObject.Properties['EntraDeviceObjectId'] -and $Device.EntraDeviceObjectId) {
+                "entra:$($Device.EntraDeviceObjectId)"
+            }
+            if ($Device.PSObject.Properties['DeviceId'] -and $Device.DeviceId) {
+                "device:$($Device.DeviceId)"
+            }
+        )) {
+        if ($candidateKey -and $seenKeys.Add($candidateKey)) {
+            $keys.Add($candidateKey)
+        }
+    }
+
+    if ($keys.Count -eq 0) {
+        throw "Get-CloudDeviceRecordKeys - Unable to build stable keys for device '$($Device.Name)'."
+    }
+
+    @($keys)
+}

--- a/Private/Get-CloudDeviceSelectionReason.ps1
+++ b/Private/Get-CloudDeviceSelectionReason.ps1
@@ -1,0 +1,62 @@
+function Get-CloudDeviceSelectionReason {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSObject] $Device,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Retire', 'Disable', 'Delete')]
+        [string] $Type,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $ActionIf,
+
+        [PSObject] $ProcessedDevice
+    )
+
+    $reasons = [System.Collections.Generic.List[string]]::new()
+
+    $reasons.Add("RecordState=$($Device.RecordState)")
+
+    if ($null -ne $ActionIf.LastSeenEntraMoreThan -and $null -ne $Device.EntraLastSeenDays) {
+        $reasons.Add("EntraLastSeenDays=$($Device.EntraLastSeenDays) > $($ActionIf.LastSeenEntraMoreThan)")
+    }
+
+    if ($null -ne $ActionIf.LastSeenIntuneMoreThan -and $null -ne $Device.IntuneLastSeenDays) {
+        $reasons.Add("IntuneLastSeenDays=$($Device.IntuneLastSeenDays) > $($ActionIf.LastSeenIntuneMoreThan)")
+    }
+
+    if ($null -ne $ActionIf.ListProcessedMoreThan -and $ProcessedDevice -and $ProcessedDevice.ActionDate) {
+        $pendingDays = (New-TimeSpan -Start $ProcessedDevice.ActionDate -End (Get-Date)).Days
+        $reasons.Add("PendingDays=$pendingDays >= $($ActionIf.ListProcessedMoreThan)")
+        $reasons.Add("PreviousAction=$($ProcessedDevice.Action)")
+    }
+
+    if ($Type -eq 'Retire' -and $Device.HasIntuneRecord) {
+        $reasons.Add('Retire via Intune managed device')
+        if ($Device.RecordState -eq 'IntuneOnly') {
+            $reasons.Add("IncludeIntuneOnly=$($ActionIf.IncludeIntuneOnly)")
+        }
+    }
+
+    if ($Type -eq 'Disable' -and $Device.HasEntraRecord) {
+        $reasons.Add('Disable via Microsoft Entra device object')
+        if ($Device.RecordState -eq 'EntraOnly') {
+            $reasons.Add("IncludeEntraOnly=$($ActionIf.IncludeEntraOnly)")
+        }
+    }
+
+    if ($Type -eq 'Delete') {
+        if ($Device.HasIntuneRecord -and $Device.HasEntraRecord) {
+            $reasons.Add('Delete Intune record and Entra device object')
+        } elseif ($Device.HasIntuneRecord) {
+            $reasons.Add('Delete Intune orphan record')
+            $reasons.Add("IncludeIntuneOnly=$($ActionIf.IncludeIntuneOnly)")
+        } elseif ($Device.HasEntraRecord) {
+            $reasons.Add('Delete Entra orphan record')
+            $reasons.Add("IncludeEntraOnly=$($ActionIf.IncludeEntraOnly)")
+        }
+    }
+
+    $reasons -join '; '
+}

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -41,7 +41,13 @@ function Get-CloudDevicesToProcess {
                 continue
             }
             if ($processedDevice -and $processedDevice.Action -eq 'Retire') {
-                continue
+                $retireAlreadySucceeded = $processedDevice.ActionStatus -is [bool] -and $processedDevice.ActionStatus
+                if (-not $retireAlreadySucceeded) {
+                    $retireAlreadySucceeded = [string] $processedDevice.ActionStatus -eq 'True'
+                }
+                if ($retireAlreadySucceeded) {
+                    continue
+                }
             }
         } elseif ($Type -eq 'Disable') {
             if (-not $device.HasEntraRecord -or $device.Enabled -eq $false) {

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -1,0 +1,101 @@
+function Get-CloudDevicesToProcess {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('Retire', 'Disable', 'Delete')]
+        [string] $Type,
+
+        [Parameter(Mandatory)]
+        [Array] $Devices,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $ActionIf,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $ProcessedDevices
+    )
+
+    Write-Color -Text '[i] ', "Applying following rules to $Type action:" -Color Yellow, Cyan, Green
+    foreach ($key in $ActionIf.Keys) {
+        if ($null -eq $ActionIf[$key] -or ($ActionIf[$key] -is [System.Array] -and $ActionIf[$key].Count -eq 0)) {
+            Write-Color -Text '   [>] ', $key, ' is ', 'Not Set' -Color Yellow, Cyan, Yellow
+        } else {
+            Write-Color -Text '   [>] ', $key, ' is ', $ActionIf[$key] -Color Yellow, Cyan, Green
+        }
+    }
+
+    $today = Get-Date
+    $candidates = foreach ($device in $Devices) {
+        $deviceKey = Get-CloudDeviceRecordKey -Device $device
+        $processedDevice = $ProcessedDevices[$deviceKey]
+
+        if ($ActionIf.ExcludeCompanyOwned -and $device.ManagedDeviceOwnerType -eq 'company') {
+            continue
+        }
+
+        if ($Type -eq 'Retire') {
+            if (-not $device.HasIntuneRecord) {
+                continue
+            }
+            if ($device.RecordState -eq 'IntuneOnly' -and -not $ActionIf.IncludeIntuneOnly) {
+                continue
+            }
+            if ($processedDevice -and $processedDevice.Action -eq 'Retire') {
+                continue
+            }
+        } elseif ($Type -eq 'Disable') {
+            if (-not $device.HasEntraRecord -or $device.Enabled -eq $false) {
+                continue
+            }
+            if ($device.RecordState -eq 'EntraOnly' -and -not $ActionIf.IncludeEntraOnly) {
+                continue
+            }
+        } elseif ($Type -eq 'Delete') {
+            if (-not $device.HasEntraRecord -and -not $device.HasIntuneRecord) {
+                continue
+            }
+            if ($device.RecordState -eq 'EntraOnly' -and -not $ActionIf.IncludeEntraOnly) {
+                continue
+            }
+            if ($device.RecordState -eq 'IntuneOnly' -and -not $ActionIf.IncludeIntuneOnly) {
+                continue
+            }
+        }
+
+        if ($null -ne $ActionIf.ListProcessedMoreThan) {
+            if (-not $processedDevice -or -not $processedDevice.ActionDate) {
+                continue
+            }
+
+            $timeOnPendingList = (New-TimeSpan -Start $processedDevice.ActionDate -End $today).Days
+            if ($timeOnPendingList -lt $ActionIf.ListProcessedMoreThan) {
+                $processedDevice.TimeOnPendingList = $timeOnPendingList
+                $processedDevice.TimeToNextAction = $ActionIf.ListProcessedMoreThan - $timeOnPendingList
+                continue
+            }
+        }
+
+        if ($null -ne $ActionIf.LastSeenEntraMoreThan) {
+            if ($null -eq $device.EntraLastSeenDays -or $device.EntraLastSeenDays -le $ActionIf.LastSeenEntraMoreThan) {
+                continue
+            }
+        }
+
+        if ($null -ne $ActionIf.LastSeenIntuneMoreThan) {
+            if ($null -eq $device.IntuneLastSeenDays -or $device.IntuneLastSeenDays -le $ActionIf.LastSeenIntuneMoreThan) {
+                continue
+            }
+        }
+
+        $candidate = $device | Select-Object *
+        $selectionReason = Get-CloudDeviceSelectionReason -Device $device -Type $Type -ActionIf $ActionIf -ProcessedDevice $processedDevice
+        Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'Action' -Value $Type -Force
+        Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'ProcessedDeviceKey' -Value $deviceKey -Force
+        Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'TimeOnPendingList' -Value $(if ($processedDevice) { $processedDevice.TimeOnPendingList } else { $null }) -Force
+        Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'TimeToNextAction' -Value $(if ($processedDevice) { $processedDevice.TimeToNextAction } else { $null }) -Force
+        Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'SelectionReason' -Value $selectionReason -Force
+        $candidate
+    }
+
+    @($candidates)
+}

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -28,6 +28,14 @@ function Get-CloudDevicesToProcess {
     $candidates = foreach ($device in $Devices) {
         $deviceKey = Get-CloudDeviceRecordKey -Device $device
         $processedDevice = $ProcessedDevices[$deviceKey]
+        $processedActionSucceeded = $false
+
+        if ($processedDevice) {
+            $processedActionSucceeded = $processedDevice.ActionStatus -is [bool] -and $processedDevice.ActionStatus
+            if (-not $processedActionSucceeded) {
+                $processedActionSucceeded = [string] $processedDevice.ActionStatus -eq 'True'
+            }
+        }
 
         if ($ActionIf.ExcludeCompanyOwned -and $device.ManagedDeviceOwnerType -eq 'company') {
             continue
@@ -40,14 +48,8 @@ function Get-CloudDevicesToProcess {
             if ($device.RecordState -eq 'IntuneOnly' -and -not $ActionIf.IncludeIntuneOnly) {
                 continue
             }
-            if ($processedDevice -and $processedDevice.Action -eq 'Retire') {
-                $retireAlreadySucceeded = $processedDevice.ActionStatus -is [bool] -and $processedDevice.ActionStatus
-                if (-not $retireAlreadySucceeded) {
-                    $retireAlreadySucceeded = [string] $processedDevice.ActionStatus -eq 'True'
-                }
-                if ($retireAlreadySucceeded) {
-                    continue
-                }
+            if ($processedDevice -and $processedDevice.Action -eq 'Retire' -and $processedActionSucceeded) {
+                continue
             }
         } elseif ($Type -eq 'Disable') {
             if (-not $device.HasEntraRecord -or $device.Enabled -eq $false) {
@@ -69,7 +71,7 @@ function Get-CloudDevicesToProcess {
         }
 
         if ($null -ne $ActionIf.ListProcessedMoreThan) {
-            if (-not $processedDevice -or -not $processedDevice.ActionDate) {
+            if (-not $processedDevice -or -not $processedDevice.ActionDate -or -not $processedActionSucceeded) {
                 continue
             }
 

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -55,6 +55,9 @@ function Get-CloudDevicesToProcess {
             if (-not $device.HasEntraRecord -or $device.Enabled -eq $false) {
                 continue
             }
+            if ($device.RecordState -eq 'IntuneOnly') {
+                continue
+            }
             if ($device.RecordState -eq 'EntraOnly' -and -not $ActionIf.IncludeEntraOnly) {
                 continue
             }

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -26,8 +26,9 @@ function Get-CloudDevicesToProcess {
 
     $today = Get-Date
     $candidates = foreach ($device in $Devices) {
-        $deviceKey = Get-CloudDeviceRecordKey -Device $device
-        $processedDevice = $ProcessedDevices[$deviceKey]
+        $processedRecord = Find-ProcessedCloudDeviceRecord -Device $device -ProcessedDevices $ProcessedDevices
+        $deviceKey = $processedRecord.CurrentDeviceKey
+        $processedDevice = $processedRecord.ProcessedDevice
         $processedActionSucceeded = $false
 
         if ($processedDevice) {
@@ -105,6 +106,8 @@ function Get-CloudDevicesToProcess {
         $selectionReason = Get-CloudDeviceSelectionReason -Device $device -Type $Type -ActionIf $ActionIf -ProcessedDevice $processedDevice
         Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'Action' -Value $Type -Force
         Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'ProcessedDeviceKey' -Value $deviceKey -Force
+        Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'ProcessedDeviceKeys' -Value $processedRecord.CurrentDeviceKeys -Force
+        Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'MatchedProcessedDeviceKey' -Value $processedRecord.MatchedProcessedDeviceKey -Force
         Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'TimeOnPendingList' -Value $(if ($processedDevice) { $processedDevice.TimeOnPendingList } else { $null }) -Force
         Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'TimeToNextAction' -Value $(if ($processedDevice) { $processedDevice.TimeToNextAction } else { $null }) -Force
         Add-Member -InputObject $candidate -MemberType NoteProperty -Name 'SelectionReason' -Value $selectionReason -Force

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -62,6 +62,9 @@ function Get-CloudDevicesToProcess {
             if (-not $device.HasEntraRecord -and -not $device.HasIntuneRecord) {
                 continue
             }
+            if ($device.HasEntraRecord -and $device.Enabled -eq $true) {
+                continue
+            }
             if ($device.RecordState -eq 'EntraOnly' -and -not $ActionIf.IncludeEntraOnly) {
                 continue
             }

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -1,0 +1,154 @@
+function Get-InitialCloudDevices {
+    [CmdletBinding()]
+    param(
+        [nullable[int]] $SafetyEntraLimit,
+        [nullable[int]] $SafetyIntuneLimit,
+        [Array] $IncludeOperatingSystem,
+        [Array] $ExcludeOperatingSystem,
+        [Array] $Exclusions
+    )
+
+    Write-Color -Text '[i] ', 'Getting AzureAD registered devices from Microsoft Entra ID' -Color Yellow, Cyan, Green
+    [Array] $entraDevices = Get-MyDevice -Type 'AzureAD registered' -WarningAction SilentlyContinue -WarningVariable warningVar
+    if ($warningVar) {
+        Write-Color -Text '[e] ', 'Error getting devices from Microsoft Entra ID: ', $warningVar, ' Terminating!' -Color Yellow, Red, Yellow, Red
+        return $false
+    }
+
+    if ($entraDevices.Count -eq 0) {
+        Write-Color -Text '[e] ', 'No AzureAD registered devices found in Microsoft Entra ID. Terminating.' -Color Yellow, Red
+        return $false
+    }
+
+    if ($null -ne $SafetyEntraLimit -and $entraDevices.Count -lt $SafetyEntraLimit) {
+        Write-Color -Text '[e] ', 'Only ', $entraDevices.Count, ' devices found in Microsoft Entra ID, this is less than the safety limit of ', $SafetyEntraLimit, '. Terminating!' -Color Yellow, Cyan, Red, Cyan
+        return $false
+    }
+
+    Write-Color -Text '[i] ', 'AzureAD registered devices found in Microsoft Entra ID: ', $entraDevices.Count -Color Yellow, Cyan, Green
+
+    Write-Color -Text '[i] ', 'Getting AzureAD registered devices from Intune' -Color Yellow, Cyan, Green
+    [Array] $intuneDevices = Get-MyDeviceIntune -Type 'AzureAD registered' -WarningAction SilentlyContinue -WarningVariable warningVar
+    if ($warningVar) {
+        Write-Color -Text '[e] ', 'Error getting devices from Intune: ', $warningVar, ' Terminating!' -Color Yellow, Red, Yellow, Red
+        return $false
+    }
+
+    if ($null -ne $SafetyIntuneLimit -and $intuneDevices.Count -lt $SafetyIntuneLimit) {
+        Write-Color -Text '[e] ', 'Only ', $intuneDevices.Count, ' devices found in Intune, this is less than the safety limit of ', $SafetyIntuneLimit, '. Terminating!' -Color Yellow, Cyan, Red, Cyan
+        return $false
+    }
+
+    Write-Color -Text '[i] ', 'AzureAD registered devices found in Intune: ', $intuneDevices.Count -Color Yellow, Cyan, Green
+
+    $intuneByAzureDeviceId = [ordered] @{}
+    $matchedIntuneManagedDeviceIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($intuneDevice in $intuneDevices) {
+        if ($intuneDevice.AzureAdDeviceId -and -not $intuneByAzureDeviceId.Contains($intuneDevice.AzureAdDeviceId)) {
+            $intuneByAzureDeviceId[$intuneDevice.AzureAdDeviceId] = $intuneDevice
+        }
+    }
+
+    $outputDevices = [System.Collections.Generic.List[object]]::new()
+    foreach ($entraDevice in $entraDevices) {
+        $operatingSystem = $entraDevice.OperatingSystem
+        $deviceInScope = Test-CloudDeviceInventoryScope -OperatingSystem $operatingSystem -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -Exclusions $Exclusions -Name $entraDevice.Name -DeviceId $entraDevice.DeviceId -EntraDeviceObjectId $entraDevice.EntraDeviceObjectId
+        if (-not $deviceInScope) {
+            continue
+        }
+
+        $intuneDevice = if ($entraDevice.DeviceId -and $intuneByAzureDeviceId.Contains($entraDevice.DeviceId)) {
+            $intuneByAzureDeviceId[$entraDevice.DeviceId]
+        } else {
+            $null
+        }
+
+        if ($intuneDevice -and $intuneDevice.ManagedDeviceId) {
+            $null = $matchedIntuneManagedDeviceIds.Add($intuneDevice.ManagedDeviceId)
+        }
+
+        $outputDevices.Add([PSCustomObject] [ordered] @{
+            Name                    = $entraDevice.Name
+            EntraDeviceObjectId     = $entraDevice.EntraDeviceObjectId
+            DeviceId                = $entraDevice.DeviceId
+            ManagedDeviceId         = if ($intuneDevice) { $intuneDevice.ManagedDeviceId } else { $null }
+            HasEntraRecord          = $true
+            HasIntuneRecord         = [bool] $intuneDevice
+            RecordState             = if ($intuneDevice) { 'Matched' } else { 'EntraOnly' }
+            RecordSource            = if ($intuneDevice) { 'Microsoft Entra ID + Intune' } else { 'Microsoft Entra ID only' }
+            Enabled                 = $entraDevice.Enabled
+            OperatingSystem         = if ($intuneDevice -and $intuneDevice.OperatingSystem) { $intuneDevice.OperatingSystem } else { $entraDevice.OperatingSystem }
+            OperatingSystemVersion  = if ($intuneDevice -and $intuneDevice.OperatingSystemVersion) { $intuneDevice.OperatingSystemVersion } else { $entraDevice.OperatingSystemVersion }
+            TrustType               = $entraDevice.TrustType
+            EntraLastSeen           = $entraDevice.LastSeen
+            EntraLastSeenDays       = $entraDevice.LastSeenDays
+            IntuneLastSeen          = if ($intuneDevice) { $intuneDevice.LastSeen } else { $null }
+            IntuneLastSeenDays      = if ($intuneDevice) { $intuneDevice.LastSeenDays } else { $null }
+            FirstSeen               = $entraDevice.FirstSeen
+            IsManaged               = $entraDevice.IsManaged
+            IsCompliant             = $entraDevice.IsCompliant
+            ManagementType          = $entraDevice.ManagementType
+            EnrollmentType          = $entraDevice.EnrollmentType
+            OwnerDisplayName        = $entraDevice.OwnerDisplayName
+            OwnerUserPrincipalName  = $entraDevice.OwnerUserPrincipalName
+            IntuneUserDisplayName   = if ($intuneDevice) { $intuneDevice.UserDisplayName } else { $null }
+            IntuneUserPrincipalName = if ($intuneDevice) { $intuneDevice.UserPrincipalName } else { $null }
+            IntuneEmailAddress      = if ($intuneDevice) { $intuneDevice.EmailAddress } else { $null }
+            ManagedDeviceOwnerType  = if ($intuneDevice) { $intuneDevice.ManagedDeviceOwnerType } else { $null }
+            DeviceRegistrationState = if ($intuneDevice) { $intuneDevice.DeviceRegistrationState } else { $null }
+            AzureAdRegistered       = if ($intuneDevice) { $intuneDevice.AzureAdRegistered } else { $null }
+            ComplianceState         = if ($intuneDevice) { $intuneDevice.ComplianceState } else { $null }
+            ManagementAgent         = if ($intuneDevice) { $intuneDevice.ManagementAgent } else { $null }
+            SelectionReason         = $null
+        })
+    }
+
+    foreach ($intuneDevice in $intuneDevices) {
+        if ($intuneDevice.ManagedDeviceId -and $matchedIntuneManagedDeviceIds.Contains($intuneDevice.ManagedDeviceId)) {
+            continue
+        }
+
+        $operatingSystem = $intuneDevice.OperatingSystem
+        $deviceInScope = Test-CloudDeviceInventoryScope -OperatingSystem $operatingSystem -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -Exclusions $Exclusions -Name $intuneDevice.Name -DeviceId $intuneDevice.AzureAdDeviceId -ManagedDeviceId $intuneDevice.ManagedDeviceId
+        if (-not $deviceInScope) {
+            continue
+        }
+
+        $outputDevices.Add([PSCustomObject] [ordered] @{
+            Name                    = $intuneDevice.Name
+            EntraDeviceObjectId     = $intuneDevice.EntraDeviceObjectId
+            DeviceId                = $intuneDevice.AzureAdDeviceId
+            ManagedDeviceId         = $intuneDevice.ManagedDeviceId
+            HasEntraRecord          = [bool] $intuneDevice.EntraDeviceObjectId
+            HasIntuneRecord         = $true
+            RecordState             = 'IntuneOnly'
+            RecordSource            = 'Intune only'
+            Enabled                 = $null
+            OperatingSystem         = $intuneDevice.OperatingSystem
+            OperatingSystemVersion  = $intuneDevice.OperatingSystemVersion
+            TrustType               = 'AzureAD registered'
+            EntraLastSeen           = $null
+            EntraLastSeenDays       = $null
+            IntuneLastSeen          = $intuneDevice.LastSeen
+            IntuneLastSeenDays      = $intuneDevice.LastSeenDays
+            FirstSeen               = $intuneDevice.FirstSeen
+            IsManaged               = $true
+            IsCompliant             = $null
+            ManagementType          = $null
+            EnrollmentType          = $null
+            OwnerDisplayName        = $null
+            OwnerUserPrincipalName  = $null
+            IntuneUserDisplayName   = $intuneDevice.UserDisplayName
+            IntuneUserPrincipalName = $intuneDevice.UserPrincipalName
+            IntuneEmailAddress      = $intuneDevice.EmailAddress
+            ManagedDeviceOwnerType  = $intuneDevice.ManagedDeviceOwnerType
+            DeviceRegistrationState = $intuneDevice.DeviceRegistrationState
+            AzureAdRegistered       = $intuneDevice.AzureAdRegistered
+            ComplianceState         = $intuneDevice.ComplianceState
+            ManagementAgent         = $intuneDevice.ManagementAgent
+            SelectionReason         = $null
+        })
+    }
+
+    @($outputDevices)
+}

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -110,7 +110,7 @@ function Get-InitialCloudDevices {
         }
 
         $operatingSystem = $intuneDevice.OperatingSystem
-        $deviceInScope = Test-CloudDeviceInventoryScope -OperatingSystem $operatingSystem -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -Exclusions $Exclusions -Name $intuneDevice.Name -DeviceId $intuneDevice.AzureAdDeviceId -ManagedDeviceId $intuneDevice.ManagedDeviceId
+        $deviceInScope = Test-CloudDeviceInventoryScope -OperatingSystem $operatingSystem -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -Exclusions $Exclusions -Name $intuneDevice.Name -DeviceId $intuneDevice.AzureAdDeviceId -EntraDeviceObjectId $intuneDevice.EntraDeviceObjectId -ManagedDeviceId $intuneDevice.ManagedDeviceId
         if (-not $deviceInScope) {
             continue
         }

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -16,11 +16,12 @@ function Get-InitialCloudDevices {
     }
 
     if ($entraDevices.Count -eq 0) {
-        Write-Color -Text '[e] ', 'No AzureAD registered devices found in Microsoft Entra ID. Terminating.' -Color Yellow, Red
-        return $false
-    }
-
-    if ($null -ne $SafetyEntraLimit -and $entraDevices.Count -lt $SafetyEntraLimit) {
+        if ($null -ne $SafetyEntraLimit -and $SafetyEntraLimit -gt 0) {
+            Write-Color -Text '[e] ', 'Only ', $entraDevices.Count, ' devices found in Microsoft Entra ID, this is less than the safety limit of ', $SafetyEntraLimit, '. Terminating!' -Color Yellow, Cyan, Red, Cyan
+            return $false
+        }
+        Write-Color -Text '[i] ', 'No AzureAD registered devices found in Microsoft Entra ID. Continuing with Intune inventory to discover orphan records.' -Color Yellow, Yellow
+    } elseif ($null -ne $SafetyEntraLimit -and $entraDevices.Count -lt $SafetyEntraLimit) {
         Write-Color -Text '[e] ', 'Only ', $entraDevices.Count, ' devices found in Microsoft Entra ID, this is less than the safety limit of ', $SafetyEntraLimit, '. Terminating!' -Color Yellow, Cyan, Red, Cyan
         return $false
     }

--- a/Private/Import-CloudDevicesData.ps1
+++ b/Private/Import-CloudDevicesData.ps1
@@ -1,0 +1,57 @@
+function Import-CloudDevicesData {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $DataStorePath,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $Export
+    )
+
+    $processedDevices = [ordered] @{}
+    $today = Get-Date
+
+    try {
+        if ($DataStorePath -and (Test-Path -LiteralPath $DataStorePath -ErrorAction Stop)) {
+            $fileImport = Import-Clixml -LiteralPath $DataStorePath -ErrorAction Stop
+
+            if ($fileImport.PendingActions) {
+                if ($fileImport.PendingActions.GetType().Name -notin 'Hashtable', 'OrderedDictionary') {
+                    Write-Color -Text '[e] ', 'Incorrect XML format. PendingActions is not a hashtable/ordereddictionary. Terminating.' -Color Yellow, Red
+                    return $false
+                }
+            }
+
+            if ($fileImport.History) {
+                if ($fileImport.History.GetType().Name -notin 'ArrayList', 'Object[]') {
+                    Write-Color -Text '[e] ', 'Incorrect XML format. History is not an array. Terminating.' -Color Yellow, Red
+                    return $false
+                }
+            }
+
+            $processedDevices = if ($fileImport.PendingActions) { $fileImport.PendingActions } else { [ordered] @{} }
+            foreach ($deviceKey in @($processedDevices.Keys)) {
+                $device = $processedDevices[$deviceKey]
+                $timeOnPendingList = if ($device.ActionDate) {
+                    - ($device.ActionDate - $today).Days
+                } else {
+                    $null
+                }
+
+                if ($device.PSObject.Properties.Name -notcontains 'TimeOnPendingList') {
+                    Add-Member -InputObject $device -MemberType NoteProperty -Name 'TimeOnPendingList' -Value $timeOnPendingList -Force
+                    Add-Member -InputObject $device -MemberType NoteProperty -Name 'TimeToNextAction' -Value $null -Force
+                } else {
+                    $device.TimeOnPendingList = $timeOnPendingList
+                }
+            }
+
+            $Export.History = @($fileImport.History)
+        }
+    } catch {
+        Write-Color -Text '[e] ', "Couldn't read cloud device list or wrong format. Error: $($_.Exception.Message)" -Color Yellow, Red
+        return $false
+    }
+
+    $processedDevices
+}

--- a/Private/New-EmailBodyCloudDevices.ps1
+++ b/Private/New-EmailBodyCloudDevices.ps1
@@ -1,0 +1,31 @@
+function New-EmailBodyCloudDevices {
+    [CmdletBinding()]
+    param(
+        [Array] $CurrentRun
+    )
+
+    Write-Color -Text '[i] ', 'Generating email body for cloud devices' -Color Yellow, White
+
+    [Array] $retiredDevices = $CurrentRun | Where-Object { $_.Action -eq 'Retire' }
+    [Array] $disabledDevices = $CurrentRun | Where-Object { $_.Action -eq 'Disable' }
+    [Array] $deletedDevices = $CurrentRun | Where-Object { $_.Action -eq 'Delete' }
+
+    $emailBody = EmailBody -EmailBody {
+        EmailText -Text 'Hello,'
+        EmailText -LineBreak
+        EmailText -Text 'This is an automated email from CleanupMonster for cloud device lifecycle cleanup.' -FontWeight bold
+        EmailText -LineBreak
+        EmailList {
+            EmailListItem -Text 'Objects actioned: ', $CurrentRun.Count -Color None, Green -FontWeight normal, bold
+            EmailListItem -Text 'Objects retired: ', $retiredDevices.Count -Color None, Orange -FontWeight normal, bold
+            EmailListItem -Text 'Objects disabled: ', $disabledDevices.Count -Color None, Orange -FontWeight normal, bold
+            EmailListItem -Text 'Objects deleted: ', $deletedDevices.Count -Color None, Salmon -FontWeight normal, bold
+        }
+        EmailTable -DataTable $CurrentRun -HideFooter
+        EmailText -LineBreak
+        EmailText -Text 'Regards,'
+        EmailText -Text 'Automations Team' -FontWeight bold
+    }
+
+    $emailBody
+}

--- a/Private/New-HTMLProcessedCloudDevices.ps1
+++ b/Private/New-HTMLProcessedCloudDevices.ps1
@@ -1,0 +1,119 @@
+function New-HTMLProcessedCloudDevices {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $Export,
+
+        [Parameter(Mandatory)]
+        [Array] $Devices,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $RetireOnlyIf,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $DisableOnlyIf,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $DeleteOnlyIf,
+
+        [Parameter(Mandatory)]
+        [string] $FilePath,
+
+        [switch] $Online,
+        [switch] $ShowHTML,
+        [string] $LogFile
+    )
+
+    New-HTML {
+        New-HTMLTabStyle -BorderRadius 0px -TextTransform capitalize -BackgroundColorActive SlateGrey -BackgroundColor BlizzardBlue
+        New-HTMLSectionStyle -BorderRadius 0px -HeaderBackGroundColor Grey -RemoveShadow
+        New-HTMLPanelStyle -BorderRadius 0px
+        New-HTMLTableOption -DataStore JavaScript -BoolAsString -ArrayJoinString ', ' -ArrayJoin
+
+        New-HTMLHeader {
+            New-HTMLSection -Invisible {
+                New-HTMLSection { New-HTMLText -Text "Report generated on $(Get-Date)" -Color Blue } -JustifyContent flex-start -Invisible
+                New-HTMLSection { New-HTMLText -Text "Cleanup Monster - $($Export.Version)" -Color Blue } -JustifyContent flex-end -Invisible
+            }
+        }
+
+        New-HTMLTab -Name 'Current Run' {
+            New-HTMLSection {
+                New-HTMLPanel { New-HTMLToast -TextHeader 'Matched' -Text "Matched records actioned: $(@($Export.CurrentRun | Where-Object { $_.RecordState -eq 'Matched' }).Count)" -BarColorLeft MintGreen -IconSolid info-circle -IconColor MintGreen } -Invisible
+                New-HTMLPanel { New-HTMLToast -TextHeader 'Entra only' -Text "Entra-only records actioned: $(@($Export.CurrentRun | Where-Object { $_.RecordState -eq 'EntraOnly' }).Count)" -BarColorLeft CornflowerBlue -IconSolid info-circle -IconColor CornflowerBlue } -Invisible
+                New-HTMLPanel { New-HTMLToast -TextHeader 'Intune only' -Text "Intune-only records actioned: $(@($Export.CurrentRun | Where-Object { $_.RecordState -eq 'IntuneOnly' }).Count)" -BarColorLeft OrangePeel -IconSolid info-circle -IconColor OrangePeel } -Invisible
+            } -Invisible
+            New-HTMLTable -DataTable $Export.CurrentRun -Filtering -ScrollX {
+                New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Retire' -BackgroundColor EnergyYellow
+                New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Disable' -BackgroundColor Yellow
+                New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Delete' -BackgroundColor PinkLace
+                New-HTMLTableCondition -Name 'ActionStatus' -ComparisonType string -Value 'True' -BackgroundColor LightGreen
+                New-HTMLTableCondition -Name 'ActionStatus' -ComparisonType string -Value 'False' -BackgroundColor Salmon
+                New-HTMLTableCondition -Name 'ActionStatus' -ComparisonType string -Value 'WhatIf' -BackgroundColor LightBlue
+                New-HTMLTableCondition -Name 'ActionStatus' -ComparisonType string -Value 'ReportOnly' -BackgroundColor Lavender
+                New-HTMLTableCondition -Name 'RecordState' -ComparisonType string -Value 'EntraOnly' -BackgroundColor AliceBlue
+                New-HTMLTableCondition -Name 'RecordState' -ComparisonType string -Value 'IntuneOnly' -BackgroundColor Cornsilk
+            } -WarningAction SilentlyContinue
+        }
+
+        New-HTMLTab -Name 'History' {
+            New-HTMLTable -DataTable $Export.History -Filtering -ScrollX {
+                New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Retire' -BackgroundColor EnergyYellow
+                New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Disable' -BackgroundColor Yellow
+                New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Delete' -BackgroundColor PinkLace
+                New-HTMLTableCondition -Name 'RecordState' -ComparisonType string -Value 'EntraOnly' -BackgroundColor AliceBlue
+                New-HTMLTableCondition -Name 'RecordState' -ComparisonType string -Value 'IntuneOnly' -BackgroundColor Cornsilk
+            } -WarningAction SilentlyContinue
+        }
+
+        New-HTMLTab -Name 'Pending Actions' {
+            New-HTMLTable -DataTable $Export.PendingActions.Values -Filtering -ScrollX {
+                New-HTMLTableCondition -Name 'RecordState' -ComparisonType string -Value 'EntraOnly' -BackgroundColor AliceBlue
+                New-HTMLTableCondition -Name 'RecordState' -ComparisonType string -Value 'IntuneOnly' -BackgroundColor Cornsilk
+            } -WarningAction SilentlyContinue
+        }
+
+        New-HTMLTab -Name 'Devices' {
+            New-HTMLSection {
+                New-HTMLPanel { New-HTMLToast -TextHeader 'Total' -Text "Devices discovered: $($Devices.Count)" -BarColorLeft MintGreen -IconSolid info-circle -IconColor MintGreen } -Invisible
+                New-HTMLPanel { New-HTMLToast -TextHeader 'Current Run' -Text "Actions this run: $($Export.CurrentRun.Count)" -BarColorLeft OrangePeel -IconSolid info-circle -IconColor OrangePeel } -Invisible
+                New-HTMLPanel { New-HTMLToast -TextHeader 'Pending' -Text "Pending actions: $($Export.PendingActions.Count)" -BarColorLeft OrangeRed -IconSolid info-circle -IconColor OrangeRed } -Invisible
+                New-HTMLPanel { New-HTMLToast -TextHeader 'Matched' -Text "Matched records: $(@($Devices | Where-Object { $_.RecordState -eq 'Matched' }).Count)" -BarColorLeft SeaGreen -IconSolid info-circle -IconColor SeaGreen } -Invisible
+                New-HTMLPanel { New-HTMLToast -TextHeader 'Entra only' -Text "Entra-only records: $(@($Devices | Where-Object { $_.RecordState -eq 'EntraOnly' }).Count)" -BarColorLeft CornflowerBlue -IconSolid info-circle -IconColor CornflowerBlue } -Invisible
+                New-HTMLPanel { New-HTMLToast -TextHeader 'Intune only' -Text "Intune-only records: $(@($Devices | Where-Object { $_.RecordState -eq 'IntuneOnly' }).Count)" -BarColorLeft OrangePeel -IconSolid info-circle -IconColor OrangePeel } -Invisible
+            } -Invisible
+
+            New-HTMLSection -HeaderText 'Rules' {
+                New-HTMLPanel {
+                    New-HTMLText -Text 'Retire rules' -FontWeight bold
+                    New-HTMLTable -DataTable @([PSCustomObject] $RetireOnlyIf)
+                }
+                New-HTMLPanel {
+                    New-HTMLText -Text 'Disable rules' -FontWeight bold
+                    New-HTMLTable -DataTable @([PSCustomObject] $DisableOnlyIf)
+                }
+                New-HTMLPanel {
+                    New-HTMLText -Text 'Delete rules' -FontWeight bold
+                    New-HTMLTable -DataTable @([PSCustomObject] $DeleteOnlyIf)
+                }
+            }
+
+            New-HTMLTable -DataTable $Devices -Filtering -ScrollX {
+                New-HTMLTableCondition -Name 'RecordState' -ComparisonType string -Value 'Matched' -BackgroundColor Honeydew
+                New-HTMLTableCondition -Name 'RecordState' -ComparisonType string -Value 'EntraOnly' -BackgroundColor AliceBlue
+                New-HTMLTableCondition -Name 'RecordState' -ComparisonType string -Value 'IntuneOnly' -BackgroundColor Cornsilk
+            } -WarningAction SilentlyContinue
+        }
+
+        try {
+            if ($LogFile -and (Test-Path -LiteralPath $LogFile -ErrorAction Stop)) {
+                $logContent = Get-Content -Raw -LiteralPath $LogFile -ErrorAction Stop
+                New-HTMLTab -Name 'Log' {
+                    New-HTMLCodeBlock -Code $logContent -Style generic
+                }
+            }
+        } catch {
+            Write-Color -Text '[e] ', "Couldn't read the log file. Skipping adding log to HTML. Error: $($_.Exception.Message)" -Color Yellow, Red
+        }
+    } -FilePath $FilePath -Online:$Online.IsPresent -ShowHTML:$ShowHTML.IsPresent
+}

--- a/Private/Remove-ProcessedCloudDeviceRecord.ps1
+++ b/Private/Remove-ProcessedCloudDeviceRecord.ps1
@@ -1,0 +1,23 @@
+function Remove-ProcessedCloudDeviceRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $ProcessedDevices,
+
+        [Parameter(Mandatory)]
+        [PSObject] $Device
+    )
+
+    foreach ($processedDeviceKey in @(
+            if ($Device.PSObject.Properties['MatchedProcessedDeviceKey'] -and $Device.MatchedProcessedDeviceKey) {
+                $Device.MatchedProcessedDeviceKey
+            }
+            if ($Device.PSObject.Properties['ProcessedDeviceKey'] -and $Device.ProcessedDeviceKey) {
+                $Device.ProcessedDeviceKey
+            }
+        )) {
+        if ($ProcessedDevices.Contains($processedDeviceKey)) {
+            $null = $ProcessedDevices.Remove($processedDeviceKey)
+        }
+    }
+}

--- a/Private/Request-CloudDevicesDelete.ps1
+++ b/Private/Request-CloudDevicesDelete.ps1
@@ -77,11 +77,12 @@ function Request-CloudDevicesDelete {
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionStatus' -Value $actionStatus -Force
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'Action' -Value 'Delete' -Force
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionNotes' -Value ($subActionMessages -join '; ') -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ProcessedDeviceKeys' -Value $device.ProcessedDeviceKeys -Force
         $results.Add($result)
 
         if (($subActionExecuted -and ($subActionSuccess -or $WhatIf -or $WhatIfDelete)) -or $ReportOnly) {
             if (-not ($WhatIf -or $WhatIfDelete -or $ReportOnly)) {
-                $null = $ProcessedDevices.Remove($device.ProcessedDeviceKey)
+                Remove-ProcessedCloudDeviceRecord -ProcessedDevices $ProcessedDevices -Device $device
             }
             $processedCount++
         }

--- a/Private/Request-CloudDevicesDelete.ps1
+++ b/Private/Request-CloudDevicesDelete.ps1
@@ -29,9 +29,11 @@ function Request-CloudDevicesDelete {
 
         $subActionMessages = [System.Collections.Generic.List[string]]::new()
         $subActionSuccess = $true
+        $subActionExecuted = $false
 
         if (-not $ReportOnly) {
             if ($DeleteRemoveIntuneRecord -and $device.HasIntuneRecord) {
+                $subActionExecuted = $true
                 $removeIntuneResult = Remove-MyDeviceIntuneRecord -InputObject $device -Confirm:$false -WhatIf:$($WhatIf -or $WhatIfDelete)
                 if ($removeIntuneResult.Message) {
                     $subActionMessages.Add("Intune: $($removeIntuneResult.Message)")
@@ -42,6 +44,7 @@ function Request-CloudDevicesDelete {
             }
 
             if ($device.HasEntraRecord) {
+                $subActionExecuted = $true
                 $removeEntraResult = Remove-MyDevice -InputObject $device -Confirm:$false -WhatIf:$($WhatIf -or $WhatIfDelete)
                 if ($removeEntraResult.Message) {
                     $subActionMessages.Add("Entra: $($removeEntraResult.Message)")
@@ -50,10 +53,17 @@ function Request-CloudDevicesDelete {
                     $subActionSuccess = $false
                 }
             }
+
+            if (-not $subActionExecuted) {
+                $subActionSuccess = $false
+                $subActionMessages.Add('No delete sub-actions were applicable for this device.')
+            }
         }
 
         $actionStatus = if ($ReportOnly) {
             'ReportOnly'
+        } elseif (-not $subActionExecuted) {
+            'False'
         } elseif ($WhatIf -or $WhatIfDelete) {
             'WhatIf'
         } elseif ($subActionSuccess) {
@@ -69,7 +79,7 @@ function Request-CloudDevicesDelete {
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionNotes' -Value ($subActionMessages -join '; ') -Force
         $results.Add($result)
 
-        if ($subActionSuccess -or $WhatIf -or $WhatIfDelete -or $ReportOnly) {
+        if (($subActionExecuted -and ($subActionSuccess -or $WhatIf -or $WhatIfDelete)) -or $ReportOnly) {
             if (-not ($WhatIf -or $WhatIfDelete -or $ReportOnly)) {
                 $null = $ProcessedDevices.Remove($device.ProcessedDeviceKey)
             }

--- a/Private/Request-CloudDevicesDelete.ps1
+++ b/Private/Request-CloudDevicesDelete.ps1
@@ -1,0 +1,81 @@
+function Request-CloudDevicesDelete {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [Array] $Devices,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $ProcessedDevices,
+
+        [Parameter(Mandatory)]
+        [datetime] $Today,
+
+        [int] $DeleteLimit = 0,
+
+        [bool] $DeleteRemoveIntuneRecord = $true,
+
+        [switch] $ReportOnly,
+        [switch] $WhatIfDelete,
+        [switch] $WhatIf
+    )
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    $processedCount = 0
+
+    foreach ($device in $Devices) {
+        if ($DeleteLimit -gt 0 -and $processedCount -ge $DeleteLimit) {
+            break
+        }
+
+        $subActionMessages = [System.Collections.Generic.List[string]]::new()
+        $subActionSuccess = $true
+
+        if (-not $ReportOnly) {
+            if ($DeleteRemoveIntuneRecord -and $device.HasIntuneRecord) {
+                $removeIntuneResult = Remove-MyDeviceIntuneRecord -InputObject $device -Confirm:$false -WhatIf:$($WhatIf -or $WhatIfDelete)
+                if ($removeIntuneResult.Message) {
+                    $subActionMessages.Add("Intune: $($removeIntuneResult.Message)")
+                }
+                if (-not $removeIntuneResult.Success -and -not ($WhatIf -or $WhatIfDelete)) {
+                    $subActionSuccess = $false
+                }
+            }
+
+            if ($device.HasEntraRecord) {
+                $removeEntraResult = Remove-MyDevice -InputObject $device -Confirm:$false -WhatIf:$($WhatIf -or $WhatIfDelete)
+                if ($removeEntraResult.Message) {
+                    $subActionMessages.Add("Entra: $($removeEntraResult.Message)")
+                }
+                if (-not $removeEntraResult.Success -and -not ($WhatIf -or $WhatIfDelete)) {
+                    $subActionSuccess = $false
+                }
+            }
+        }
+
+        $actionStatus = if ($ReportOnly) {
+            'ReportOnly'
+        } elseif ($WhatIf -or $WhatIfDelete) {
+            'WhatIf'
+        } elseif ($subActionSuccess) {
+            'True'
+        } else {
+            'False'
+        }
+
+        $result = $device | Select-Object *
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionDate' -Value $Today -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionStatus' -Value $actionStatus -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'Action' -Value 'Delete' -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionNotes' -Value ($subActionMessages -join '; ') -Force
+        $results.Add($result)
+
+        if ($subActionSuccess -or $WhatIf -or $WhatIfDelete -or $ReportOnly) {
+            if (-not ($WhatIf -or $WhatIfDelete -or $ReportOnly)) {
+                $null = $ProcessedDevices.Remove($device.ProcessedDeviceKey)
+            }
+            $processedCount++
+        }
+    }
+
+    @($results)
+}

--- a/Private/Request-CloudDevicesDisable.ps1
+++ b/Private/Request-CloudDevicesDisable.ps1
@@ -38,10 +38,11 @@ function Request-CloudDevicesDisable {
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionDate' -Value $Today -Force
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionStatus' -Value $actionStatus -Force
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'Action' -Value 'Disable' -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ProcessedDeviceKeys' -Value $device.ProcessedDeviceKeys -Force
         $results.Add($result)
 
         if ($actionSucceeded -or $WhatIf -or $WhatIfDisable -or $ReportOnly) {
-            $ProcessedDevices[$device.ProcessedDeviceKey] = $result
+            Set-ProcessedCloudDeviceRecord -ProcessedDevices $ProcessedDevices -Device $device -Result $result
             $processedCount++
         }
     }

--- a/Private/Request-CloudDevicesDisable.ps1
+++ b/Private/Request-CloudDevicesDisable.ps1
@@ -1,0 +1,50 @@
+function Request-CloudDevicesDisable {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [Array] $Devices,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $ProcessedDevices,
+
+        [Parameter(Mandatory)]
+        [datetime] $Today,
+
+        [int] $DisableLimit = 0,
+
+        [switch] $ReportOnly,
+        [switch] $WhatIfDisable,
+        [switch] $WhatIf
+    )
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    $processedCount = 0
+
+    foreach ($device in $Devices) {
+        if ($DisableLimit -gt 0 -and $processedCount -ge $DisableLimit) {
+            break
+        }
+
+        if ($ReportOnly) {
+            $actionStatus = 'ReportOnly'
+            $actionSucceeded = $true
+        } else {
+            $disableResult = Disable-MyDevice -InputObject $device -Confirm:$false -WhatIf:$($WhatIf -or $WhatIfDisable)
+            $actionSucceeded = [bool] $disableResult.Success
+            $actionStatus = if ($WhatIf -or $WhatIfDisable) { 'WhatIf' } elseif ($disableResult.Success) { 'True' } else { 'False' }
+        }
+
+        $result = $device | Select-Object *
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionDate' -Value $Today -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionStatus' -Value $actionStatus -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'Action' -Value 'Disable' -Force
+        $results.Add($result)
+
+        if ($actionSucceeded -or $WhatIf -or $WhatIfDisable -or $ReportOnly) {
+            $ProcessedDevices[$device.ProcessedDeviceKey] = $result
+            $processedCount++
+        }
+    }
+
+    @($results)
+}

--- a/Private/Request-CloudDevicesRetire.ps1
+++ b/Private/Request-CloudDevicesRetire.ps1
@@ -1,0 +1,50 @@
+function Request-CloudDevicesRetire {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [Array] $Devices,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $ProcessedDevices,
+
+        [Parameter(Mandatory)]
+        [datetime] $Today,
+
+        [int] $RetireLimit = 0,
+
+        [switch] $ReportOnly,
+        [switch] $WhatIfRetire,
+        [switch] $WhatIf
+    )
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    $processedCount = 0
+
+    foreach ($device in $Devices) {
+        if ($RetireLimit -gt 0 -and $processedCount -ge $RetireLimit) {
+            break
+        }
+
+        if ($ReportOnly) {
+            $actionStatus = 'ReportOnly'
+            $actionSucceeded = $true
+        } else {
+            $retireResult = Invoke-MyDeviceRetire -InputObject $device -Confirm:$false -WhatIf:$($WhatIf -or $WhatIfRetire)
+            $actionSucceeded = [bool] $retireResult.Success
+            $actionStatus = if ($WhatIf -or $WhatIfRetire) { 'WhatIf' } elseif ($retireResult.Success) { 'True' } else { 'False' }
+        }
+
+        $result = $device | Select-Object *
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionDate' -Value $Today -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionStatus' -Value $actionStatus -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'Action' -Value 'Retire' -Force
+        $results.Add($result)
+
+        if ($actionSucceeded -or $WhatIf -or $WhatIfRetire -or $ReportOnly) {
+            $ProcessedDevices[$device.ProcessedDeviceKey] = $result
+            $processedCount++
+        }
+    }
+
+    @($results)
+}

--- a/Private/Request-CloudDevicesRetire.ps1
+++ b/Private/Request-CloudDevicesRetire.ps1
@@ -38,10 +38,11 @@ function Request-CloudDevicesRetire {
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionDate' -Value $Today -Force
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionStatus' -Value $actionStatus -Force
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'Action' -Value 'Retire' -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ProcessedDeviceKeys' -Value $device.ProcessedDeviceKeys -Force
         $results.Add($result)
 
         if ($actionSucceeded -or $WhatIf -or $WhatIfRetire -or $ReportOnly) {
-            $ProcessedDevices[$device.ProcessedDeviceKey] = $result
+            Set-ProcessedCloudDeviceRecord -ProcessedDevices $ProcessedDevices -Device $device -Result $result
             $processedCount++
         }
     }

--- a/Private/Set-ProcessedCloudDeviceRecord.ps1
+++ b/Private/Set-ProcessedCloudDeviceRecord.ps1
@@ -1,0 +1,22 @@
+function Set-ProcessedCloudDeviceRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $ProcessedDevices,
+
+        [Parameter(Mandatory)]
+        [PSObject] $Device,
+
+        [Parameter(Mandatory)]
+        [PSObject] $Result
+    )
+
+    if ($Device.PSObject.Properties['MatchedProcessedDeviceKey'] -and
+        $Device.MatchedProcessedDeviceKey -and
+        $Device.MatchedProcessedDeviceKey -ne $Device.ProcessedDeviceKey -and
+        $ProcessedDevices.Contains($Device.MatchedProcessedDeviceKey)) {
+        $null = $ProcessedDevices.Remove($Device.MatchedProcessedDeviceKey)
+    }
+
+    $ProcessedDevices[$Device.ProcessedDeviceKey] = $Result
+}

--- a/Private/Test-CloudDeviceInventoryScope.ps1
+++ b/Private/Test-CloudDeviceInventoryScope.ps1
@@ -2,6 +2,8 @@ function Test-CloudDeviceInventoryScope {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
+        [AllowNull()]
+        [AllowEmptyString()]
         [string] $OperatingSystem,
 
         [Parameter(Mandatory)]
@@ -21,6 +23,12 @@ function Test-CloudDeviceInventoryScope {
         [string] $EntraDeviceObjectId,
         [string] $ManagedDeviceId
     )
+
+    if ([string]::IsNullOrWhiteSpace($OperatingSystem)) {
+        if ($IncludeOperatingSystem.Count -gt 0) {
+            return $false
+        }
+    }
 
     if ($IncludeOperatingSystem.Count -gt 0) {
         $includeMatch = $false

--- a/Private/Test-CloudDeviceInventoryScope.ps1
+++ b/Private/Test-CloudDeviceInventoryScope.ps1
@@ -1,0 +1,57 @@
+function Test-CloudDeviceInventoryScope {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $OperatingSystem,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [Array] $IncludeOperatingSystem,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [Array] $ExcludeOperatingSystem,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [Array] $Exclusions,
+
+        [string] $Name,
+        [string] $DeviceId,
+        [string] $EntraDeviceObjectId,
+        [string] $ManagedDeviceId
+    )
+
+    if ($IncludeOperatingSystem.Count -gt 0) {
+        $includeMatch = $false
+        foreach ($includePattern in $IncludeOperatingSystem) {
+            if ($OperatingSystem -like $includePattern) {
+                $includeMatch = $true
+                break
+            }
+        }
+
+        if (-not $includeMatch) {
+            return $false
+        }
+    }
+
+    if ($ExcludeOperatingSystem.Count -gt 0) {
+        foreach ($excludePattern in $ExcludeOperatingSystem) {
+            if ($OperatingSystem -like $excludePattern) {
+                return $false
+            }
+        }
+    }
+
+    foreach ($partialExclusion in $Exclusions) {
+        if (($Name -and $Name -like $partialExclusion) -or
+            ($DeviceId -and $DeviceId -like $partialExclusion) -or
+            ($EntraDeviceObjectId -and $EntraDeviceObjectId -like $partialExclusion) -or
+            ($ManagedDeviceId -and $ManagedDeviceId -like $partialExclusion)) {
+            return $false
+        }
+    }
+
+    $true
+}

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -1,0 +1,236 @@
+function Invoke-CloudDevicesCleanup {
+    <#
+    .SYNOPSIS
+    Cleans up stale AzureAD registered cloud devices.
+
+    .DESCRIPTION
+    Handles staged cleanup for AzureAD registered mobile devices from the cloud side.
+    The workflow is designed for iOS and Android devices and supports:
+    - Intune retire for stale managed devices
+    - Microsoft Entra disable after a grace period
+    - Final deletion from Microsoft Entra and optional Intune record removal
+
+    Blank activity timestamps are intentionally excluded from destructive actions by default.
+    This follows Microsoft guidance for stale-device cleanup where activity timestamps can be empty
+    even for active devices.
+
+    .PARAMETER Retire
+    Enables the Intune retire stage.
+
+    .PARAMETER Disable
+    Enables the Microsoft Entra disable stage.
+
+    .PARAMETER Delete
+    Enables the final delete stage.
+
+    .PARAMETER RetireLastSeenIntuneMoreThan
+    Retire devices only if Intune LastSeenDays is greater than this number.
+
+    .PARAMETER RetireIncludeIntuneOnly
+    Allows retire-stage processing of Intune-only orphan records.
+    By default, orphan Intune records are discovered and reported but not actioned.
+
+    .PARAMETER DisableListProcessedMoreThan
+    Disable devices only after they were previously actioned and remained pending longer than this number of days.
+
+    .PARAMETER DisableIncludeEntraOnly
+    Allows disable-stage processing of Entra-only records.
+    By default, Entra-only records are discovered and reported but not actioned.
+
+    .PARAMETER DeleteListProcessedMoreThan
+    Delete devices only after they were previously actioned and remained pending longer than this number of days.
+
+    .PARAMETER DeleteIncludeEntraOnly
+    Allows delete-stage processing of Entra-only orphan records.
+
+    .PARAMETER DeleteIncludeIntuneOnly
+    Allows delete-stage processing of Intune-only orphan records.
+
+    .EXAMPLE
+    Invoke-CloudDevicesCleanup -Retire -ReportOnly -ShowHTML
+
+    .EXAMPLE
+    Invoke-CloudDevicesCleanup -Retire -Disable -Delete -RetireLastSeenIntuneMoreThan 120 -DisableListProcessedMoreThan 30 -DeleteListProcessedMoreThan 30
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [switch] $Retire,
+        [nullable[int]] $RetireLastSeenIntuneMoreThan = 120,
+        [nullable[int]] $RetireLastSeenEntraMoreThan,
+        [switch] $RetireIncludeIntuneOnly,
+        [int] $RetireLimit = 10,
+
+        [switch] $Disable,
+        [nullable[int]] $DisableLastSeenEntraMoreThan,
+        [nullable[int]] $DisableLastSeenIntuneMoreThan,
+        [nullable[int]] $DisableListProcessedMoreThan = 30,
+        [switch] $DisableIncludeEntraOnly,
+        [int] $DisableLimit = 10,
+
+        [switch] $Delete,
+        [nullable[int]] $DeleteLastSeenEntraMoreThan,
+        [nullable[int]] $DeleteLastSeenIntuneMoreThan,
+        [nullable[int]] $DeleteListProcessedMoreThan = 30,
+        [switch] $DeleteIncludeEntraOnly,
+        [switch] $DeleteIncludeIntuneOnly,
+        [int] $DeleteLimit = 10,
+        [bool] $DeleteRemoveIntuneRecord = $true,
+
+        [Array] $IncludeOperatingSystem = @('iOS*', 'Android*'),
+        [Array] $ExcludeOperatingSystem = @(),
+        [Array] $Exclusions = @(),
+        [switch] $IncludeCompanyOwned,
+
+        [string] $DataStorePath,
+        [switch] $ReportOnly,
+        [switch] $WhatIfRetire,
+        [switch] $WhatIfDisable,
+        [switch] $WhatIfDelete,
+        [string] $LogPath,
+        [int] $LogMaximum = 5,
+        [switch] $LogShowTime,
+        [string] $LogTimeFormat,
+        [switch] $Suppress,
+        [switch] $ShowHTML,
+        [switch] $Online,
+        [string] $ReportPath,
+        [nullable[int]] $SafetyEntraLimit,
+        [nullable[int]] $SafetyIntuneLimit
+    )
+
+    if ($WhatIfPreference) {
+        if (-not $PSBoundParameters.ContainsKey('WhatIfRetire')) {
+            $WhatIfRetire = $true
+        }
+        if (-not $PSBoundParameters.ContainsKey('WhatIfDisable')) {
+            $WhatIfDisable = $true
+        }
+        if (-not $PSBoundParameters.ContainsKey('WhatIfDelete')) {
+            $WhatIfDelete = $true
+        }
+    }
+
+    Set-LoggingCapabilities -LogPath $LogPath -LogMaximum $LogMaximum -ShowTime:$LogShowTime -TimeFormat $LogTimeFormat -ScriptPath $MyInvocation.ScriptName
+
+    if (-not $DataStorePath) {
+        $DataStorePath = Join-Path -Path $MyInvocation.PSScriptRoot -ChildPath 'ProcessedCloudDevices.xml'
+    }
+    if (-not $ReportPath) {
+        $ReportPath = Join-Path -Path $MyInvocation.PSScriptRoot -ChildPath 'ProcessedCloudDevices.html'
+    }
+
+    Set-ReportingCapabilities -ReportPath $ReportPath -ReportMaximum 0 -ScriptPath $MyInvocation.ScriptName
+
+    Write-Color -Text '[i] ', 'Started process of cleaning up stale cloud devices' -Color Yellow, White
+    Write-Color -Text '[i] ', 'Executed by: ', $Env:USERNAME -Color Yellow, White, Green
+
+    if (-not (Assert-CloudDeviceCleanupSettings)) {
+        return
+    }
+
+    if (-not $Retire -and -not $Disable -and -not $Delete) {
+        Write-Color -Text '[i] ', 'No action can be taken. You need to enable Retire, Disable or Delete.' -Color Yellow, Red
+        return
+    }
+
+    $retireOnlyIf = [ordered] @{
+        LastSeenIntuneMoreThan = $RetireLastSeenIntuneMoreThan
+        LastSeenEntraMoreThan  = $RetireLastSeenEntraMoreThan
+        ExcludeCompanyOwned    = -not $IncludeCompanyOwned
+        IncludeIntuneOnly      = $RetireIncludeIntuneOnly.IsPresent
+    }
+
+    $disableOnlyIf = [ordered] @{
+        LastSeenEntraMoreThan  = $DisableLastSeenEntraMoreThan
+        LastSeenIntuneMoreThan = $DisableLastSeenIntuneMoreThan
+        ListProcessedMoreThan  = $DisableListProcessedMoreThan
+        ExcludeCompanyOwned    = -not $IncludeCompanyOwned
+        IncludeEntraOnly       = $DisableIncludeEntraOnly.IsPresent
+    }
+
+    $deleteOnlyIf = [ordered] @{
+        LastSeenEntraMoreThan  = $DeleteLastSeenEntraMoreThan
+        LastSeenIntuneMoreThan = $DeleteLastSeenIntuneMoreThan
+        ListProcessedMoreThan  = $DeleteListProcessedMoreThan
+        ExcludeCompanyOwned    = -not $IncludeCompanyOwned
+        IncludeEntraOnly       = $DeleteIncludeEntraOnly.IsPresent
+        IncludeIntuneOnly      = $DeleteIncludeIntuneOnly.IsPresent
+    }
+
+    $export = [ordered] @{
+        Version        = Get-GitHubVersion -Cmdlet 'Invoke-CloudDevicesCleanup' -RepositoryOwner 'evotecit' -RepositoryName 'CleanupMonster'
+        CurrentRun     = @()
+        History        = @()
+        PendingActions = [ordered] @{}
+    }
+
+    if (-not $ReportOnly) {
+        $processedDevices = Import-CloudDevicesData -DataStorePath $DataStorePath -Export $export
+        if ($processedDevices -eq $false) {
+            return
+        }
+    } else {
+        $processedDevices = [ordered] @{}
+    }
+
+    $allDevices = Get-InitialCloudDevices -SafetyEntraLimit $SafetyEntraLimit -SafetyIntuneLimit $SafetyIntuneLimit -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -Exclusions $Exclusions
+    if ($allDevices -eq $false) {
+        return
+    }
+
+    $today = Get-Date
+    $reportRetired = @()
+    $reportDisabled = @()
+    $reportDeleted = @()
+
+    if ($Retire) {
+        $devicesToRetire = Get-CloudDevicesToProcess -Type Retire -Devices $allDevices -ActionIf $retireOnlyIf -ProcessedDevices $processedDevices
+        Write-Color -Text '[i] ', 'Devices to be retired: ', $devicesToRetire.Count, '. Current retire limit: ', $(if ($RetireLimit -eq 0) { 'Unlimited' } else { $RetireLimit }) -Color Yellow, Cyan, Green, Cyan, Yellow
+
+        $reportRetired = Request-CloudDevicesRetire -Devices $devicesToRetire -ProcessedDevices $processedDevices -Today $today -RetireLimit $RetireLimit -ReportOnly:$ReportOnly -WhatIfRetire:$WhatIfRetire -WhatIf:$WhatIfPreference
+    }
+
+    if ($Disable) {
+        $devicesToDisable = Get-CloudDevicesToProcess -Type Disable -Devices $allDevices -ActionIf $disableOnlyIf -ProcessedDevices $processedDevices
+        Write-Color -Text '[i] ', 'Devices to be disabled: ', $devicesToDisable.Count, '. Current disable limit: ', $(if ($DisableLimit -eq 0) { 'Unlimited' } else { $DisableLimit }) -Color Yellow, Cyan, Green, Cyan, Yellow
+
+        $reportDisabled = Request-CloudDevicesDisable -Devices $devicesToDisable -ProcessedDevices $processedDevices -Today $today -DisableLimit $DisableLimit -ReportOnly:$ReportOnly -WhatIfDisable:$WhatIfDisable -WhatIf:$WhatIfPreference
+    }
+
+    if ($Delete) {
+        $devicesToDelete = Get-CloudDevicesToProcess -Type Delete -Devices $allDevices -ActionIf $deleteOnlyIf -ProcessedDevices $processedDevices
+        Write-Color -Text '[i] ', 'Devices to be deleted: ', $devicesToDelete.Count, '. Current delete limit: ', $(if ($DeleteLimit -eq 0) { 'Unlimited' } else { $DeleteLimit }) -Color Yellow, Cyan, Green, Cyan, Yellow
+
+        $reportDeleted = Request-CloudDevicesDelete -Devices $devicesToDelete -ProcessedDevices $processedDevices -Today $today -DeleteLimit $DeleteLimit -DeleteRemoveIntuneRecord:$DeleteRemoveIntuneRecord -ReportOnly:$ReportOnly -WhatIfDelete:$WhatIfDelete -WhatIf:$WhatIfPreference
+    }
+
+    $export.PendingActions = $processedDevices
+    $export.CurrentRun = @(
+        if ($reportRetired.Count -gt 0) { $reportRetired }
+        if ($reportDisabled.Count -gt 0) { $reportDisabled }
+        if ($reportDeleted.Count -gt 0) { $reportDeleted }
+    )
+    $export.History = @(
+        if ($export.History) { $export.History }
+        if ($reportRetired.Count -gt 0) { $reportRetired }
+        if ($reportDisabled.Count -gt 0) { $reportDisabled }
+        if ($reportDeleted.Count -gt 0) { $reportDeleted }
+    )
+
+    if (-not $ReportOnly) {
+        try {
+            $export | Export-Clixml -LiteralPath $DataStorePath -Encoding Unicode -WhatIf:$false -ErrorAction Stop
+        } catch {
+            Write-Color -Text '[-] Exporting processed cloud device list failed. Error: ', $_.Exception.Message -Color Yellow, Red
+        }
+    }
+
+    New-HTMLProcessedCloudDevices -Export $export -Devices $allDevices -RetireOnlyIf $retireOnlyIf -DisableOnlyIf $disableOnlyIf -DeleteOnlyIf $deleteOnlyIf -FilePath $ReportPath -Online:$Online -ShowHTML:$ShowHTML -LogFile $LogPath
+
+    Write-Color -Text '[i] ', 'Finished process of cleaning up stale cloud devices' -Color Green
+
+    if (-not $Suppress) {
+        $export.EmailBody = New-EmailBodyCloudDevices -CurrentRun $export.CurrentRun
+        $export
+    }
+}

--- a/README.MD
+++ b/README.MD
@@ -20,11 +20,12 @@
   <a href="https://evo.yt/discord"><img alt="Discord" src="https://img.shields.io/discord/508328927853281280?style=flat-square&label=discord%20chat"></a>
 </p>
 
-`CleanupMonster` is a PowerShell module to that helps you clean up **Active Directory**.
+`CleanupMonster` is a PowerShell module that helps you clean up **Active Directory** and stale cloud device records.
 
 It has multiple functionalities currently & planned:
 - [x] Cleanup stale Computer objects from Active Directory
 - [x] Cleanup SID History from Active Directory
+- [x] Cleanup stale AzureAD registered mobile devices from the cloud side
 - [ ] Cleanup stale User objects from Active Directory
 - [ ] Cleanup stale Group objects from Active Directory
 - [x] Cleanup GMSA/MSA objects from Active Directory
@@ -117,6 +118,7 @@ flowchart LR
 | Area | Cmdlet | Best for | Typical actions | Recommended mindset |
 | --- | --- | --- | --- | --- |
 | Computer cleanup | `Invoke-ADComputersCleanup` | Stale computer lifecycle management in AD, optionally cross-checked against Azure AD, Intune, and Jamf | Disable, move, disable-and-move, delete | Stage changes across multiple runs |
+| Cloud device cleanup | `Invoke-CloudDevicesCleanup` | Stale AzureAD registered mobile devices that need Intune retire and Entra cleanup | Retire, disable, delete | Retire first, then enforce grace periods |
 | Service-account cleanup | `Invoke-ADServiceAccountsCleanup` | Reviewing and cleaning stale `MSA` / `gMSA` objects with stronger destructive-run guardrails | Disable, delete | Start narrow and require explicit selectors |
 | SID history cleanup | `Invoke-ADSIDHistoryCleanup` | Removing legacy SID history entries with detailed before/after reporting | Report, selective remove | Start with discovery and tiny limits |
 
@@ -127,6 +129,9 @@ Recommended first commands for each path:
 ```powershell
 # Computer cleanup preview
 Invoke-ADComputersCleanup -Disable -ReportOnly -WhatIf -ShowHTML
+
+# Cloud device cleanup preview
+Invoke-CloudDevicesCleanup -Retire -ReportOnly -WhatIf -ShowHTML
 
 # Service-account cleanup preview
 Invoke-ADServiceAccountsCleanup -Disable -ReportOnly -WhatIf -IncludeAccounts 'gmsa-*'
@@ -193,6 +198,59 @@ Relevant examples:
 - `Examples/DeleteComputersWithMoveAndEmail.ps1`
 - `Examples/DeleteComputersWithO365.ps1`
 - `Examples/DeleteComputersWithO365andJAMF.ps1`
+
+### Cloud Device Cleanup 📱
+
+Cloud device cleanup is the Azure-side companion workflow for stale mobile devices. It is intentionally separate from AD computer cleanup because the lifecycle is different: Intune-managed devices should be retired first, while Microsoft Entra directory objects should usually be disabled before final deletion.
+
+Use it when you want to:
+
+- review stale AzureAD registered `iOS` and `Android` devices
+- distinguish matched devices from `EntraOnly` and `IntuneOnly` orphan records
+- retire managed devices first and keep a pending list before later disable/delete steps
+- clean up Intune-only orphan records that no longer have a matching Entra device object
+
+Typical lifecycle:
+
+```mermaid
+flowchart LR
+    classDef stage fill:#FFF0CC,stroke:#B7791F,stroke-width:2px,color:#5B3A00;
+    classDef gate fill:#FFF7E6,stroke:#B7791F,stroke-width:2px,color:#5B3A00;
+    classDef outcome fill:#EDF2F7,stroke:#4A5568,stroke-width:1px,color:#1A202C;
+
+    A["Discover cloud device records"] --> B{"Matched or orphan?"}
+    B -- "Matched" --> C["Retire in Intune"]
+    B -- "EntraOnly" --> D["Disable in Entra after grace period"]
+    B -- "IntuneOnly" --> E["Retire or delete orphan Intune record"]
+    C --> F["Add to pending list"]
+    D --> F
+    E --> F
+    F --> G{"Still stale after grace period?"}
+    G -- "Yes" --> H["Delete remaining records"]
+    G -- "No" --> Z["Remain pending / untouched"]
+
+    class A,C,D,E,F,H stage;
+    class B,G gate;
+    class Z outcome;
+```
+
+What matters most:
+
+- inventory now includes `Matched`, `EntraOnly`, and `IntuneOnly` record states
+- action candidates include a `SelectionReason` so reports explain why a device qualified
+- orphan records are discovered by default, but stage-specific orphan processing now requires explicit switches
+- default scope is mobile-first: `iOS` and `Android`, with company-owned devices excluded unless requested
+
+Recommended production stance:
+
+- discover all record states in the report
+- action matched records first
+- enable `-RetireIncludeIntuneOnly`, `-DisableIncludeEntraOnly`, `-DeleteIncludeEntraOnly`, and `-DeleteIncludeIntuneOnly` only after reviewing orphan behavior in your tenant
+
+Relevant examples:
+
+- `Examples/CleanupCloudDevicesPreview.ps1`
+- `Examples/CleanupCloudDevicesStaged.ps1`
 
 ### Service-Account Cleanup 🔐
 

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -259,4 +259,49 @@ Describe 'Cloud device inventory and selection helpers' {
 
         $candidates.Count | Should -Be 0
     }
+
+    It 'excludes enabled Entra-backed delete candidates' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'iPhone-Reenabled'
+                EntraDeviceObjectId    = 'entra-5'
+                DeviceId               = 'device-5'
+                ManagedDeviceId        = 'managed-5'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = 300
+                IntuneLastSeenDays     = 300
+                Enabled                = $true
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = $null
+            ListProcessedMoreThan  = 30
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+            IncludeIntuneOnly      = $false
+        }
+
+        $processedDevices = [ordered] @{
+            'entra:entra-5' = [PSCustomObject] @{
+                Action       = 'Disable'
+                ActionStatus = 'True'
+                ActionDate   = (Get-Date).AddDays(-45)
+            }
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
+
+        $candidates.Count | Should -Be 0
+    }
+
+    It 'treats missing operating system as out of scope when include filters are present' {
+        $result = Test-CloudDeviceInventoryScope -OperatingSystem $null -IncludeOperatingSystem @('iOS*') -ExcludeOperatingSystem @() -Exclusions @()
+
+        $result | Should -BeFalse
+    }
 }

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -7,6 +7,8 @@ BeforeAll {
     . (Get-CleanupMonsterPath 'Private/Get-CloudDevicesToProcess.ps1')
 
     function Write-Color { param([Parameter(ValueFromRemainingArguments = $true)] $Text, [object[]] $Color) }
+    function Get-MyDevice {}
+    function Get-MyDeviceIntune {}
 }
 
 Describe 'Cloud device inventory and selection helpers' {
@@ -83,6 +85,39 @@ Describe 'Cloud device inventory and selection helpers' {
         ($devices | Where-Object { $_.Name -eq 'Android-Orphan' }).ManagedDeviceId | Should -Be 'managed-2'
     }
 
+    It 'continues with Intune inventory when Entra inventory is empty' {
+        Mock Get-MyDevice { @() }
+        Mock Get-MyDeviceIntune {
+            @(
+                [PSCustomObject] @{
+                    Name                    = 'Android-Orphan'
+                    ManagedDeviceId         = 'managed-2'
+                    EntraDeviceObjectId     = $null
+                    AzureAdDeviceId         = 'device-2'
+                    OperatingSystem         = 'Android'
+                    OperatingSystemVersion  = '14'
+                    LastSeen                = (Get-Date).AddDays(-190)
+                    LastSeenDays            = 190
+                    FirstSeen               = (Get-Date).AddDays(-400)
+                    UserDisplayName         = 'User Two'
+                    UserPrincipalName       = 'user.two@contoso.com'
+                    EmailAddress            = 'user.two@contoso.com'
+                    ManagedDeviceOwnerType  = 'personal'
+                    DeviceRegistrationState = 'registered'
+                    AzureAdRegistered       = $true
+                    ComplianceState         = 'unknown'
+                    ManagementAgent         = 'mdm'
+                }
+            )
+        }
+
+        $devices = Get-InitialCloudDevices -IncludeOperatingSystem @('Android*') -ExcludeOperatingSystem @() -Exclusions @()
+
+        $devices.Count | Should -Be 1
+        $devices[0].RecordState | Should -Be 'IntuneOnly'
+        $devices[0].ManagedDeviceId | Should -Be 'managed-2'
+    }
+
     It 'adds an orphan-aware selection reason for delete candidates' {
         $devices = @(
             [PSCustomObject] @{
@@ -146,5 +181,44 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates = Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{})
 
         $candidates.Count | Should -Be 0
+    }
+
+    It 'allows retire candidates after a WhatIf preview entry exists' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'iPhone-Preview'
+                EntraDeviceObjectId    = 'entra-3'
+                DeviceId               = 'device-3'
+                ManagedDeviceId        = 'managed-3'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = 200
+                IntuneLastSeenDays     = 200
+                Enabled                = $true
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = $null
+            LastSeenIntuneMoreThan = 180
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeIntuneOnly      = $false
+        }
+
+        $processedDevices = [ordered] @{
+            'entra:entra-3' = [PSCustomObject] @{
+                Action       = 'Retire'
+                ActionStatus = 'WhatIf'
+                ActionDate   = (Get-Date).AddDays(-5)
+            }
+        }
+
+        $candidates = Get-CloudDevicesToProcess -Type Retire -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices
+
+        $candidates.Count | Should -Be 1
+        $candidates[0].ProcessedDeviceKey | Should -Be 'entra:entra-3'
     }
 }

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -1,0 +1,150 @@
+BeforeAll {
+    . "$PSScriptRoot\TestHelpers.ps1"
+    . (Get-CleanupMonsterPath 'Private/Test-CloudDeviceInventoryScope.ps1')
+    . (Get-CleanupMonsterPath 'Private/Get-InitialCloudDevices.ps1')
+    . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceRecordKey.ps1')
+    . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceSelectionReason.ps1')
+    . (Get-CleanupMonsterPath 'Private/Get-CloudDevicesToProcess.ps1')
+
+    function Write-Color { param([Parameter(ValueFromRemainingArguments = $true)] $Text, [object[]] $Color) }
+}
+
+Describe 'Cloud device inventory and selection helpers' {
+    It 'includes Intune orphan records in inventory output' {
+        Mock Get-MyDevice {
+            @(
+                [PSCustomObject] @{
+                    Name                  = 'iPhone-01'
+                    EntraDeviceObjectId   = 'entra-1'
+                    DeviceId              = 'device-1'
+                    Enabled               = $true
+                    OperatingSystem       = 'iOS'
+                    OperatingSystemVersion = '17.0'
+                    TrustType             = 'AzureAD registered'
+                    LastSeen              = (Get-Date).AddDays(-100)
+                    LastSeenDays          = 100
+                    FirstSeen             = (Get-Date).AddDays(-300)
+                    IsManaged             = $true
+                    IsCompliant           = $true
+                    ManagementType        = 'mdm'
+                    EnrollmentType        = 'userEnrollment'
+                    OwnerDisplayName      = @('User One')
+                    OwnerUserPrincipalName = @('user.one@contoso.com')
+                }
+            )
+        }
+        Mock Get-MyDeviceIntune {
+            @(
+                [PSCustomObject] @{
+                    Name                  = 'iPhone-01'
+                    ManagedDeviceId       = 'managed-1'
+                    EntraDeviceObjectId   = 'entra-1'
+                    AzureAdDeviceId       = 'device-1'
+                    OperatingSystem       = 'iOS'
+                    OperatingSystemVersion = '17.0'
+                    LastSeen              = (Get-Date).AddDays(-95)
+                    LastSeenDays          = 95
+                    FirstSeen             = (Get-Date).AddDays(-300)
+                    UserDisplayName       = 'User One'
+                    UserPrincipalName     = 'user.one@contoso.com'
+                    EmailAddress          = 'user.one@contoso.com'
+                    ManagedDeviceOwnerType = 'personal'
+                    DeviceRegistrationState = 'registered'
+                    AzureAdRegistered     = $true
+                    ComplianceState       = 'compliant'
+                    ManagementAgent       = 'mdm'
+                }
+                [PSCustomObject] @{
+                    Name                  = 'Android-Orphan'
+                    ManagedDeviceId       = 'managed-2'
+                    EntraDeviceObjectId   = $null
+                    AzureAdDeviceId       = 'device-2'
+                    OperatingSystem       = 'Android'
+                    OperatingSystemVersion = '14'
+                    LastSeen              = (Get-Date).AddDays(-190)
+                    LastSeenDays          = 190
+                    FirstSeen             = (Get-Date).AddDays(-400)
+                    UserDisplayName       = 'User Two'
+                    UserPrincipalName     = 'user.two@contoso.com'
+                    EmailAddress          = 'user.two@contoso.com'
+                    ManagedDeviceOwnerType = 'personal'
+                    DeviceRegistrationState = 'registered'
+                    AzureAdRegistered     = $true
+                    ComplianceState       = 'unknown'
+                    ManagementAgent       = 'mdm'
+                }
+            )
+        }
+
+        $devices = Get-InitialCloudDevices -IncludeOperatingSystem @('iOS*', 'Android*') -ExcludeOperatingSystem @() -Exclusions @()
+
+        $devices.Count | Should -Be 2
+        ($devices | Where-Object { $_.RecordState -eq 'IntuneOnly' }).Count | Should -Be 1
+        ($devices | Where-Object { $_.Name -eq 'Android-Orphan' }).ManagedDeviceId | Should -Be 'managed-2'
+    }
+
+    It 'adds an orphan-aware selection reason for delete candidates' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                = 'Android-Orphan'
+                EntraDeviceObjectId = $null
+                DeviceId            = 'device-2'
+                ManagedDeviceId     = 'managed-2'
+                HasEntraRecord      = $false
+                HasIntuneRecord     = $true
+                RecordState         = 'IntuneOnly'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays   = $null
+                IntuneLastSeenDays  = 190
+                Enabled             = $null
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = $null
+            LastSeenIntuneMoreThan = 180
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+            IncludeIntuneOnly      = $true
+        }
+
+        $candidates = Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{})
+
+        $candidates.Count | Should -Be 1
+        $candidates[0].SelectionReason | Should -Match 'Delete Intune orphan record'
+        $candidates[0].SelectionReason | Should -Match 'IncludeIntuneOnly=True'
+        $candidates[0].ProcessedDeviceKey | Should -Be 'device:device-2'
+    }
+
+    It 'excludes Intune-only delete candidates unless explicitly enabled' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                 = 'Android-Orphan'
+                EntraDeviceObjectId  = $null
+                DeviceId             = 'device-2'
+                ManagedDeviceId      = 'managed-2'
+                HasEntraRecord       = $false
+                HasIntuneRecord      = $true
+                RecordState          = 'IntuneOnly'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays    = $null
+                IntuneLastSeenDays   = 190
+                Enabled              = $null
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = $null
+            LastSeenIntuneMoreThan = 180
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+            IncludeIntuneOnly      = $false
+        }
+
+        $candidates = Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{})
+
+        $candidates.Count | Should -Be 0
+    }
+}

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -78,10 +78,10 @@ Describe 'Cloud device inventory and selection helpers' {
             )
         }
 
-        $devices = Get-InitialCloudDevices -IncludeOperatingSystem @('iOS*', 'Android*') -ExcludeOperatingSystem @() -Exclusions @()
+        $devices = @(Get-InitialCloudDevices -IncludeOperatingSystem @('iOS*', 'Android*') -ExcludeOperatingSystem @() -Exclusions @())
 
         $devices.Count | Should -Be 2
-        ($devices | Where-Object { $_.RecordState -eq 'IntuneOnly' }).Count | Should -Be 1
+        @($devices | Where-Object { $_.RecordState -eq 'IntuneOnly' }).Count | Should -Be 1
         ($devices | Where-Object { $_.Name -eq 'Android-Orphan' }).ManagedDeviceId | Should -Be 'managed-2'
     }
 
@@ -111,7 +111,7 @@ Describe 'Cloud device inventory and selection helpers' {
             )
         }
 
-        $devices = Get-InitialCloudDevices -IncludeOperatingSystem @('Android*') -ExcludeOperatingSystem @() -Exclusions @()
+        $devices = @(Get-InitialCloudDevices -IncludeOperatingSystem @('Android*') -ExcludeOperatingSystem @() -Exclusions @())
 
         $devices.Count | Should -Be 1
         $devices[0].RecordState | Should -Be 'IntuneOnly'
@@ -144,7 +144,7 @@ Describe 'Cloud device inventory and selection helpers' {
             IncludeIntuneOnly      = $true
         }
 
-        $candidates = Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{})
+        $candidates = @(Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
 
         $candidates.Count | Should -Be 1
         $candidates[0].SelectionReason | Should -Match 'Delete Intune orphan record'
@@ -178,7 +178,7 @@ Describe 'Cloud device inventory and selection helpers' {
             IncludeIntuneOnly      = $false
         }
 
-        $candidates = Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{})
+        $candidates = @(Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
 
         $candidates.Count | Should -Be 0
     }
@@ -216,9 +216,47 @@ Describe 'Cloud device inventory and selection helpers' {
             }
         }
 
-        $candidates = Get-CloudDevicesToProcess -Type Retire -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices
+        $candidates = @(Get-CloudDevicesToProcess -Type Retire -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
 
         $candidates.Count | Should -Be 1
         $candidates[0].ProcessedDeviceKey | Should -Be 'entra:entra-3'
+    }
+
+    It 'does not promote WhatIf entries through pending-age gates' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'iPhone-Staged'
+                EntraDeviceObjectId    = 'entra-4'
+                DeviceId               = 'device-4'
+                ManagedDeviceId        = 'managed-4'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = 200
+                IntuneLastSeenDays     = 200
+                Enabled                = $true
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = $null
+            ListProcessedMoreThan  = 30
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+        }
+
+        $processedDevices = [ordered] @{
+            'entra:entra-4' = [PSCustomObject] @{
+                Action       = 'Disable'
+                ActionStatus = 'WhatIf'
+                ActionDate   = (Get-Date).AddDays(-45)
+            }
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
+
+        $candidates.Count | Should -Be 0
     }
 }

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -1,6 +1,8 @@
 BeforeAll {
     . "$PSScriptRoot\TestHelpers.ps1"
     . (Get-CleanupMonsterPath 'Private/Test-CloudDeviceInventoryScope.ps1')
+    . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceRecordKeys.ps1')
+    . (Get-CleanupMonsterPath 'Private/Find-ProcessedCloudDeviceRecord.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-InitialCloudDevices.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceRecordKey.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceSelectionReason.ps1')
@@ -116,6 +118,37 @@ Describe 'Cloud device inventory and selection helpers' {
         $devices.Count | Should -Be 1
         $devices[0].RecordState | Should -Be 'IntuneOnly'
         $devices[0].ManagedDeviceId | Should -Be 'managed-2'
+    }
+
+    It 'applies Entra object-id exclusions during the Intune orphan sweep' {
+        Mock Get-MyDevice { @() }
+        Mock Get-MyDeviceIntune {
+            @(
+                [PSCustomObject] @{
+                    Name                    = 'Android-Excluded'
+                    ManagedDeviceId         = 'managed-excluded'
+                    EntraDeviceObjectId     = 'entra-excluded'
+                    AzureAdDeviceId         = 'device-excluded'
+                    OperatingSystem         = 'Android'
+                    OperatingSystemVersion  = '14'
+                    LastSeen                = (Get-Date).AddDays(-90)
+                    LastSeenDays            = 90
+                    FirstSeen               = (Get-Date).AddDays(-200)
+                    UserDisplayName         = 'User Excluded'
+                    UserPrincipalName       = 'user.excluded@contoso.com'
+                    EmailAddress            = 'user.excluded@contoso.com'
+                    ManagedDeviceOwnerType  = 'personal'
+                    DeviceRegistrationState = 'registered'
+                    AzureAdRegistered       = $true
+                    ComplianceState         = 'unknown'
+                    ManagementAgent         = 'mdm'
+                }
+            )
+        }
+
+        $devices = @(Get-InitialCloudDevices -IncludeOperatingSystem @('Android*') -ExcludeOperatingSystem @() -Exclusions @('entra-excluded'))
+
+        $devices.Count | Should -Be 0
     }
 
     It 'adds an orphan-aware selection reason for delete candidates' {
@@ -354,5 +387,50 @@ Describe 'Cloud device inventory and selection helpers' {
         $key = Get-CloudDeviceRecordKey -Device $device
 
         $key | Should -Be 'intune:managed-7'
+    }
+
+    It 'finds prior pending state when a managed record falls back to Entra keys' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'iPhone-Staged'
+                EntraDeviceObjectId    = 'entra-8'
+                DeviceId               = 'device-8'
+                ManagedDeviceId        = $null
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $false
+                RecordState            = 'EntraOnly'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = 200
+                IntuneLastSeenDays     = $null
+                Enabled                = $false
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = $null
+            ListProcessedMoreThan  = 30
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $true
+            IncludeIntuneOnly      = $false
+        }
+
+        $processedDevices = [ordered] @{
+            'intune:managed-8' = [PSCustomObject] @{
+                Action              = 'Disable'
+                ActionStatus        = 'True'
+                ActionDate          = (Get-Date).AddDays(-45)
+                ManagedDeviceId     = 'managed-8'
+                EntraDeviceObjectId = 'entra-8'
+                DeviceId            = 'device-8'
+                ProcessedDeviceKeys = @('intune:managed-8', 'entra:entra-8', 'device:device-8')
+            }
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
+
+        $candidates.Count | Should -Be 1
+        $candidates[0].ProcessedDeviceKey | Should -Be 'entra:entra-8'
+        $candidates[0].MatchedProcessedDeviceKey | Should -Be 'intune:managed-8'
     }
 }

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -149,7 +149,7 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates.Count | Should -Be 1
         $candidates[0].SelectionReason | Should -Match 'Delete Intune orphan record'
         $candidates[0].SelectionReason | Should -Match 'IncludeIntuneOnly=True'
-        $candidates[0].ProcessedDeviceKey | Should -Be 'device:device-2'
+        $candidates[0].ProcessedDeviceKey | Should -Be 'intune:managed-2'
     }
 
     It 'excludes Intune-only delete candidates unless explicitly enabled' {
@@ -209,7 +209,7 @@ Describe 'Cloud device inventory and selection helpers' {
         }
 
         $processedDevices = [ordered] @{
-            'entra:entra-3' = [PSCustomObject] @{
+            'intune:managed-3' = [PSCustomObject] @{
                 Action       = 'Retire'
                 ActionStatus = 'WhatIf'
                 ActionDate   = (Get-Date).AddDays(-5)
@@ -219,7 +219,7 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates = @(Get-CloudDevicesToProcess -Type Retire -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
 
         $candidates.Count | Should -Be 1
-        $candidates[0].ProcessedDeviceKey | Should -Be 'entra:entra-3'
+        $candidates[0].ProcessedDeviceKey | Should -Be 'intune:managed-3'
     }
 
     It 'does not promote WhatIf entries through pending-age gates' {
@@ -248,7 +248,7 @@ Describe 'Cloud device inventory and selection helpers' {
         }
 
         $processedDevices = [ordered] @{
-            'entra:entra-4' = [PSCustomObject] @{
+            'intune:managed-4' = [PSCustomObject] @{
                 Action       = 'Disable'
                 ActionStatus = 'WhatIf'
                 ActionDate   = (Get-Date).AddDays(-45)
@@ -287,7 +287,7 @@ Describe 'Cloud device inventory and selection helpers' {
         }
 
         $processedDevices = [ordered] @{
-            'entra:entra-5' = [PSCustomObject] @{
+            'intune:managed-5' = [PSCustomObject] @{
                 Action       = 'Disable'
                 ActionStatus = 'True'
                 ActionDate   = (Get-Date).AddDays(-45)
@@ -303,5 +303,56 @@ Describe 'Cloud device inventory and selection helpers' {
         $result = Test-CloudDeviceInventoryScope -OperatingSystem $null -IncludeOperatingSystem @('iOS*') -ExcludeOperatingSystem @() -Exclusions @()
 
         $result | Should -BeFalse
+    }
+
+    It 'does not include Intune-only records in disable selection' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'Android-Orphan'
+                EntraDeviceObjectId    = 'entra-6'
+                DeviceId               = 'device-6'
+                ManagedDeviceId        = 'managed-6'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'IntuneOnly'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = 300
+                IntuneLastSeenDays     = 300
+                Enabled                = $true
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = $null
+            ListProcessedMoreThan  = 30
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+        }
+
+        $processedDevices = [ordered] @{
+            'intune:managed-6' = [PSCustomObject] @{
+                Action       = 'Retire'
+                ActionStatus = 'True'
+                ActionDate   = (Get-Date).AddDays(-45)
+            }
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
+
+        $candidates.Count | Should -Be 0
+    }
+
+    It 'prefers managed device id when building cloud device keys' {
+        $device = [PSCustomObject] @{
+            Name               = 'Android-Duplicate'
+            ManagedDeviceId    = 'managed-7'
+            EntraDeviceObjectId = 'entra-7'
+            DeviceId           = 'device-7'
+        }
+
+        $key = Get-CloudDeviceRecordKey -Device $device
+
+        $key | Should -Be 'intune:managed-7'
     }
 }

--- a/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
+++ b/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
@@ -1,0 +1,195 @@
+BeforeAll {
+    . "$PSScriptRoot\TestHelpers.ps1"
+    . (Get-CleanupMonsterPath 'Public/Invoke-CloudDevicesCleanup.ps1')
+
+    function Write-Color { param([Parameter(ValueFromRemainingArguments = $true)] $Text, [object[]] $Color) }
+    function Set-LoggingCapabilities {}
+    function Set-ReportingCapabilities {}
+    function Get-GitHubVersion { param($Cmdlet, $RepositoryOwner, $RepositoryName) '0.0.0' }
+    function Assert-CloudDeviceCleanupSettings { $true }
+    function Import-CloudDevicesData { [ordered] @{} }
+    function Get-InitialCloudDevices { @() }
+    function Get-CloudDevicesToProcess { @() }
+    function Request-CloudDevicesRetire { @() }
+    function Request-CloudDevicesDisable { @() }
+    function Request-CloudDevicesDelete { @() }
+    function New-HTMLProcessedCloudDevices {}
+    function New-EmailBodyCloudDevices { param($CurrentRun) '' }
+}
+
+Describe 'Invoke-CloudDevicesCleanup' {
+    It 'retires stale cloud devices when retire mode is enabled' {
+        Mock Get-InitialCloudDevices {
+            @(
+                [PSCustomObject] @{
+                    Name                 = 'iPhone-01'
+                    EntraDeviceObjectId  = 'entra-1'
+                    ManagedDeviceId      = 'managed-1'
+                    DeviceId             = 'device-1'
+                    HasEntraRecord       = $true
+                    HasIntuneRecord      = $true
+                    Enabled              = $true
+                    OperatingSystem      = 'iOS'
+                    ManagedDeviceOwnerType = 'personal'
+                    IntuneLastSeenDays   = 150
+                    EntraLastSeenDays    = 150
+                }
+            )
+        }
+        Mock Get-CloudDevicesToProcess {
+            @(
+                [PSCustomObject] @{
+                    Name                = 'iPhone-01'
+                    EntraDeviceObjectId = 'entra-1'
+                    ManagedDeviceId     = 'managed-1'
+                    DeviceId            = 'device-1'
+                    HasEntraRecord      = $true
+                    HasIntuneRecord     = $true
+                    ProcessedDeviceKey  = 'entra:entra-1'
+                }
+            )
+        } -ParameterFilter { $Type -eq 'Retire' }
+        Mock Request-CloudDevicesRetire {
+            @(
+                [PSCustomObject] @{
+                    Name         = 'iPhone-01'
+                    Action       = 'Retire'
+                    ActionStatus = 'True'
+                }
+            )
+        }
+
+        Invoke-CloudDevicesCleanup -Retire -Suppress | Out-Null
+
+        Assert-MockCalled Request-CloudDevicesRetire -Times 1 -Exactly
+    }
+
+    It 'passes company-owned exclusion by default to candidate selection' {
+        $script:capturedRetireExcludeCompanyOwned = $null
+
+        Mock Get-InitialCloudDevices {
+            @(
+                [PSCustomObject] @{
+                    Name                = 'iPhone-02'
+                    EntraDeviceObjectId = 'entra-2'
+                    ManagedDeviceId     = 'managed-2'
+                    DeviceId            = 'device-2'
+                    HasEntraRecord      = $true
+                    HasIntuneRecord     = $true
+                }
+            )
+        }
+        Mock Get-CloudDevicesToProcess {
+            param(
+                $Type,
+                $Devices,
+                $ActionIf,
+                $ProcessedDevices
+            )
+            $script:capturedRetireExcludeCompanyOwned = $ActionIf.ExcludeCompanyOwned
+            @()
+        }
+
+        Invoke-CloudDevicesCleanup -Retire -Suppress | Out-Null
+
+        $script:capturedRetireExcludeCompanyOwned | Should -BeTrue
+    }
+
+    It 'allows including company-owned devices when requested' {
+        $script:capturedRetireExcludeCompanyOwned = $null
+
+        Mock Get-InitialCloudDevices { @() }
+        Mock Get-CloudDevicesToProcess {
+            param(
+                $Type,
+                $Devices,
+                $ActionIf,
+                $ProcessedDevices
+            )
+            $script:capturedRetireExcludeCompanyOwned = $ActionIf.ExcludeCompanyOwned
+            @()
+        } -ParameterFilter { $Type -eq 'Retire' }
+
+        Invoke-CloudDevicesCleanup -Retire -IncludeCompanyOwned -Suppress | Out-Null
+
+        $script:capturedRetireExcludeCompanyOwned | Should -BeFalse
+    }
+
+    It 'does not include orphan states for actions unless explicitly requested' {
+        $script:capturedRetireIncludeIntuneOnly = $null
+        $script:capturedDisableIncludeEntraOnly = $null
+        $script:capturedDeleteIncludeEntraOnly = $null
+        $script:capturedDeleteIncludeIntuneOnly = $null
+
+        Mock Get-InitialCloudDevices { @() }
+        Mock Get-CloudDevicesToProcess {
+            param(
+                $Type,
+                $Devices,
+                $ActionIf,
+                $ProcessedDevices
+            )
+
+            if ($Type -eq 'Retire') {
+                $script:capturedRetireIncludeIntuneOnly = $ActionIf.IncludeIntuneOnly
+            } elseif ($Type -eq 'Disable') {
+                $script:capturedDisableIncludeEntraOnly = $ActionIf.IncludeEntraOnly
+            } elseif ($Type -eq 'Delete') {
+                $script:capturedDeleteIncludeEntraOnly = $ActionIf.IncludeEntraOnly
+                $script:capturedDeleteIncludeIntuneOnly = $ActionIf.IncludeIntuneOnly
+            }
+
+            @()
+        }
+
+        Invoke-CloudDevicesCleanup -Retire -Disable -Delete -Suppress | Out-Null
+
+        $script:capturedRetireIncludeIntuneOnly | Should -BeFalse
+        $script:capturedDisableIncludeEntraOnly | Should -BeFalse
+        $script:capturedDeleteIncludeEntraOnly | Should -BeFalse
+        $script:capturedDeleteIncludeIntuneOnly | Should -BeFalse
+    }
+
+    It 'passes orphan inclusion switches through when explicitly requested' {
+        $script:capturedRetireIncludeIntuneOnly = $null
+        $script:capturedDisableIncludeEntraOnly = $null
+        $script:capturedDeleteIncludeEntraOnly = $null
+        $script:capturedDeleteIncludeIntuneOnly = $null
+
+        Mock Get-InitialCloudDevices { @() }
+        Mock Get-CloudDevicesToProcess {
+            param(
+                $Type,
+                $Devices,
+                $ActionIf,
+                $ProcessedDevices
+            )
+
+            if ($Type -eq 'Retire') {
+                $script:capturedRetireIncludeIntuneOnly = $ActionIf.IncludeIntuneOnly
+            } elseif ($Type -eq 'Disable') {
+                $script:capturedDisableIncludeEntraOnly = $ActionIf.IncludeEntraOnly
+            } elseif ($Type -eq 'Delete') {
+                $script:capturedDeleteIncludeEntraOnly = $ActionIf.IncludeEntraOnly
+                $script:capturedDeleteIncludeIntuneOnly = $ActionIf.IncludeIntuneOnly
+            }
+
+            @()
+        }
+
+        Invoke-CloudDevicesCleanup `
+            -Retire `
+            -Disable `
+            -Delete `
+            -RetireIncludeIntuneOnly `
+            -DisableIncludeEntraOnly `
+            -DeleteIncludeEntraOnly `
+            -DeleteIncludeIntuneOnly `
+            -Suppress | Out-Null
+
+        $script:capturedRetireIncludeIntuneOnly | Should -BeTrue
+        $script:capturedDisableIncludeEntraOnly | Should -BeTrue
+        $script:capturedDeleteIncludeEntraOnly | Should -BeTrue
+        $script:capturedDeleteIncludeIntuneOnly | Should -BeTrue
+    }
+}

--- a/Tests/Request-CloudDeviceActions.Tests.ps1
+++ b/Tests/Request-CloudDeviceActions.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Request-CloudDevicesDelete' {
             }
         )
 
-        $results = Request-CloudDevicesDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -DeleteRemoveIntuneRecord:$false
+        $results = @(Request-CloudDevicesDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -DeleteRemoveIntuneRecord:$false)
 
         $results.Count | Should -Be 1
         $results[0].ActionStatus | Should -Be 'False'

--- a/Tests/Request-CloudDeviceActions.Tests.ps1
+++ b/Tests/Request-CloudDeviceActions.Tests.ps1
@@ -1,5 +1,7 @@
 BeforeAll {
     . "$PSScriptRoot\TestHelpers.ps1"
+    . (Get-CleanupMonsterPath 'Private/Remove-ProcessedCloudDeviceRecord.ps1')
+    . (Get-CleanupMonsterPath 'Private/Set-ProcessedCloudDeviceRecord.ps1')
     . (Get-CleanupMonsterPath 'Private/Request-CloudDevicesDelete.ps1')
 
     function Remove-MyDevice {}

--- a/Tests/Request-CloudDeviceActions.Tests.ps1
+++ b/Tests/Request-CloudDeviceActions.Tests.ps1
@@ -1,0 +1,42 @@
+BeforeAll {
+    . "$PSScriptRoot\TestHelpers.ps1"
+    . (Get-CleanupMonsterPath 'Private/Request-CloudDevicesDelete.ps1')
+
+    function Remove-MyDevice {}
+    function Remove-MyDeviceIntuneRecord {}
+}
+
+Describe 'Request-CloudDevicesDelete' {
+    BeforeEach {
+        Mock Remove-MyDevice {}
+        Mock Remove-MyDeviceIntuneRecord {}
+    }
+
+    It 'marks delete as failed when no delete sub-action is applicable' {
+        $processedDevices = [ordered] @{
+            'device:device-2' = [PSCustomObject] @{
+                Action       = 'Retire'
+                ActionStatus = 'True'
+                ActionDate   = (Get-Date).AddDays(-35)
+            }
+        }
+
+        $devices = @(
+            [PSCustomObject] @{
+                Name               = 'Android-Orphan'
+                ProcessedDeviceKey = 'device:device-2'
+                HasEntraRecord     = $false
+                HasIntuneRecord    = $true
+            }
+        )
+
+        $results = Request-CloudDevicesDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -DeleteRemoveIntuneRecord:$false
+
+        $results.Count | Should -Be 1
+        $results[0].ActionStatus | Should -Be 'False'
+        $results[0].ActionNotes | Should -Match 'No delete sub-actions were applicable'
+        $processedDevices.Contains('device:device-2') | Should -BeTrue
+        Assert-MockCalled Remove-MyDevice -Times 0 -Exactly
+        Assert-MockCalled Remove-MyDeviceIntuneRecord -Times 0 -Exactly
+    }
+}


### PR DESCRIPTION
## Summary

- add a staged `Invoke-CloudDevicesCleanup` workflow for AzureAD registered mobile devices
- introduce cloud-device inventory, selection, reporting, datastore, and action helpers in small dedicated files
- classify records as `Matched`, `EntraOnly`, or `IntuneOnly` and explain candidate selection with `SelectionReason`
- require explicit stage-specific switches before actioning orphan states in production
- add examples, docs, and focused Pester coverage for the new cloud-device path

## Why

CleanupMonster already supported using Azure and Intune signals to validate stale AD computer cleanup, but it did not have a cloud-native lifecycle for AzureAD registered mobile devices. This PR adds that missing path so stale iOS and Android devices can be reviewed, retired, disabled, and deleted in a staged way.

## Dependency

This PR depends on the GraphEssentials action layer added here:

- https://github.com/EvotecIT/GraphEssentials/pull/18

## Impact

Teams can now:

- preview stale cloud-device candidates safely
- stage Intune retire before later Entra disable/delete actions
- discover orphan records without actioning them by default
- opt into `EntraOnly` and `IntuneOnly` processing per stage when ready

## Validation

- `Invoke-Pester -Path Tests\\Invoke-CloudDevicesCleanup.Tests.ps1,Tests\\CloudDeviceInventory.Tests.ps1 -Output Minimal`