### PR TITLE
Tighten cloud device cleanup follow-ups

### DIFF
--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -52,16 +52,20 @@ function Get-InitialCloudDevices {
 
     $outputDevices = [System.Collections.Generic.List[object]]::new()
     foreach ($entraDevice in $entraDevices) {
-        $operatingSystem = $entraDevice.OperatingSystem
-        $deviceInScope = Test-CloudDeviceInventoryScope -OperatingSystem $operatingSystem -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -Exclusions $Exclusions -Name $entraDevice.Name -DeviceId $entraDevice.DeviceId -EntraDeviceObjectId $entraDevice.EntraDeviceObjectId
-        if (-not $deviceInScope) {
-            continue
-        }
-
         $intuneDevice = if ($entraDevice.DeviceId -and $intuneByAzureDeviceId.Contains($entraDevice.DeviceId)) {
             $intuneByAzureDeviceId[$entraDevice.DeviceId]
         } else {
             $null
+        }
+
+        $operatingSystem = if ($intuneDevice -and $intuneDevice.OperatingSystem) {
+            $intuneDevice.OperatingSystem
+        } else {
+            $entraDevice.OperatingSystem
+        }
+        $deviceInScope = Test-CloudDeviceInventoryScope -OperatingSystem $operatingSystem -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -Exclusions $Exclusions -Name $entraDevice.Name -DeviceId $entraDevice.DeviceId -EntraDeviceObjectId $entraDevice.EntraDeviceObjectId -ManagedDeviceId $(if ($intuneDevice) { $intuneDevice.ManagedDeviceId } else { $null })
+        if (-not $deviceInScope) {
+            continue
         }
 
         if ($intuneDevice -and $intuneDevice.ManagedDeviceId) {

--- a/Private/Request-CloudDevicesDelete.ps1
+++ b/Private/Request-CloudDevicesDelete.ps1
@@ -43,7 +43,7 @@ function Request-CloudDevicesDelete {
                 }
             }
 
-            if ($device.HasEntraRecord) {
+            if ($device.HasEntraRecord -and $device.RecordState -ne 'IntuneOnly') {
                 $subActionExecuted = $true
                 $removeEntraResult = Remove-MyDevice -InputObject $device -Confirm:$false -WhatIf:$($WhatIf -or $WhatIfDelete)
                 if ($removeEntraResult.Message) {

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -120,6 +120,58 @@ Describe 'Cloud device inventory and selection helpers' {
         $devices[0].ManagedDeviceId | Should -Be 'managed-2'
     }
 
+    It 'applies managed-device exclusions to matched records' {
+        Mock Get-MyDevice {
+            @(
+                [PSCustomObject] @{
+                    Name                   = 'iPhone-ManagedExcluded'
+                    EntraDeviceObjectId    = 'entra-managed-excluded'
+                    DeviceId               = 'device-managed-excluded'
+                    Enabled                = $true
+                    OperatingSystem        = 'iOS'
+                    OperatingSystemVersion = '17.0'
+                    TrustType              = 'AzureAD registered'
+                    LastSeen               = (Get-Date).AddDays(-100)
+                    LastSeenDays           = 100
+                    FirstSeen              = (Get-Date).AddDays(-300)
+                    IsManaged              = $true
+                    IsCompliant            = $true
+                    ManagementType         = 'mdm'
+                    EnrollmentType         = 'userEnrollment'
+                    OwnerDisplayName       = @('User Managed')
+                    OwnerUserPrincipalName = @('user.managed@contoso.com')
+                }
+            )
+        }
+        Mock Get-MyDeviceIntune {
+            @(
+                [PSCustomObject] @{
+                    Name                    = 'iPhone-ManagedExcluded'
+                    ManagedDeviceId         = 'managed-excluded'
+                    EntraDeviceObjectId     = 'entra-managed-excluded'
+                    AzureAdDeviceId         = 'device-managed-excluded'
+                    OperatingSystem         = 'iOS'
+                    OperatingSystemVersion  = '17.0'
+                    LastSeen                = (Get-Date).AddDays(-95)
+                    LastSeenDays            = 95
+                    FirstSeen               = (Get-Date).AddDays(-300)
+                    UserDisplayName         = 'User Managed'
+                    UserPrincipalName       = 'user.managed@contoso.com'
+                    EmailAddress            = 'user.managed@contoso.com'
+                    ManagedDeviceOwnerType  = 'personal'
+                    DeviceRegistrationState = 'registered'
+                    AzureAdRegistered       = $true
+                    ComplianceState         = 'compliant'
+                    ManagementAgent         = 'mdm'
+                }
+            )
+        }
+
+        $devices = @(Get-InitialCloudDevices -IncludeOperatingSystem @('iOS*') -ExcludeOperatingSystem @() -Exclusions @('managed-excluded'))
+
+        $devices.Count | Should -Be 0
+    }
+
     It 'applies Entra object-id exclusions during the Intune orphan sweep' {
         Mock Get-MyDevice { @() }
         Mock Get-MyDeviceIntune {

--- a/Tests/Request-CloudDeviceActions.Tests.ps1
+++ b/Tests/Request-CloudDeviceActions.Tests.ps1
@@ -41,4 +41,36 @@ Describe 'Request-CloudDevicesDelete' {
         Assert-MockCalled Remove-MyDevice -Times 0 -Exactly
         Assert-MockCalled Remove-MyDeviceIntuneRecord -Times 0 -Exactly
     }
+
+    It 'does not remove Entra objects for Intune-only delete candidates' {
+        Mock Remove-MyDeviceIntuneRecord { [PSCustomObject] @{ Success = $true; Message = 'Removed Intune record' } }
+
+        $processedDevices = [ordered] @{
+            'intune:managed-3' = [PSCustomObject] @{
+                Action       = 'Disable'
+                ActionStatus = 'True'
+                ActionDate   = (Get-Date).AddDays(-35)
+            }
+        }
+
+        $devices = @(
+            [PSCustomObject] @{
+                Name                    = 'Android-IntuneOnly'
+                ProcessedDeviceKey      = 'intune:managed-3'
+                ProcessedDeviceKeys     = @('intune:managed-3', 'entra:entra-3', 'device:device-3')
+                MatchedProcessedDeviceKey = 'intune:managed-3'
+                RecordState             = 'IntuneOnly'
+                HasEntraRecord          = $true
+                HasIntuneRecord         = $true
+            }
+        )
+
+        $results = @(Request-CloudDevicesDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date))
+
+        $results.Count | Should -Be 1
+        $results[0].ActionStatus | Should -Be 'True'
+        $results[0].ActionNotes | Should -Match 'Intune: Removed Intune record'
+        Assert-MockCalled Remove-MyDevice -Times 0 -Exactly
+        Assert-MockCalled Remove-MyDeviceIntuneRecord -Times 1 -Exactly
+    }
 }


### PR DESCRIPTION
## Summary
- apply managed-device exclusions after matched Intune records are attached
- keep Intune-only delete runs from deleting Entra objects outside the intended scope
- add regression coverage for both follow-up cases

## Testing
- full CleanupMonster Pester suite in Windows PowerShell 5.1
- full CleanupMonster Pester suite in PowerShell 7