### PR TITLE
Guard cloud device follow-up cleanup

### DIFF
--- a/Docs/Invoke-CloudDevicesCleanup.md
+++ b/Docs/Invoke-CloudDevicesCleanup.md
@@ -33,7 +33,7 @@ Orphan records are still discovered by default, but actioning them is intentiona
 Destructive cloud cleanup treats missing Graph data as unsafe:
 
 - blank activity timestamps are excluded from destructive action selection
-- hybrid Azure AD joined, Azure AD joined, synchronized, and non-registered Intune states are excluded; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
+- hybrid Azure AD joined, Azure AD joined, synchronized, non-registered, and unknown registration states are excluded; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
 - pending devices are not promoted if current inventory loses activity that existed when staged
 - Entra-backed disable requires `Enabled -eq $true`
 - Entra-backed delete requires `Enabled -eq $false`

--- a/Docs/Invoke-CloudDevicesCleanup.md
+++ b/Docs/Invoke-CloudDevicesCleanup.md
@@ -33,7 +33,7 @@ Orphan records are still discovered by default, but actioning them is intentiona
 Destructive cloud cleanup treats missing Graph data as unsafe:
 
 - blank activity timestamps are excluded from destructive action selection
-- hybrid Azure AD joined and Azure AD joined devices are excluded; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
+- hybrid Azure AD joined, Azure AD joined, synchronized, and non-registered Intune states are excluded; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
 - pending devices are not promoted if current inventory loses activity that existed when staged
 - Entra-backed disable requires `Enabled -eq $true`
 - Entra-backed delete requires `Enabled -eq $false`

--- a/Docs/Invoke-CloudDevicesCleanup.md
+++ b/Docs/Invoke-CloudDevicesCleanup.md
@@ -8,11 +8,11 @@ schema: 2.0.0
 # Invoke-CloudDevicesCleanup
 
 ## SYNOPSIS
-Stages cleanup for stale AzureAD registered mobile devices from Microsoft Entra ID and Intune.
+Stages cleanup for stale Microsoft Entra registered mobile devices from Microsoft Entra ID and Intune.
 
 ## DESCRIPTION
 `Invoke-CloudDevicesCleanup` is the cloud-side companion to AD computer cleanup.
-It targets AzureAD registered mobile devices, builds a combined Entra and Intune inventory,
+It targets Microsoft Entra registered mobile devices, builds a combined Entra and Intune inventory,
 classifies records as matched or orphaned, and supports staged actions:
 
 - `Retire` for Intune-managed devices
@@ -20,6 +20,8 @@ classifies records as matched or orphaned, and supports staged actions:
 - `Delete` for final record cleanup
 
 The workflow keeps its own pending datastore so actions can be separated across multiple runs.
+Real successful retire and disable actions are stored in `PendingActions`; `-ReportOnly`,
+top-level `-WhatIf`, and action-specific preview switches do not mutate pending cleanup state.
 
 Orphan records are still discovered by default, but actioning them is intentionally explicit:
 
@@ -27,6 +29,14 @@ Orphan records are still discovered by default, but actioning them is intentiona
 - `-DisableIncludeEntraOnly`
 - `-DeleteIncludeEntraOnly`
 - `-DeleteIncludeIntuneOnly`
+
+Destructive cloud cleanup treats missing Graph data as unsafe:
+
+- blank activity timestamps are excluded from destructive action selection
+- pending devices are not promoted if current inventory loses activity that existed when staged
+- Entra-backed disable requires `Enabled -eq $true`
+- Entra-backed delete requires `Enabled -eq $false`
+- unknown Entra enabled state is excluded from disable/delete
 
 ## EXAMPLES
 
@@ -50,8 +60,24 @@ Invoke-CloudDevicesCleanup `
 
 Run the staged lifecycle for stale mobile devices with explicit grace periods.
 
+### Example 3
+```powershell
+Invoke-CloudDevicesCleanup `
+    -Retire `
+    -Disable `
+    -Delete `
+    -WhatIf `
+    -SafetyEntraLimit 1000 `
+    -SafetyIntuneLimit 1000 `
+    -ReportPath C:\Reports\CloudDevices.html `
+    -ShowHTML
+```
+
+Preview all stages, stop on suspiciously low Graph inventory, and generate an HTML report.
+
 ## NOTES
 
-- Designed primarily for `iOS` and `Android` AzureAD registered devices.
+- Designed primarily for `iOS` and `Android` Microsoft Entra registered devices.
 - Inventory includes `Matched`, `EntraOnly`, and `IntuneOnly` record states.
 - Default behavior excludes company-owned devices unless explicitly included.
+- Use `-Confirm` when running interactively and keep `RetireLimit`, `DisableLimit`, and `DeleteLimit` low during rollout.

--- a/Docs/Invoke-CloudDevicesCleanup.md
+++ b/Docs/Invoke-CloudDevicesCleanup.md
@@ -33,6 +33,7 @@ Orphan records are still discovered by default, but actioning them is intentiona
 Destructive cloud cleanup treats missing Graph data as unsafe:
 
 - blank activity timestamps are excluded from destructive action selection
+- hybrid Azure AD joined and Azure AD joined devices are excluded; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
 - pending devices are not promoted if current inventory loses activity that existed when staged
 - Entra-backed disable requires `Enabled -eq $true`
 - Entra-backed delete requires `Enabled -eq $false`

--- a/Docs/Readme.md
+++ b/Docs/Readme.md
@@ -8,12 +8,17 @@ Locale: en-US
 
 # CleanupMonster Module
 ## Description
-{{ Fill in the Description }}
+CleanupMonster provides staged, reportable cleanup workflows for Active Directory computers, cloud devices, service accounts, and SID history.
 
 ## CleanupMonster Cmdlets
 ### [Invoke-ADComputersCleanup](Invoke-ADComputersCleanup.md)
-{{ Fill in the Synopsis }}
+Staged cleanup of stale Active Directory computer objects, including disable, move, disable-and-move, and delete workflows.
 
 ### [Invoke-CloudDevicesCleanup](Invoke-CloudDevicesCleanup.md)
-Staged cleanup of stale AzureAD registered mobile devices from Microsoft Entra ID and Intune.
+Staged cleanup of stale Microsoft Entra registered mobile devices from Microsoft Entra ID and Intune.
 
+### [Invoke-ADServiceAccountsCleanup](Invoke-ADServiceAccountsCleanup.md)
+Staged cleanup of stale Active Directory managed service accounts and group managed service accounts.
+
+### [Invoke-ADSIDHistoryCleanup](Invoke-ADSIDHistoryCleanup.md)
+Targeted cleanup of SID history entries with filtering, reporting, and small removal limits.

--- a/Private/Get-CloudDeviceSelectionReason.ps1
+++ b/Private/Get-CloudDeviceSelectionReason.ps1
@@ -47,7 +47,15 @@ function Get-CloudDeviceSelectionReason {
     }
 
     if ($Type -eq 'Delete') {
-        if ($Device.HasIntuneRecord -and $Device.HasEntraRecord) {
+        if ($Device.RecordState -eq 'Matched' -and $Device.HasIntuneRecord -and $Device.HasEntraRecord) {
+            $reasons.Add('Delete Intune record and Entra device object')
+        } elseif ($Device.RecordState -eq 'IntuneOnly' -and $Device.HasIntuneRecord) {
+            $reasons.Add('Delete Intune orphan record')
+            $reasons.Add("IncludeIntuneOnly=$($ActionIf.IncludeIntuneOnly)")
+        } elseif ($Device.RecordState -eq 'EntraOnly' -and $Device.HasEntraRecord) {
+            $reasons.Add('Delete Entra orphan record')
+            $reasons.Add("IncludeEntraOnly=$($ActionIf.IncludeEntraOnly)")
+        } elseif ($Device.HasIntuneRecord -and $Device.HasEntraRecord) {
             $reasons.Add('Delete Intune record and Entra device object')
         } elseif ($Device.HasIntuneRecord) {
             $reasons.Add('Delete Intune orphan record')

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -88,6 +88,12 @@ function Get-CloudDevicesToProcess {
                 $processedDevice.TimeToNextAction = $ActionIf.ListProcessedMoreThan - $timeOnPendingList
                 continue
             }
+
+            if ($null -eq $ActionIf.LastSeenEntraMoreThan -and
+                $null -eq $ActionIf.LastSeenIntuneMoreThan -and
+                -not (Test-CloudDevicePendingActivity -Device $device -ProcessedDevice $processedDevice)) {
+                continue
+            }
         }
 
         if ($null -ne $ActionIf.LastSeenEntraMoreThan) {

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -89,9 +89,7 @@ function Get-CloudDevicesToProcess {
                 continue
             }
 
-            if ($null -eq $ActionIf.LastSeenEntraMoreThan -and
-                $null -eq $ActionIf.LastSeenIntuneMoreThan -and
-                -not (Test-CloudDevicePendingActivity -Device $device -ProcessedDevice $processedDevice)) {
+            if (-not (Test-CloudDevicePendingActivity -Device $device -ProcessedDevice $processedDevice)) {
                 continue
             }
         }

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -53,7 +53,7 @@ function Get-CloudDevicesToProcess {
                 continue
             }
         } elseif ($Type -eq 'Disable') {
-            if (-not $device.HasEntraRecord -or $device.Enabled -eq $false) {
+            if (-not $device.HasEntraRecord -or $device.Enabled -ne $true) {
                 continue
             }
             if ($device.RecordState -eq 'IntuneOnly') {
@@ -66,7 +66,7 @@ function Get-CloudDevicesToProcess {
             if (-not $device.HasEntraRecord -and -not $device.HasIntuneRecord) {
                 continue
             }
-            if ($device.HasEntraRecord -and $device.Enabled -eq $true) {
+            if ($device.HasEntraRecord -and $device.RecordState -ne 'IntuneOnly' -and $device.Enabled -ne $false) {
                 continue
             }
             if ($device.RecordState -eq 'EntraOnly' -and -not $ActionIf.IncludeEntraOnly) {

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -52,6 +52,10 @@ function Get-InitialCloudDevices {
 
     $outputDevices = [System.Collections.Generic.List[object]]::new()
     foreach ($entraDevice in $entraDevices) {
+        if (-not (Test-CloudDeviceRegistrationScope -Device $entraDevice)) {
+            continue
+        }
+
         $intuneDevice = if ($entraDevice.DeviceId -and $intuneByAzureDeviceId.Contains($entraDevice.DeviceId)) {
             $intuneByAzureDeviceId[$entraDevice.DeviceId]
         } else {
@@ -109,6 +113,10 @@ function Get-InitialCloudDevices {
     }
 
     foreach ($intuneDevice in $intuneDevices) {
+        if (-not (Test-CloudDeviceRegistrationScope -Device $intuneDevice)) {
+            continue
+        }
+
         if ($intuneDevice.ManagedDeviceId -and $matchedIntuneManagedDeviceIds.Contains($intuneDevice.ManagedDeviceId)) {
             continue
         }

--- a/Private/Request-CloudDevicesDisable.ps1
+++ b/Private/Request-CloudDevicesDisable.ps1
@@ -41,8 +41,10 @@ function Request-CloudDevicesDisable {
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ProcessedDeviceKeys' -Value $device.ProcessedDeviceKeys -Force
         $results.Add($result)
 
-        if ($actionSucceeded -or $WhatIf -or $WhatIfDisable -or $ReportOnly) {
+        if ($actionSucceeded -and -not ($WhatIf -or $WhatIfDisable -or $ReportOnly)) {
             Set-ProcessedCloudDeviceRecord -ProcessedDevices $ProcessedDevices -Device $device -Result $result
+            $processedCount++
+        } elseif ($actionSucceeded -or $WhatIf -or $WhatIfDisable -or $ReportOnly) {
             $processedCount++
         }
     }

--- a/Private/Request-CloudDevicesRetire.ps1
+++ b/Private/Request-CloudDevicesRetire.ps1
@@ -41,8 +41,10 @@ function Request-CloudDevicesRetire {
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ProcessedDeviceKeys' -Value $device.ProcessedDeviceKeys -Force
         $results.Add($result)
 
-        if ($actionSucceeded -or $WhatIf -or $WhatIfRetire -or $ReportOnly) {
+        if ($actionSucceeded -and -not ($WhatIf -or $WhatIfRetire -or $ReportOnly)) {
             Set-ProcessedCloudDeviceRecord -ProcessedDevices $ProcessedDevices -Device $device -Result $result
+            $processedCount++
+        } elseif ($actionSucceeded -or $WhatIf -or $WhatIfRetire -or $ReportOnly) {
             $processedCount++
         }
     }

--- a/Private/Test-CloudDevicePendingActivity.ps1
+++ b/Private/Test-CloudDevicePendingActivity.ps1
@@ -28,7 +28,7 @@ function Test-CloudDevicePendingActivity {
         }
 
         if ($null -eq $currentActivity) {
-            continue
+            return $false
         }
 
         if ([datetime] $currentActivity -gt [datetime] $processedActivity) {

--- a/Private/Test-CloudDevicePendingActivity.ps1
+++ b/Private/Test-CloudDevicePendingActivity.ps1
@@ -1,0 +1,40 @@
+function Test-CloudDevicePendingActivity {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSObject] $Device,
+
+        [Parameter(Mandatory)]
+        [PSObject] $ProcessedDevice
+    )
+
+    foreach ($activityProperty in 'EntraLastSeen', 'IntuneLastSeen') {
+        $currentActivity = if ($Device.PSObject.Properties[$activityProperty]) {
+            $Device.$activityProperty
+        } else {
+            $null
+        }
+        $processedActivity = if ($ProcessedDevice.PSObject.Properties[$activityProperty]) {
+            $ProcessedDevice.$activityProperty
+        } else {
+            $null
+        }
+
+        if ($null -eq $processedActivity) {
+            if ($null -ne $currentActivity) {
+                return $false
+            }
+            continue
+        }
+
+        if ($null -eq $currentActivity) {
+            continue
+        }
+
+        if ([datetime] $currentActivity -gt [datetime] $processedActivity) {
+            return $false
+        }
+    }
+
+    $true
+}

--- a/Private/Test-CloudDeviceRegistrationScope.ps1
+++ b/Private/Test-CloudDeviceRegistrationScope.ps1
@@ -1,0 +1,21 @@
+function Test-CloudDeviceRegistrationScope {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object] $Device
+    )
+
+    if ($Device.PSObject.Properties['TrustType'] -and $Device.TrustType) {
+        return $Device.TrustType -eq 'AzureAD registered'
+    }
+
+    if ($Device.PSObject.Properties['IsSynchronized'] -and $Device.IsSynchronized -eq $true) {
+        return $false
+    }
+
+    if ($Device.PSObject.Properties['AzureAdRegistered'] -and $Device.AzureAdRegistered -eq $false) {
+        return $false
+    }
+
+    $true
+}

--- a/Private/Test-CloudDeviceRegistrationScope.ps1
+++ b/Private/Test-CloudDeviceRegistrationScope.ps1
@@ -21,5 +21,5 @@ function Test-CloudDeviceRegistrationScope {
         return $false
     }
 
-    $true
+    $false
 }

--- a/Private/Test-CloudDeviceRegistrationScope.ps1
+++ b/Private/Test-CloudDeviceRegistrationScope.ps1
@@ -9,6 +9,10 @@ function Test-CloudDeviceRegistrationScope {
         return $Device.TrustType -eq 'AzureAD registered'
     }
 
+    if ($Device.PSObject.Properties['DeviceRegistrationState'] -and $Device.DeviceRegistrationState) {
+        return $Device.DeviceRegistrationState -eq 'registered'
+    }
+
     if ($Device.PSObject.Properties['IsSynchronized'] -and $Device.IsSynchronized -eq $true) {
         return $false
     }

--- a/Public/Invoke-ADComputersCleanup.ps1
+++ b/Public/Invoke-ADComputersCleanup.ps1
@@ -192,6 +192,9 @@
     This is to prevent accidental deletion of all computers that meet the criteria.
     Adjust the limit to your needs.
 
+    .PARAMETER Move
+    Enable the move process, meaning computers that meet the move criteria will be moved to MoveTargetOrganizationalUnit.
+
     .PARAMETER MoveIsEnabled
     Move computer only if it's Enabled or only if it's Disabled.
     By default it will try to Move all computers that are either disabled or enabled.
@@ -273,15 +276,6 @@
     .PARAMETER MoveLimit
     Limit the number of computers that will be moved. 0 = unlimited. Default is 1.
     This is to prevent accidental move of all computers that meet the criteria.
-    Adjust the limit to your needs.
-
-    .PARAMETER MoveDoNotAddToPendingList
-    By default the script will add computers that are moved to a list of computers that will be actioned later (deleted).
-    If you want to move computers, but not add them to the list of computers that will be action later (aka pending list),  use this switch.
-
-    .PARAMETER DeleteLimit
-    Limit the number of computers that will be deleted. 0 = unlimited. Default is 1.
-    This is to prevent accidental deletion of all computers that meet the criteria.
     Adjust the limit to your needs.
 
     .PARAMETER DisableLimit
@@ -395,10 +389,10 @@
     It will use the default server if no server is provided for a domain, which is default approach.
     This feature is only nessecary if you have specific requirments per domain/forest rather than using the automatic detection.
 
-.PARAMETER RemoveProtectedFromAccidentalDeletionFlag
-Remove the ProtectedFromAccidentalDeletion flag from the computer object before moving or deleting it.
-Disable-only workflows leave the flag untouched.
-By default it will not remove the flag, and require it to be removed manually.
+    .PARAMETER RemoveProtectedFromAccidentalDeletionFlag
+    Remove the ProtectedFromAccidentalDeletion flag from the computer object before moving or deleting it.
+    Disable-only workflows leave the flag untouched.
+    By default it will not remove the flag, and require it to be removed manually.
 
     .PARAMETER ADQueryMaxRetries
     Maximum number of retries for AD query operations. Default is 3.

--- a/Public/Invoke-ADSIDHistoryCleanup.ps1
+++ b/Public/Invoke-ADSIDHistoryCleanup.ps1
@@ -83,14 +83,11 @@
     .PARAMETER ReportOnly
     If specified, only generates a report without making any changes.
 
-    .PARAMETER Report
-    Generates a report of affected objects without making any changes.
-
     .PARAMETER ReportPath
-    The path where the HTML report should be saved. Used with the -Report parameter.
+    The path where the HTML report should be saved.
 
-    .PARAMETER WhatIf
-    Shows what would happen if the function runs. The SID history entries aren't actually removed.
+    .PARAMETER DontWriteToEventLog
+    Prevents writing cleanup events to the Windows event log.
 
     .EXAMPLE
     Invoke-ADSIDHistoryCleanup -Forest "contoso.com" -IncludeType "External" -ReportOnly -ReportPath "C:\Temp\SIDHistoryReport.html" -WhatIf

--- a/Public/Invoke-ADServiceAccountsCleanup.ps1
+++ b/Public/Invoke-ADServiceAccountsCleanup.ps1
@@ -75,14 +75,44 @@ function Invoke-ADServiceAccountsCleanup {
     .PARAMETER WhatIfDelete
     Shows what would happen if accounts were deleted.
 
+    .PARAMETER DontWriteToEventLog
+    Prevents writing cleanup events to the Windows event log.
+
+    .PARAMETER Suppress
+    Suppresses returning the export object to the pipeline.
+
+    .PARAMETER LogPath
+    Path to a log file. When omitted, file logging is not enabled.
+
+    .PARAMETER LogMaximum
+    Maximum number of rotated log files to keep. Default is 5.
+
+    .PARAMETER LogShowTime
+    Includes timestamps in log output.
+
+    .PARAMETER LogTimeFormat
+    Date/time format used when LogShowTime is enabled.
+
     .EXAMPLE
     Invoke-ADServiceAccountsCleanup -Disable -DisableLastLogonDateMoreThan 90 -ReportOnly
+
+    Reports service accounts that would be disabled because they have not logged on for more than 90 days.
 
     .EXAMPLE
     Invoke-ADServiceAccountsCleanup -Delete -DeleteLastLogonDateMoreThan 180 -WhatIfDelete
 
+    Previews deletion of service accounts that have not logged on for more than 180 days.
+
     .EXAMPLE
     Invoke-ADServiceAccountsCleanup -Disable -Delete -DisableLastLogonDateMoreThan 90 -DeleteLastLogonDateMoreThan 180 -DisableLimit 2 -DeleteLimit 1 -SafetyADLimit 10 -WhatIfDisable -WhatIfDelete
+
+    Previews a staged disable/delete cleanup while limiting the number of accounts per action and requiring a minimum AD inventory count.
+
+    .EXAMPLE
+    $serviceAccounts = Invoke-ADServiceAccountsCleanup -Forest contoso.com -IncludeAccounts 'svc-*' -Disable -DisablePasswordLastSetMoreThan 120 -DisableLimit 5 -ReportPath C:\Reports\ServiceAccounts.html -ShowHTML
+    $serviceAccounts.CurrentRun | Format-Table SamAccountName, Action, ActionStatus
+
+    Disables up to five matching service accounts with old passwords, writes an HTML report, and returns the current run for review.
     #>
     [CmdletBinding(SupportsShouldProcess)]
     param(

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -4,11 +4,19 @@ function Invoke-CloudDevicesCleanup {
     Cleans up stale AzureAD registered cloud devices.
 
     .DESCRIPTION
-    Handles staged cleanup for AzureAD registered mobile devices from the cloud side.
-    The workflow is designed for iOS and Android devices and supports:
-    - Intune retire for stale managed devices
-    - Microsoft Entra disable after a grace period
-    - Final deletion from Microsoft Entra and optional Intune record removal
+    Handles staged cleanup for Microsoft Entra and Intune cloud device records.
+    The default operating-system scope is iOS and Android because these are the
+    intended mobile-device cleanup targets, but the scope can be changed with
+    IncludeOperatingSystem and ExcludeOperatingSystem.
+
+    The workflow supports three explicit stages:
+    - Retire: retires stale Intune managed devices.
+    - Disable: disables stale Microsoft Entra devices after matching criteria or pending-list age.
+    - Delete: removes stale Microsoft Entra devices and, by default, eligible Intune records.
+
+    The cmdlet keeps a datastore with PendingActions and History so staged actions
+    can be reviewed over multiple runs. ReportOnly and WhatIf/action-specific
+    WhatIf modes show candidates without mutating pending cleanup state.
 
     Blank activity timestamps are intentionally excluded from destructive actions by default.
     This follows Microsoft guidance for stale-device cleanup where activity timestamps can be empty
@@ -17,28 +25,57 @@ function Invoke-CloudDevicesCleanup {
     .PARAMETER Retire
     Enables the Intune retire stage.
 
-    .PARAMETER Disable
-    Enables the Microsoft Entra disable stage.
-
-    .PARAMETER Delete
-    Enables the final delete stage.
-
     .PARAMETER RetireLastSeenIntuneMoreThan
-    Retire devices only if Intune LastSeenDays is greater than this number.
+    Retire devices only when the Intune LastSeenDays value is greater than this number.
+    Defaults to 120 days. Devices with blank Intune activity are not selected by this criterion.
+
+    .PARAMETER RetireLastSeenEntraMoreThan
+    Retire devices only when the Entra LastSeenDays value is greater than this number.
+    Devices with blank Entra activity are not selected by this criterion.
 
     .PARAMETER RetireIncludeIntuneOnly
     Allows retire-stage processing of Intune-only orphan records.
     By default, orphan Intune records are discovered and reported but not actioned.
 
+    .PARAMETER RetireLimit
+    Maximum number of devices to retire in one run. 0 means unlimited. Default is 10.
+
+    .PARAMETER Disable
+    Enables the Microsoft Entra disable stage.
+
+    .PARAMETER DisableLastSeenEntraMoreThan
+    Disable devices only when the Entra LastSeenDays value is greater than this number.
+    Entra-backed devices must have Enabled equal to $true; unknown enabled state is treated as unsafe.
+
+    .PARAMETER DisableLastSeenIntuneMoreThan
+    Disable devices only when the Intune LastSeenDays value is greater than this number.
+    Devices with blank Intune activity are not selected by this criterion.
+
     .PARAMETER DisableListProcessedMoreThan
     Disable devices only after they were previously actioned and remained pending longer than this number of days.
+    Defaults to 30 days.
 
     .PARAMETER DisableIncludeEntraOnly
     Allows disable-stage processing of Entra-only records.
     By default, Entra-only records are discovered and reported but not actioned.
 
+    .PARAMETER DisableLimit
+    Maximum number of devices to disable in one run. 0 means unlimited. Default is 10.
+
+    .PARAMETER Delete
+    Enables the final delete stage.
+
+    .PARAMETER DeleteLastSeenEntraMoreThan
+    Delete devices only when the Entra LastSeenDays value is greater than this number.
+    Entra-backed devices must have Enabled equal to $false; unknown enabled state is treated as unsafe.
+
+    .PARAMETER DeleteLastSeenIntuneMoreThan
+    Delete devices only when the Intune LastSeenDays value is greater than this number.
+    Devices with blank Intune activity are not selected by this criterion.
+
     .PARAMETER DeleteListProcessedMoreThan
     Delete devices only after they were previously actioned and remained pending longer than this number of days.
+    Defaults to 30 days.
 
     .PARAMETER DeleteIncludeEntraOnly
     Allows delete-stage processing of Entra-only orphan records.
@@ -46,11 +83,102 @@ function Invoke-CloudDevicesCleanup {
     .PARAMETER DeleteIncludeIntuneOnly
     Allows delete-stage processing of Intune-only orphan records.
 
+    .PARAMETER DeleteLimit
+    Maximum number of devices to delete in one run. 0 means unlimited. Default is 10.
+
+    .PARAMETER DeleteRemoveIntuneRecord
+    Controls whether delete-stage processing also removes eligible Intune managed-device records.
+    Defaults to $true.
+
+    .PARAMETER IncludeOperatingSystem
+    Operating-system patterns to include when building cloud-device inventory.
+    Defaults to iOS and Android patterns. Wildcards are supported.
+
+    .PARAMETER ExcludeOperatingSystem
+    Operating-system patterns to exclude when building cloud-device inventory.
+    Wildcards are supported.
+
+    .PARAMETER Exclusions
+    Device names, Entra object IDs, Intune managed-device IDs, or other supported identifiers to exclude from cleanup.
+
+    .PARAMETER IncludeCompanyOwned
+    Includes company-owned devices in candidate selection. By default company-owned devices are excluded from actions.
+
+    .PARAMETER DataStorePath
+    Path to the XML datastore that tracks PendingActions and History.
+    Defaults to ProcessedCloudDevices.xml next to this function.
+
+    .PARAMETER ReportOnly
+    Generates inventory and reports without executing retire, disable, or delete actions and without writing updated cleanup state.
+    Existing pending actions are still read so staged candidates can be reported accurately.
+
+    .PARAMETER WhatIfRetire
+    Previews retire actions only. Preview results are shown in the current report but are not stored as pending actions or history.
+
+    .PARAMETER WhatIfDisable
+    Previews disable actions only. Preview results are shown in the current report but are not stored as pending actions or history.
+
+    .PARAMETER WhatIfDelete
+    Previews delete actions only. Preview results are shown in the current report but are not stored as pending actions or history.
+
+    .PARAMETER LogPath
+    Path to a log file. When omitted, file logging is not enabled.
+
+    .PARAMETER LogMaximum
+    Maximum number of rotated log files to keep. Default is 5.
+
+    .PARAMETER LogShowTime
+    Includes timestamps in log output.
+
+    .PARAMETER LogTimeFormat
+    Date/time format used when LogShowTime is enabled.
+
+    .PARAMETER Suppress
+    Suppresses returning the export object to the pipeline.
+
+    .PARAMETER ShowHTML
+    Opens the generated HTML report after the run.
+
+    .PARAMETER Online
+    Uses CDN-hosted CSS and JavaScript assets for the HTML report, reducing report file size.
+
+    .PARAMETER ReportPath
+    Path where the HTML report is written.
+    Defaults to ProcessedCloudDevices.html next to this function.
+
+    .PARAMETER SafetyEntraLimit
+    Stops processing if the Entra inventory count is below this value.
+    Use this as a guard against partial Graph inventory responses.
+
+    .PARAMETER SafetyIntuneLimit
+    Stops processing if the Intune inventory count is below this value.
+    Use this as a guard against partial Graph inventory responses.
+
     .EXAMPLE
     Invoke-CloudDevicesCleanup -Retire -ReportOnly -ShowHTML
 
+    Builds a report of Intune retire candidates using the default stale threshold without changing devices or cleanup state.
+
     .EXAMPLE
     Invoke-CloudDevicesCleanup -Retire -Disable -Delete -RetireLastSeenIntuneMoreThan 120 -DisableListProcessedMoreThan 30 -DeleteListProcessedMoreThan 30
+
+    Runs the full staged workflow: retire stale Intune devices, disable pending devices after 30 days, and delete pending devices after 30 days.
+
+    .EXAMPLE
+    Invoke-CloudDevicesCleanup -Retire -Disable -Delete -WhatIf -SafetyEntraLimit 1000 -SafetyIntuneLimit 1000 -ReportPath C:\Reports\CloudDevices.html -ShowHTML
+
+    Previews all enabled stages, requires minimum inventory counts, writes an HTML report, and opens it for review.
+
+    .EXAMPLE
+    Invoke-CloudDevicesCleanup -Delete -DeleteIncludeIntuneOnly -DeleteRemoveIntuneRecord $true -DeleteLastSeenIntuneMoreThan 180 -WhatIfDelete
+
+    Previews cleanup of stale Intune-only orphan records without deleting anything or updating the pending-action datastore.
+
+    .EXAMPLE
+    $cloudCleanup = Invoke-CloudDevicesCleanup -Disable -DisableLastSeenEntraMoreThan 180 -IncludeOperatingSystem 'Android*' -ExcludeOperatingSystem '*Dedicated*' -Confirm
+    $cloudCleanup.CurrentRun | Format-Table Name, Action, ActionStatus, ActionDate
+
+    Disables matching Android Entra-backed devices after confirmation and reviews the current run.
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -21,8 +21,8 @@ function Invoke-CloudDevicesCleanup {
     Blank activity timestamps are intentionally excluded from destructive actions by default.
     This follows Microsoft guidance for stale-device cleanup where activity timestamps can be empty
     even for active devices.
-    Hybrid Azure AD joined and Azure AD joined records are excluded from this cloud-device workflow;
-    use Invoke-ADComputersCleanup for hybrid device lifecycle cleanup.
+    Hybrid Azure AD joined, Azure AD joined, synchronized, and non-registered Intune records are excluded
+    from this cloud-device workflow; use Invoke-ADComputersCleanup for hybrid device lifecycle cleanup.
 
     .PARAMETER Retire
     Enables the Intune retire stage.

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -133,6 +133,8 @@ function Invoke-CloudDevicesCleanup {
         return
     }
 
+    $confirmActions = $PSBoundParameters.ContainsKey('Confirm') -and [bool] $PSBoundParameters['Confirm']
+
     $retireOnlyIf = [ordered] @{
         LastSeenIntuneMoreThan = $RetireLastSeenIntuneMoreThan
         LastSeenEntraMoreThan  = $RetireLastSeenEntraMoreThan
@@ -184,24 +186,42 @@ function Invoke-CloudDevicesCleanup {
     $reportDeleted = @()
 
     if ($Retire) {
-        $devicesToRetire = Get-CloudDevicesToProcess -Type Retire -Devices $allDevices -ActionIf $retireOnlyIf -ProcessedDevices $processedDevices
+        $devicesToRetire = @(Get-CloudDevicesToProcess -Type Retire -Devices $allDevices -ActionIf $retireOnlyIf -ProcessedDevices $processedDevices)
         Write-Color -Text '[i] ', 'Devices to be retired: ', $devicesToRetire.Count, '. Current retire limit: ', $(if ($RetireLimit -eq 0) { 'Unlimited' } else { $RetireLimit }) -Color Yellow, Cyan, Green, Cyan, Yellow
 
-        $reportRetired = Request-CloudDevicesRetire -Devices $devicesToRetire -ProcessedDevices $processedDevices -Today $today -RetireLimit $RetireLimit -ReportOnly:$ReportOnly -WhatIfRetire:$WhatIfRetire -WhatIf:$WhatIfPreference
+        $processRetire = $devicesToRetire.Count -gt 0
+        if ($processRetire -and $confirmActions -and -not ($ReportOnly -or $WhatIfPreference -or $WhatIfRetire)) {
+            $processRetire = $PSCmdlet.ShouldProcess("$($devicesToRetire.Count) cloud device(s)", 'Retire')
+        }
+        if ($processRetire) {
+            $reportRetired = Request-CloudDevicesRetire -Devices $devicesToRetire -ProcessedDevices $processedDevices -Today $today -RetireLimit $RetireLimit -ReportOnly:$ReportOnly -WhatIfRetire:$WhatIfRetire -WhatIf:$WhatIfPreference
+        }
     }
 
     if ($Disable) {
-        $devicesToDisable = Get-CloudDevicesToProcess -Type Disable -Devices $allDevices -ActionIf $disableOnlyIf -ProcessedDevices $processedDevices
+        $devicesToDisable = @(Get-CloudDevicesToProcess -Type Disable -Devices $allDevices -ActionIf $disableOnlyIf -ProcessedDevices $processedDevices)
         Write-Color -Text '[i] ', 'Devices to be disabled: ', $devicesToDisable.Count, '. Current disable limit: ', $(if ($DisableLimit -eq 0) { 'Unlimited' } else { $DisableLimit }) -Color Yellow, Cyan, Green, Cyan, Yellow
 
-        $reportDisabled = Request-CloudDevicesDisable -Devices $devicesToDisable -ProcessedDevices $processedDevices -Today $today -DisableLimit $DisableLimit -ReportOnly:$ReportOnly -WhatIfDisable:$WhatIfDisable -WhatIf:$WhatIfPreference
+        $processDisable = $devicesToDisable.Count -gt 0
+        if ($processDisable -and $confirmActions -and -not ($ReportOnly -or $WhatIfPreference -or $WhatIfDisable)) {
+            $processDisable = $PSCmdlet.ShouldProcess("$($devicesToDisable.Count) cloud device(s)", 'Disable')
+        }
+        if ($processDisable) {
+            $reportDisabled = Request-CloudDevicesDisable -Devices $devicesToDisable -ProcessedDevices $processedDevices -Today $today -DisableLimit $DisableLimit -ReportOnly:$ReportOnly -WhatIfDisable:$WhatIfDisable -WhatIf:$WhatIfPreference
+        }
     }
 
     if ($Delete) {
-        $devicesToDelete = Get-CloudDevicesToProcess -Type Delete -Devices $allDevices -ActionIf $deleteOnlyIf -ProcessedDevices $processedDevices
+        $devicesToDelete = @(Get-CloudDevicesToProcess -Type Delete -Devices $allDevices -ActionIf $deleteOnlyIf -ProcessedDevices $processedDevices)
         Write-Color -Text '[i] ', 'Devices to be deleted: ', $devicesToDelete.Count, '. Current delete limit: ', $(if ($DeleteLimit -eq 0) { 'Unlimited' } else { $DeleteLimit }) -Color Yellow, Cyan, Green, Cyan, Yellow
 
-        $reportDeleted = Request-CloudDevicesDelete -Devices $devicesToDelete -ProcessedDevices $processedDevices -Today $today -DeleteLimit $DeleteLimit -DeleteRemoveIntuneRecord:$DeleteRemoveIntuneRecord -ReportOnly:$ReportOnly -WhatIfDelete:$WhatIfDelete -WhatIf:$WhatIfPreference
+        $processDelete = $devicesToDelete.Count -gt 0
+        if ($processDelete -and $confirmActions -and -not ($ReportOnly -or $WhatIfPreference -or $WhatIfDelete)) {
+            $processDelete = $PSCmdlet.ShouldProcess("$($devicesToDelete.Count) cloud device(s)", 'Delete')
+        }
+        if ($processDelete) {
+            $reportDeleted = Request-CloudDevicesDelete -Devices $devicesToDelete -ProcessedDevices $processedDevices -Today $today -DeleteLimit $DeleteLimit -DeleteRemoveIntuneRecord:$DeleteRemoveIntuneRecord -ReportOnly:$ReportOnly -WhatIfDelete:$WhatIfDelete -WhatIf:$WhatIfPreference
+        }
     }
 
     $export.PendingActions = $processedDevices

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -21,8 +21,8 @@ function Invoke-CloudDevicesCleanup {
     Blank activity timestamps are intentionally excluded from destructive actions by default.
     This follows Microsoft guidance for stale-device cleanup where activity timestamps can be empty
     even for active devices.
-    Hybrid Azure AD joined, Azure AD joined, synchronized, and non-registered Intune records are excluded
-    from this cloud-device workflow; use Invoke-ADComputersCleanup for hybrid device lifecycle cleanup.
+    Hybrid Azure AD joined, Azure AD joined, synchronized, non-registered, and unknown registration
+    records are excluded from this cloud-device workflow; use Invoke-ADComputersCleanup for hybrid device lifecycle cleanup.
 
     .PARAMETER Retire
     Enables the Intune retire stage.

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -166,13 +166,9 @@ function Invoke-CloudDevicesCleanup {
         PendingActions = [ordered] @{}
     }
 
-    if (-not $ReportOnly) {
-        $processedDevices = Import-CloudDevicesData -DataStorePath $DataStorePath -Export $export
-        if ($processedDevices -eq $false) {
-            return
-        }
-    } else {
-        $processedDevices = [ordered] @{}
+    $processedDevices = Import-CloudDevicesData -DataStorePath $DataStorePath -Export $export
+    if ($processedDevices -eq $false) {
+        return
     }
 
     $allDevices = Get-InitialCloudDevices -SafetyEntraLimit $SafetyEntraLimit -SafetyIntuneLimit $SafetyIntuneLimit -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -Exclusions $Exclusions
@@ -194,7 +190,7 @@ function Invoke-CloudDevicesCleanup {
             $processRetire = $PSCmdlet.ShouldProcess("$($devicesToRetire.Count) cloud device(s)", 'Retire')
         }
         if ($processRetire) {
-            $reportRetired = Request-CloudDevicesRetire -Devices $devicesToRetire -ProcessedDevices $processedDevices -Today $today -RetireLimit $RetireLimit -ReportOnly:$ReportOnly -WhatIfRetire:$WhatIfRetire -WhatIf:$WhatIfPreference
+            $reportRetired = @(Request-CloudDevicesRetire -Devices $devicesToRetire -ProcessedDevices $processedDevices -Today $today -RetireLimit $RetireLimit -ReportOnly:$ReportOnly -WhatIfRetire:$WhatIfRetire -WhatIf:$WhatIfPreference)
         }
     }
 
@@ -207,7 +203,7 @@ function Invoke-CloudDevicesCleanup {
             $processDisable = $PSCmdlet.ShouldProcess("$($devicesToDisable.Count) cloud device(s)", 'Disable')
         }
         if ($processDisable) {
-            $reportDisabled = Request-CloudDevicesDisable -Devices $devicesToDisable -ProcessedDevices $processedDevices -Today $today -DisableLimit $DisableLimit -ReportOnly:$ReportOnly -WhatIfDisable:$WhatIfDisable -WhatIf:$WhatIfPreference
+            $reportDisabled = @(Request-CloudDevicesDisable -Devices $devicesToDisable -ProcessedDevices $processedDevices -Today $today -DisableLimit $DisableLimit -ReportOnly:$ReportOnly -WhatIfDisable:$WhatIfDisable -WhatIf:$WhatIfPreference)
         }
     }
 
@@ -220,7 +216,7 @@ function Invoke-CloudDevicesCleanup {
             $processDelete = $PSCmdlet.ShouldProcess("$($devicesToDelete.Count) cloud device(s)", 'Delete')
         }
         if ($processDelete) {
-            $reportDeleted = Request-CloudDevicesDelete -Devices $devicesToDelete -ProcessedDevices $processedDevices -Today $today -DeleteLimit $DeleteLimit -DeleteRemoveIntuneRecord:$DeleteRemoveIntuneRecord -ReportOnly:$ReportOnly -WhatIfDelete:$WhatIfDelete -WhatIf:$WhatIfPreference
+            $reportDeleted = @(Request-CloudDevicesDelete -Devices $devicesToDelete -ProcessedDevices $processedDevices -Today $today -DeleteLimit $DeleteLimit -DeleteRemoveIntuneRecord:$DeleteRemoveIntuneRecord -ReportOnly:$ReportOnly -WhatIfDelete:$WhatIfDelete -WhatIf:$WhatIfPreference)
         }
     }
 
@@ -230,11 +226,19 @@ function Invoke-CloudDevicesCleanup {
         if ($reportDisabled.Count -gt 0) { $reportDisabled }
         if ($reportDeleted.Count -gt 0) { $reportDeleted }
     )
+    $persistedRun = @()
+    if ($reportRetired.Count -gt 0) {
+        $persistedRun += @($reportRetired | Where-Object { $_.ActionStatus -notin 'WhatIf', 'ReportOnly' })
+    }
+    if ($reportDisabled.Count -gt 0) {
+        $persistedRun += @($reportDisabled | Where-Object { $_.ActionStatus -notin 'WhatIf', 'ReportOnly' })
+    }
+    if ($reportDeleted.Count -gt 0) {
+        $persistedRun += @($reportDeleted | Where-Object { $_.ActionStatus -notin 'WhatIf', 'ReportOnly' })
+    }
     $export.History = @(
         if ($export.History) { $export.History }
-        if ($reportRetired.Count -gt 0) { $reportRetired }
-        if ($reportDisabled.Count -gt 0) { $reportDisabled }
-        if ($reportDeleted.Count -gt 0) { $reportDeleted }
+        if ($persistedRun.Count -gt 0) { $persistedRun }
     )
 
     if (-not $ReportOnly) {

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -1,7 +1,7 @@
 function Invoke-CloudDevicesCleanup {
     <#
     .SYNOPSIS
-    Cleans up stale AzureAD registered cloud devices.
+    Cleans up stale Microsoft Entra registered cloud devices.
 
     .DESCRIPTION
     Handles staged cleanup for Microsoft Entra and Intune cloud device records.
@@ -21,6 +21,8 @@ function Invoke-CloudDevicesCleanup {
     Blank activity timestamps are intentionally excluded from destructive actions by default.
     This follows Microsoft guidance for stale-device cleanup where activity timestamps can be empty
     even for active devices.
+    Hybrid Azure AD joined and Azure AD joined records are excluded from this cloud-device workflow;
+    use Invoke-ADComputersCleanup for hybrid device lifecycle cleanup.
 
     .PARAMETER Retire
     Enables the Intune retire stage.

--- a/README.MD
+++ b/README.MD
@@ -25,7 +25,7 @@
 It has multiple functionalities currently & planned:
 - [x] Cleanup stale Computer objects from Active Directory
 - [x] Cleanup SID History from Active Directory
-- [x] Cleanup stale AzureAD registered mobile devices from the cloud side
+- [x] Cleanup stale Microsoft Entra registered mobile devices from the cloud side
 - [ ] Cleanup stale User objects from Active Directory
 - [ ] Cleanup stale Group objects from Active Directory
 - [x] Cleanup GMSA/MSA objects from Active Directory
@@ -80,7 +80,7 @@ Whether you are retiring stale computers, pruning unused `MSA` / `gMSA` objects,
 
 ## Overview 🧭
 
-CleanupMonster is easiest to understand as three end-to-end cleanup paths. They all start with discovery and reporting, but each one is optimized for a different cleanup problem.
+CleanupMonster is easiest to understand as four end-to-end cleanup paths. They all start with discovery and reporting, but each one is optimized for a different cleanup problem.
 
 > [!TIP]
 > If you are new to the module, start with `-ReportOnly` and `-WhatIf`, keep limits low, and validate the generated HTML output before enabling destructive actions.
@@ -88,37 +88,45 @@ CleanupMonster is easiest to understand as three end-to-end cleanup paths. They 
 ```mermaid
 flowchart LR
     classDef computer fill:#D9F2E6,stroke:#1F7A4D,stroke-width:2px,color:#123524;
+    classDef cloud fill:#E6FFFA,stroke:#2C7A7B,stroke-width:2px,color:#234E52;
     classDef service fill:#FFF0CC,stroke:#B7791F,stroke-width:2px,color:#5B3A00;
     classDef sid fill:#DCEBFF,stroke:#2B6CB0,stroke-width:2px,color:#153E75;
     classDef action fill:#F7FAFC,stroke:#4A5568,stroke-width:1px,color:#1A202C;
 
     A["CleanupMonster"] --> B["Computer cleanup"]
-    A --> C["Service-account cleanup"]
-    A --> D["SID history cleanup"]
+    A --> C["Cloud-device cleanup"]
+    A --> D["Service-account cleanup"]
+    A --> E["SID history cleanup"]
 
     B --> B1["Disable"]
     B --> B2["Move"]
     B --> B3["DisableAndMove"]
     B --> B4["Delete after pending age"]
 
-    C --> C1["Disable"]
-    C --> C2["Delete"]
-    C --> C3["Explicit selectors and low limits"]
+    C --> C1["Retire in Intune"]
+    C --> C2["Disable in Entra"]
+    C --> C3["Delete after pending age"]
+    C --> C4["Explicit orphan handling"]
 
-    D --> D1["Discover SID history"]
-    D --> D2["Filter by OU / object type / SID domain"]
-    D --> D3["Remove with small limits"]
+    D --> D1["Disable"]
+    D --> D2["Delete"]
+    D --> D3["Explicit selectors and low limits"]
+
+    E --> E1["Discover SID history"]
+    E --> E2["Filter by OU / object type / SID domain"]
+    E --> E3["Remove with small limits"]
 
     class B,B1,B2,B3,B4 computer;
-    class C,C1,C2,C3 service;
-    class D,D1,D2,D3 sid;
+    class C,C1,C2,C3,C4 cloud;
+    class D,D1,D2,D3 service;
+    class E,E1,E2,E3 sid;
     class A action;
 ```
 
 | Area | Cmdlet | Best for | Typical actions | Recommended mindset |
 | --- | --- | --- | --- | --- |
 | Computer cleanup | `Invoke-ADComputersCleanup` | Stale computer lifecycle management in AD, optionally cross-checked against Azure AD, Intune, and Jamf | Disable, move, disable-and-move, delete | Stage changes across multiple runs |
-| Cloud device cleanup | `Invoke-CloudDevicesCleanup` | Stale AzureAD registered mobile devices that need Intune retire and Entra cleanup | Retire, disable, delete | Retire first, then enforce grace periods |
+| Cloud device cleanup | `Invoke-CloudDevicesCleanup` | Stale Microsoft Entra registered mobile devices that need Intune retire and Entra cleanup | Retire, disable, delete | Retire first, then enforce grace periods |
 | Service-account cleanup | `Invoke-ADServiceAccountsCleanup` | Reviewing and cleaning stale `MSA` / `gMSA` objects with stronger destructive-run guardrails | Disable, delete | Start narrow and require explicit selectors |
 | SID history cleanup | `Invoke-ADSIDHistoryCleanup` | Removing legacy SID history entries with detailed before/after reporting | Report, selective remove | Start with discovery and tiny limits |
 
@@ -201,11 +209,11 @@ Relevant examples:
 
 ### Cloud Device Cleanup 📱
 
-Cloud device cleanup is the Azure-side companion workflow for stale mobile devices. It is intentionally separate from AD computer cleanup because the lifecycle is different: Intune-managed devices should be retired first, while Microsoft Entra directory objects should usually be disabled before final deletion.
+Cloud device cleanup is the Microsoft Entra and Intune companion workflow for stale mobile devices. It is intentionally separate from AD computer cleanup because the lifecycle is different: Intune-managed devices should normally be retired first, while Microsoft Entra directory objects should be disabled and held for a grace period before final deletion.
 
 Use it when you want to:
 
-- review stale AzureAD registered `iOS` and `Android` devices
+- review stale Microsoft Entra registered `iOS` and `Android` devices
 - distinguish matched devices from `EntraOnly` and `IntuneOnly` orphan records
 - retire managed devices first and keep a pending list before later disable/delete steps
 - clean up Intune-only orphan records that no longer have a matching Entra device object
@@ -213,24 +221,34 @@ Use it when you want to:
 Typical lifecycle:
 
 ```mermaid
-flowchart LR
+flowchart TD
     classDef stage fill:#FFF0CC,stroke:#B7791F,stroke-width:2px,color:#5B3A00;
     classDef gate fill:#FFF7E6,stroke:#B7791F,stroke-width:2px,color:#5B3A00;
+    classDef safety fill:#FFE5E5,stroke:#C53030,stroke-width:2px,color:#742A2A;
     classDef outcome fill:#EDF2F7,stroke:#4A5568,stroke-width:1px,color:#1A202C;
 
-    A["Discover cloud device records"] --> B{"Matched or orphan?"}
-    B -- "Matched" --> C["Retire in Intune"]
-    B -- "EntraOnly" --> D["Disable in Entra after grace period"]
-    B -- "IntuneOnly" --> E["Retire or delete orphan Intune record"]
-    C --> F["Add to pending list"]
-    D --> F
-    E --> F
-    F --> G{"Still stale after grace period?"}
-    G -- "Yes" --> H["Delete remaining records"]
-    G -- "No" --> Z["Remain pending / untouched"]
+    A["Discover Entra and Intune records"] --> B{"Activity timestamps present?"}
+    B -- "Missing required activity" --> Z["Exclude from destructive actions"]
+    B -- "Usable activity" --> C{"Matched or orphan?"}
 
-    class A,C,D,E,F,H stage;
-    class B,G gate;
+    C -- "Matched or IntuneOnly allowed" --> D["Retire in Intune"]
+    D --> E["Store real successful action in PendingActions"]
+    E --> F{"Later run: still stale and pending age met?"}
+
+    C -- "Matched or EntraOnly allowed" --> G{"Entra Enabled known?"}
+    G -- "Unknown" --> U["Treat as unsafe"]
+    G -- "Enabled = true" --> H["Disable in Entra"]
+    H --> E
+
+    F -- "Disable gate" --> G
+    F -- "Delete gate" --> I{"Entra Enabled = false or IntuneOnly?"}
+    I -- "No / unknown" --> U
+    I -- "Yes" --> J["Delete Entra object and eligible Intune record"]
+    F -- "Activity changed or disappeared" --> Z
+
+    class A,D,E,H,J stage;
+    class B,C,F,G,I gate;
+    class U safety;
     class Z outcome;
 ```
 
@@ -240,12 +258,19 @@ What matters most:
 - action candidates include a `SelectionReason` so reports explain why a device qualified
 - orphan records are discovered by default, but stage-specific orphan processing now requires explicit switches
 - default scope is mobile-first: `iOS` and `Android`, with company-owned devices excluded unless requested
+- blank current activity is unsafe for destructive selection, including when a pending device had activity before but the current inventory loses it
+- Entra-backed disable requires `Enabled -eq $true`; Entra-backed delete requires `Enabled -eq $false`; unknown enabled state is treated as unsafe
+- `-ReportOnly`, top-level `-WhatIf`, and action-specific preview switches do not add devices to `PendingActions` or persisted `History`
+- `-Confirm` prompts at the top-level action stage before destructive retire, disable, or delete requests are submitted
 
 Recommended production stance:
 
 - discover all record states in the report
 - action matched records first
 - enable `-RetireIncludeIntuneOnly`, `-DisableIncludeEntraOnly`, `-DeleteIncludeEntraOnly`, and `-DeleteIncludeIntuneOnly` only after reviewing orphan behavior in your tenant
+- use `SafetyEntraLimit` and `SafetyIntuneLimit` to stop cleanup when Graph returns suspiciously low inventory
+- keep `RetireLimit`, `DisableLimit`, and `DeleteLimit` low until the report output matches expectations
+- store `DataStorePath` somewhere durable and backed up, because staged cleanup depends on the pending-action history
 
 Relevant examples:
 
@@ -361,7 +386,8 @@ These are good defaults almost everywhere:
 
 - `-ReportOnly` for first-pass validation
 - top-level `-WhatIf` for broad previews
-- action-specific `-WhatIfDisable`, `-WhatIfMove`, and `-WhatIfDelete` when you want mixed behavior
+- top-level `-Confirm` for interactive confirmation before destructive action batches
+- action-specific `-WhatIfRetire`, `-WhatIfDisable`, `-WhatIfMove`, and `-WhatIfDelete` when you want mixed behavior
 - low action limits during rollout, then widen later
 - HTML reporting plus log files for every scheduled run
 
@@ -371,6 +397,7 @@ These help ensure your data sources are healthy before any action happens:
 
 - `SafetyADLimit` to stop if AD returns fewer objects than expected
 - `SafetyAzureADLimit`, `SafetyIntuneLimit`, and `SafetyJamfLimit` when cloud/device-source validation matters
+- `SafetyEntraLimit` and `SafetyIntuneLimit` for cloud-device cleanup to stop on partial Microsoft Graph inventory
 - `TargetServers` when you want deterministic domain-controller selection
 
 ### Workflow guards
@@ -380,6 +407,8 @@ These reduce risk in destructive cleanup patterns:
 - pending-list aging via `DeleteListProcessedMoreThan` or `MoveListProcessedMoreThan`
 - OU quarantine with `-Move` or `-DisableAndMove`
 - exclusions for known-sensitive OUs, names, or systems
+- cloud-device activity and enabled-state checks that treat missing data as unsafe for destructive cleanup
+- explicit orphan switches before cloud cleanup actions touch `EntraOnly` or `IntuneOnly` records
 - service-account explicit selectors before destructive runs
 - protected-from-accidental-deletion checks for move/delete operations
 
@@ -389,7 +418,7 @@ These reduce risk in destructive cleanup patterns:
 | --- | --- |
 | First lab / pilot | `-ReportOnly`, top-level `-WhatIf`, low limits, HTML report, log file |
 | Early production rollout | Explicit exclusions, low limits, AD safety limit, pending-list staging, action-specific `WhatIf` for risky steps |
-| Mature production automation | AD and cloud safety limits, staged disable/delete windows, OU quarantine, reports/logs, explicit target servers where needed |
+| Mature production automation | AD and cloud safety limits, staged disable/delete windows, OU quarantine, durable datastores, reports/logs, explicit target servers where needed |
 
 ## Rollout Pattern 🪜
 
@@ -407,6 +436,14 @@ For service accounts, start even narrower:
 2. keep `DisableLimit` / `DeleteLimit` low
 3. review the report
 4. then automate
+
+For cloud devices, treat missing Graph data as a stop sign:
+
+1. run `Invoke-CloudDevicesCleanup -Retire -Disable -Delete -ReportOnly -WhatIf -ShowHTML`
+2. review `Matched`, `EntraOnly`, and `IntuneOnly` records separately
+3. keep orphan action switches disabled until you understand tenant-specific orphan patterns
+4. set `SafetyEntraLimit` and `SafetyIntuneLimit` before production runs
+5. enable retire first, then disable/delete only after pending-age behavior is proven
 
 For SID history, start by discovering:
 
@@ -618,6 +655,121 @@ $invokeADComputersCleanupSplat = @{
 $Output = Invoke-ADComputersCleanup @invokeADComputersCleanupSplat
 $Output
 ```
+
+### Cloud Device Walkthrough 📱
+
+Cloud-device cleanup has its own datastore and report because the cloud lifecycle is staged differently from AD computers. The safest operating model is to preview first, retire stale Intune-managed devices, then use pending-list age before disable/delete stages.
+
+#### Report only
+
+```powershell
+$Output = Invoke-CloudDevicesCleanup `
+    -Retire `
+    -Disable `
+    -Delete `
+    -ReportOnly `
+    -WhatIf `
+    -ShowHTML `
+    -SafetyEntraLimit 1000 `
+    -SafetyIntuneLimit 1000
+
+$Output.CurrentRun
+```
+
+This reads existing pending actions so staged candidates are visible, but it does not write updated cleanup state.
+
+#### Retire stale Intune devices
+
+```powershell
+$Output = Invoke-CloudDevicesCleanup `
+    -Retire `
+    -RetireLastSeenIntuneMoreThan 120 `
+    -RetireLimit 10 `
+    -DataStorePath "$PSScriptRoot\CloudDevices\ProcessedCloudDevices.xml" `
+    -ReportPath "$PSScriptRoot\Reports\CloudDevicesRetire.html" `
+    -ShowHTML `
+    -Confirm
+
+$Output.CurrentRun | Format-Table Name, RecordState, Action, ActionStatus, SelectionReason
+```
+
+Successful real retire actions are stored in `PendingActions`. Preview actions from `-WhatIf`, `-WhatIfRetire`, or `-ReportOnly` are not promoted to pending state.
+
+#### Disable after a pending grace period
+
+```powershell
+$Output = Invoke-CloudDevicesCleanup `
+    -Disable `
+    -DisableListProcessedMoreThan 30 `
+    -DisableLimit 10 `
+    -DataStorePath "$PSScriptRoot\CloudDevices\ProcessedCloudDevices.xml" `
+    -ReportPath "$PSScriptRoot\Reports\CloudDevicesDisable.html" `
+    -SafetyEntraLimit 1000 `
+    -WhatIfDisable `
+    -ShowHTML
+
+$Output.CurrentRun
+```
+
+Disable is conservative by design. Entra-backed devices are selected only when the current inventory says `Enabled` is exactly `$true`. If Graph omits the enabled state, the device is treated as unsafe and excluded.
+
+#### Delete disabled or Intune-only records
+
+```powershell
+$Output = Invoke-CloudDevicesCleanup `
+    -Delete `
+    -DeleteListProcessedMoreThan 30 `
+    -DeleteLimit 5 `
+    -DeleteIncludeIntuneOnly `
+    -DeleteRemoveIntuneRecord $true `
+    -DataStorePath "$PSScriptRoot\CloudDevices\ProcessedCloudDevices.xml" `
+    -ReportPath "$PSScriptRoot\Reports\CloudDevicesDelete.html" `
+    -WhatIfDelete `
+    -ShowHTML
+
+$Output.CurrentRun | Format-Table Name, RecordState, Action, ActionStatus, ActionError
+```
+
+Entra-backed delete requires the current inventory to say `Enabled` is exactly `$false`. If a pending device previously had activity timestamps but the current inventory loses them, CleanupMonster will not promote it to the next destructive stage.
+
+#### Full staged cloud profile
+
+```powershell
+$invokeCloudDevicesCleanupSplat = @{
+    Retire                         = $true
+    RetireLastSeenIntuneMoreThan   = 120
+    RetireLimit                    = 10
+
+    Disable                        = $true
+    DisableListProcessedMoreThan   = 30
+    DisableLimit                   = 10
+
+    Delete                         = $true
+    DeleteListProcessedMoreThan    = 30
+    DeleteLimit                    = 5
+    DeleteRemoveIntuneRecord       = $true
+
+    IncludeOperatingSystem         = @('iOS*', 'Android*')
+    ExcludeOperatingSystem         = @('*Dedicated*')
+    IncludeCompanyOwned            = $false
+
+    SafetyEntraLimit               = 1000
+    SafetyIntuneLimit              = 1000
+    DataStorePath                  = "$PSScriptRoot\CloudDevices\ProcessedCloudDevices.xml"
+    ReportPath                     = "$PSScriptRoot\Reports\CloudDevices_$((Get-Date).ToString('yyyy-MM-dd_HH_mm_ss')).html"
+    LogPath                        = "$PSScriptRoot\Logs\CloudDevices_$((Get-Date).ToString('yyyy-MM-dd_HH_mm_ss')).log"
+
+    WhatIfRetire                   = $true
+    WhatIfDisable                  = $true
+    WhatIfDelete                   = $true
+    ShowHTML                       = $true
+}
+
+$Output = Invoke-CloudDevicesCleanup @invokeCloudDevicesCleanupSplat
+$Output
+```
+
+Remove the action-specific `WhatIf` switches gradually after reports are reviewed and the pending-action lifecycle is behaving as expected.
 
 ### Service-Account Walkthrough 🔐
 

--- a/README.MD
+++ b/README.MD
@@ -258,6 +258,7 @@ What matters most:
 - action candidates include a `SelectionReason` so reports explain why a device qualified
 - orphan records are discovered by default, but stage-specific orphan processing now requires explicit switches
 - default scope is mobile-first: `iOS` and `Android`, with company-owned devices excluded unless requested
+- hybrid Azure AD joined and Azure AD joined devices are excluded from cloud-device cleanup; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
 - blank current activity is unsafe for destructive selection, including when a pending device had activity before but the current inventory loses it
 - Entra-backed disable requires `Enabled -eq $true`; Entra-backed delete requires `Enabled -eq $false`; unknown enabled state is treated as unsafe
 - `-ReportOnly`, top-level `-WhatIf`, and action-specific preview switches do not add devices to `PendingActions` or persisted `History`

--- a/README.MD
+++ b/README.MD
@@ -258,7 +258,7 @@ What matters most:
 - action candidates include a `SelectionReason` so reports explain why a device qualified
 - orphan records are discovered by default, but stage-specific orphan processing now requires explicit switches
 - default scope is mobile-first: `iOS` and `Android`, with company-owned devices excluded unless requested
-- hybrid Azure AD joined and Azure AD joined devices are excluded from cloud-device cleanup; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
+- hybrid Azure AD joined, Azure AD joined, synchronized, and non-registered Intune states are excluded from cloud-device cleanup; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
 - blank current activity is unsafe for destructive selection, including when a pending device had activity before but the current inventory loses it
 - Entra-backed disable requires `Enabled -eq $true`; Entra-backed delete requires `Enabled -eq $false`; unknown enabled state is treated as unsafe
 - `-ReportOnly`, top-level `-WhatIf`, and action-specific preview switches do not add devices to `PendingActions` or persisted `History`

--- a/README.MD
+++ b/README.MD
@@ -258,7 +258,7 @@ What matters most:
 - action candidates include a `SelectionReason` so reports explain why a device qualified
 - orphan records are discovered by default, but stage-specific orphan processing now requires explicit switches
 - default scope is mobile-first: `iOS` and `Android`, with company-owned devices excluded unless requested
-- hybrid Azure AD joined, Azure AD joined, synchronized, and non-registered Intune states are excluded from cloud-device cleanup; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
+- hybrid Azure AD joined, Azure AD joined, synchronized, non-registered, and unknown registration states are excluded from cloud-device cleanup; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
 - blank current activity is unsafe for destructive selection, including when a pending device had activity before but the current inventory loses it
 - Entra-backed disable requires `Enabled -eq $true`; Entra-backed delete requires `Enabled -eq $false`; unknown enabled state is treated as unsafe
 - `-ReportOnly`, top-level `-WhatIf`, and action-specific preview switches do not add devices to `PendingActions` or persisted `History`

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -6,6 +6,7 @@ BeforeAll {
     . (Get-CleanupMonsterPath 'Private/Get-InitialCloudDevices.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceRecordKey.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceSelectionReason.ps1')
+    . (Get-CleanupMonsterPath 'Private/Test-CloudDevicePendingActivity.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDevicesToProcess.ps1')
 
     function Write-Color { param([Parameter(ValueFromRemainingArguments = $true)] $Text, [object[]] $Color) }
@@ -237,6 +238,36 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates[0].ProcessedDeviceKey | Should -Be 'intune:managed-2'
     }
 
+    It 'keeps Intune-only delete selection reasons aligned with the executor' {
+        $device = [PSCustomObject] @{
+            Name                 = 'Android-Orphan'
+            EntraDeviceObjectId  = 'entra-2'
+            DeviceId             = 'device-2'
+            ManagedDeviceId      = 'managed-2'
+            HasEntraRecord       = $true
+            HasIntuneRecord      = $true
+            RecordState          = 'IntuneOnly'
+            ManagedDeviceOwnerType = 'personal'
+            EntraLastSeenDays    = $null
+            IntuneLastSeenDays   = 190
+            Enabled              = $null
+        }
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = $null
+            LastSeenIntuneMoreThan = 180
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+            IncludeIntuneOnly      = $true
+        }
+
+        $reason = Get-CloudDeviceSelectionReason -Device $device -Type Delete -ActionIf $actionIf
+
+        $reason | Should -Match 'Delete Intune orphan record'
+        $reason | Should -Not -Match 'Entra device object'
+    }
+
     It 'excludes Intune-only delete candidates unless explicitly enabled' {
         $devices = @(
             [PSCustomObject] @{
@@ -343,6 +374,105 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates = @(Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
 
         $candidates.Count | Should -Be 0
+    }
+
+    It 'does not promote pending-aged devices after new activity is observed' {
+        $previousEntraLastSeen = (Get-Date).AddDays(-200)
+        $previousIntuneLastSeen = (Get-Date).AddDays(-200)
+
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'iPhone-Reactivated'
+                EntraDeviceObjectId    = 'entra-reactivated'
+                DeviceId               = 'device-reactivated'
+                ManagedDeviceId        = 'managed-reactivated'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeen          = (Get-Date).AddDays(-1)
+                IntuneLastSeen         = (Get-Date).AddDays(-1)
+                EntraLastSeenDays      = 1
+                IntuneLastSeenDays     = 1
+                Enabled                = $true
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = $null
+            LastSeenIntuneMoreThan = $null
+            ListProcessedMoreThan  = 30
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+        }
+
+        $processedDevices = [ordered] @{
+            'intune:managed-reactivated' = [PSCustomObject] @{
+                Action              = 'Retire'
+                ActionStatus        = 'True'
+                ActionDate          = (Get-Date).AddDays(-31)
+                ManagedDeviceId     = 'managed-reactivated'
+                EntraDeviceObjectId = 'entra-reactivated'
+                DeviceId            = 'device-reactivated'
+                EntraLastSeen       = $previousEntraLastSeen
+                IntuneLastSeen      = $previousIntuneLastSeen
+                ProcessedDeviceKeys = @('intune:managed-reactivated', 'entra:entra-reactivated', 'device:device-reactivated')
+            }
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
+
+        $candidates.Count | Should -Be 0
+    }
+
+    It 'promotes pending-aged devices when activity has not advanced' {
+        $staleEntraLastSeen = (Get-Date).AddDays(-200)
+        $staleIntuneLastSeen = (Get-Date).AddDays(-200)
+
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'iPhone-StillStale'
+                EntraDeviceObjectId    = 'entra-still-stale'
+                DeviceId               = 'device-still-stale'
+                ManagedDeviceId        = 'managed-still-stale'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeen          = $staleEntraLastSeen
+                IntuneLastSeen         = $staleIntuneLastSeen
+                EntraLastSeenDays      = 200
+                IntuneLastSeenDays     = 200
+                Enabled                = $true
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = $null
+            LastSeenIntuneMoreThan = $null
+            ListProcessedMoreThan  = 30
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+        }
+
+        $processedDevices = [ordered] @{
+            'intune:managed-still-stale' = [PSCustomObject] @{
+                Action              = 'Retire'
+                ActionStatus        = 'True'
+                ActionDate          = (Get-Date).AddDays(-31)
+                ManagedDeviceId     = 'managed-still-stale'
+                EntraDeviceObjectId = 'entra-still-stale'
+                DeviceId            = 'device-still-stale'
+                EntraLastSeen       = $staleEntraLastSeen
+                IntuneLastSeen      = $staleIntuneLastSeen
+                ProcessedDeviceKeys = @('intune:managed-still-stale', 'entra:entra-still-stale', 'device:device-still-stale')
+            }
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
+
+        $candidates.Count | Should -Be 1
+        $candidates[0].ProcessedDeviceKey | Should -Be 'intune:managed-still-stale'
     }
 
     It 'excludes enabled Entra-backed delete candidates' {

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -425,6 +425,57 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates.Count | Should -Be 0
     }
 
+    It 'does not promote pending-aged devices with stale thresholds after new activity is observed' {
+        $previousEntraLastSeen = (Get-Date).AddDays(-220)
+        $previousIntuneLastSeen = (Get-Date).AddDays(-220)
+        $currentEntraLastSeen = (Get-Date).AddDays(-190)
+        $currentIntuneLastSeen = (Get-Date).AddDays(-190)
+
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'iPhone-ReactivatedButStillStale'
+                EntraDeviceObjectId    = 'entra-reactivated-stale'
+                DeviceId               = 'device-reactivated-stale'
+                ManagedDeviceId        = 'managed-reactivated-stale'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeen          = $currentEntraLastSeen
+                IntuneLastSeen         = $currentIntuneLastSeen
+                EntraLastSeenDays      = 190
+                IntuneLastSeenDays     = 190
+                Enabled                = $true
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = 180
+            ListProcessedMoreThan  = 30
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+        }
+
+        $processedDevices = [ordered] @{
+            'intune:managed-reactivated-stale' = [PSCustomObject] @{
+                Action              = 'Retire'
+                ActionStatus        = 'True'
+                ActionDate          = (Get-Date).AddDays(-31)
+                ManagedDeviceId     = 'managed-reactivated-stale'
+                EntraDeviceObjectId = 'entra-reactivated-stale'
+                DeviceId            = 'device-reactivated-stale'
+                EntraLastSeen       = $previousEntraLastSeen
+                IntuneLastSeen      = $previousIntuneLastSeen
+                ProcessedDeviceKeys = @('intune:managed-reactivated-stale', 'entra:entra-reactivated-stale', 'device:device-reactivated-stale')
+            }
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
+
+        $candidates.Count | Should -Be 0
+    }
+
     It 'promotes pending-aged devices when activity has not advanced' {
         $staleEntraLastSeen = (Get-Date).AddDays(-200)
         $staleIntuneLastSeen = (Get-Date).AddDays(-200)

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -187,6 +187,16 @@ Describe 'Cloud device inventory and selection helpers' {
                     DeviceRegistrationState = 'joined'
                 }
                 [PSCustomObject] @{
+                    Name                    = 'Unknown-State-Intune'
+                    ManagedDeviceId         = 'managed-unknown-state'
+                    EntraDeviceObjectId     = $null
+                    AzureAdDeviceId         = 'device-unknown-state'
+                    OperatingSystem         = 'Android'
+                    AzureAdRegistered       = $true
+                    LastSeen                = (Get-Date).AddDays(-200)
+                    LastSeenDays            = 200
+                }
+                [PSCustomObject] @{
                     Name                    = 'Android-Orphan'
                     ManagedDeviceId         = 'managed-registered'
                     EntraDeviceObjectId     = $null
@@ -210,6 +220,7 @@ Describe 'Cloud device inventory and selection helpers' {
         $devices.Name | Should -Not -Contain 'Joined-Windows'
         $devices.Name | Should -Not -Contain 'Hybrid-Intune'
         $devices.Name | Should -Not -Contain 'Joined-State-Intune'
+        $devices.Name | Should -Not -Contain 'Unknown-State-Intune'
     }
 
     It 'applies managed-device exclusions to matched records' {

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -476,6 +476,55 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates.Count | Should -Be 0
     }
 
+    It 'does not promote pending-aged devices when current activity is missing' {
+        $previousEntraLastSeen = (Get-Date).AddDays(-220)
+        $previousIntuneLastSeen = (Get-Date).AddDays(-220)
+
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'iPhone-MissingActivity'
+                EntraDeviceObjectId    = 'entra-missing-activity'
+                DeviceId               = 'device-missing-activity'
+                ManagedDeviceId        = 'managed-missing-activity'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeen          = $null
+                IntuneLastSeen         = $previousIntuneLastSeen
+                EntraLastSeenDays      = $null
+                IntuneLastSeenDays     = 220
+                Enabled                = $true
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = $null
+            LastSeenIntuneMoreThan = $null
+            ListProcessedMoreThan  = 30
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+        }
+
+        $processedDevices = [ordered] @{
+            'intune:managed-missing-activity' = [PSCustomObject] @{
+                Action              = 'Retire'
+                ActionStatus        = 'True'
+                ActionDate          = (Get-Date).AddDays(-31)
+                ManagedDeviceId     = 'managed-missing-activity'
+                EntraDeviceObjectId = 'entra-missing-activity'
+                DeviceId            = 'device-missing-activity'
+                EntraLastSeen       = $previousEntraLastSeen
+                IntuneLastSeen      = $previousIntuneLastSeen
+                ProcessedDeviceKeys = @('intune:managed-missing-activity', 'entra:entra-missing-activity', 'device:device-missing-activity')
+            }
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
+
+        $candidates.Count | Should -Be 0
+    }
+
     It 'promotes pending-aged devices when activity has not advanced' {
         $staleEntraLastSeen = (Get-Date).AddDays(-200)
         $staleIntuneLastSeen = (Get-Date).AddDays(-200)
@@ -561,6 +610,67 @@ Describe 'Cloud device inventory and selection helpers' {
         }
 
         $candidates = @(Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices $processedDevices)
+
+        $candidates.Count | Should -Be 0
+    }
+
+    It 'does not disable Entra-backed candidates when enabled state is unknown' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'iPhone-UnknownEnabled'
+                EntraDeviceObjectId    = 'entra-unknown-enabled'
+                DeviceId               = 'device-unknown-enabled'
+                ManagedDeviceId        = 'managed-unknown-enabled'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = 300
+                IntuneLastSeenDays     = 300
+                Enabled                = $null
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = $null
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
+
+        $candidates.Count | Should -Be 0
+    }
+
+    It 'does not delete Entra-backed candidates when enabled state is unknown' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'iPhone-UnknownDeleteState'
+                EntraDeviceObjectId    = 'entra-unknown-delete'
+                DeviceId               = 'device-unknown-delete'
+                ManagedDeviceId        = 'managed-unknown-delete'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = 300
+                IntuneLastSeenDays     = 300
+                Enabled                = $null
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = $null
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+            IncludeIntuneOnly      = $false
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
 
         $candidates.Count | Should -Be 0
     }

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -176,6 +176,17 @@ Describe 'Cloud device inventory and selection helpers' {
                     DeviceRegistrationState = 'registered'
                 }
                 [PSCustomObject] @{
+                    Name                    = 'Joined-State-Intune'
+                    ManagedDeviceId         = 'managed-joined-state'
+                    EntraDeviceObjectId     = $null
+                    AzureAdDeviceId         = 'device-joined-state'
+                    OperatingSystem         = 'Android'
+                    AzureAdRegistered       = $true
+                    LastSeen                = (Get-Date).AddDays(-200)
+                    LastSeenDays            = 200
+                    DeviceRegistrationState = 'joined'
+                }
+                [PSCustomObject] @{
                     Name                    = 'Android-Orphan'
                     ManagedDeviceId         = 'managed-registered'
                     EntraDeviceObjectId     = $null
@@ -198,6 +209,7 @@ Describe 'Cloud device inventory and selection helpers' {
         $devices.Name | Should -Not -Contain 'Hybrid-Windows'
         $devices.Name | Should -Not -Contain 'Joined-Windows'
         $devices.Name | Should -Not -Contain 'Hybrid-Intune'
+        $devices.Name | Should -Not -Contain 'Joined-State-Intune'
     }
 
     It 'applies managed-device exclusions to matched records' {

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -1,5 +1,6 @@
 BeforeAll {
     . "$PSScriptRoot\TestHelpers.ps1"
+    . (Get-CleanupMonsterPath 'Private/Test-CloudDeviceRegistrationScope.ps1')
     . (Get-CleanupMonsterPath 'Private/Test-CloudDeviceInventoryScope.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceRecordKeys.ps1')
     . (Get-CleanupMonsterPath 'Private/Find-ProcessedCloudDeviceRecord.ps1')
@@ -119,6 +120,84 @@ Describe 'Cloud device inventory and selection helpers' {
         $devices.Count | Should -Be 1
         $devices[0].RecordState | Should -Be 'IntuneOnly'
         $devices[0].ManagedDeviceId | Should -Be 'managed-2'
+    }
+
+    It 'excludes hybrid and joined records from cloud cleanup inventory' {
+        Mock Get-MyDevice {
+            @(
+                [PSCustomObject] @{
+                    Name                  = 'Hybrid-Windows'
+                    EntraDeviceObjectId   = 'entra-hybrid'
+                    DeviceId              = 'device-hybrid'
+                    Enabled               = $true
+                    OperatingSystem       = 'Windows'
+                    TrustType             = 'Hybrid AzureAD'
+                    IsSynchronized        = $true
+                    LastSeen              = (Get-Date).AddDays(-200)
+                    LastSeenDays          = 200
+                }
+                [PSCustomObject] @{
+                    Name                  = 'Joined-Windows'
+                    EntraDeviceObjectId   = 'entra-joined'
+                    DeviceId              = 'device-joined'
+                    Enabled               = $true
+                    OperatingSystem       = 'Windows'
+                    TrustType             = 'AzureAD joined'
+                    IsSynchronized        = $false
+                    LastSeen              = (Get-Date).AddDays(-200)
+                    LastSeenDays          = 200
+                }
+                [PSCustomObject] @{
+                    Name                  = 'Android-Registered'
+                    EntraDeviceObjectId   = 'entra-registered'
+                    DeviceId              = 'device-registered'
+                    Enabled               = $true
+                    OperatingSystem       = 'Android'
+                    TrustType             = 'AzureAD registered'
+                    IsSynchronized        = $false
+                    LastSeen              = (Get-Date).AddDays(-200)
+                    LastSeenDays          = 200
+                }
+            )
+        }
+        Mock Get-MyDeviceIntune {
+            @(
+                [PSCustomObject] @{
+                    Name                    = 'Hybrid-Intune'
+                    ManagedDeviceId         = 'managed-hybrid'
+                    EntraDeviceObjectId     = 'entra-hybrid-intune'
+                    AzureAdDeviceId         = 'device-hybrid-intune'
+                    OperatingSystem         = 'Windows'
+                    TrustType               = 'Hybrid AzureAD'
+                    IsSynchronized          = $true
+                    AzureAdRegistered       = $true
+                    LastSeen                = (Get-Date).AddDays(-200)
+                    LastSeenDays            = 200
+                    DeviceRegistrationState = 'registered'
+                }
+                [PSCustomObject] @{
+                    Name                    = 'Android-Orphan'
+                    ManagedDeviceId         = 'managed-registered'
+                    EntraDeviceObjectId     = $null
+                    AzureAdDeviceId         = 'device-orphan'
+                    OperatingSystem         = 'Android'
+                    TrustType               = 'AzureAD registered'
+                    IsSynchronized          = $false
+                    AzureAdRegistered       = $true
+                    LastSeen                = (Get-Date).AddDays(-200)
+                    LastSeenDays            = 200
+                    DeviceRegistrationState = 'registered'
+                }
+            )
+        }
+
+        $devices = @(Get-InitialCloudDevices -IncludeOperatingSystem @('*') -ExcludeOperatingSystem @() -Exclusions @())
+
+        $devices.Name | Should -Contain 'Android-Registered'
+        $devices.Name | Should -Contain 'Android-Orphan'
+        $devices.Name | Should -Not -Contain 'Hybrid-Windows'
+        $devices.Name | Should -Not -Contain 'Joined-Windows'
+        $devices.Name | Should -Not -Contain 'Hybrid-Intune'
     }
 
     It 'applies managed-device exclusions to matched records' {

--- a/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
+++ b/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
@@ -214,4 +214,83 @@ Describe 'Invoke-CloudDevicesCleanup' {
         Assert-MockCalled Request-CloudDevicesDelete -Times 0 -Exactly
     }
 
+    It 'uses existing pending actions for report-only candidate selection' {
+        $script:capturedReportOnlyProcessedDevices = $null
+        $pendingActions = [ordered] @{
+            'intune:managed-staged' = [PSCustomObject] @{
+                Name         = 'iPhone-Staged'
+                Action       = 'Retire'
+                ActionStatus = 'True'
+                ActionDate   = (Get-Date).AddDays(-31)
+            }
+        }
+
+        Mock Import-CloudDevicesData { $pendingActions }
+        Mock Get-InitialCloudDevices { @() }
+        Mock Get-CloudDevicesToProcess {
+            param(
+                $Type,
+                $Devices,
+                $ActionIf,
+                $ProcessedDevices
+            )
+
+            $script:capturedReportOnlyProcessedDevices = $ProcessedDevices
+            @()
+        }
+
+        Invoke-CloudDevicesCleanup -Disable -ReportOnly -Suppress | Out-Null
+
+        $script:capturedReportOnlyProcessedDevices.Contains('intune:managed-staged') | Should -BeTrue
+    }
+
+    It 'does not persist WhatIf action results into exported history' {
+        $dataStorePath = Join-Path ([IO.Path]::GetTempPath()) "cleanupmonster-whatif-$([guid]::NewGuid()).xml"
+
+        try {
+            Mock Import-CloudDevicesData { [ordered] @{} }
+            Mock Get-InitialCloudDevices {
+                @(
+                    [PSCustomObject] @{
+                        Name            = 'iPhone-Preview'
+                        ManagedDeviceId = 'managed-preview'
+                        HasIntuneRecord = $true
+                    }
+                )
+            }
+            Mock Get-CloudDevicesToProcess {
+                @(
+                    [PSCustomObject] @{
+                        Name                = 'iPhone-Preview'
+                        ManagedDeviceId     = 'managed-preview'
+                        HasIntuneRecord     = $true
+                        ProcessedDeviceKey  = 'intune:managed-preview'
+                        ProcessedDeviceKeys = @('intune:managed-preview')
+                    }
+                )
+            }
+            Mock Request-CloudDevicesRetire {
+                @(
+                    [PSCustomObject] @{
+                        Name         = 'iPhone-Preview'
+                        Action       = 'Retire'
+                        ActionStatus = 'WhatIf'
+                    }
+                )
+            }
+
+            Invoke-CloudDevicesCleanup -Retire -WhatIfRetire -DataStorePath $dataStorePath -Suppress | Out-Null
+
+            $exportedCloudCleanup = Import-Clixml -LiteralPath $dataStorePath
+            @($exportedCloudCleanup.CurrentRun).Count | Should -Be 1
+            $exportedCloudCleanup.History.Count | Should -Be 0
+            $exportedCloudCleanup.PendingActions.Count | Should -Be 0
+
+        } finally {
+            if (Test-Path -LiteralPath $dataStorePath) {
+                Remove-Item -LiteralPath $dataStorePath -Force
+            }
+        }
+    }
+
 }

--- a/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
+++ b/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
@@ -37,6 +37,13 @@ Describe 'Invoke-CloudDevicesCleanup' {
             )
         }
         Mock Get-CloudDevicesToProcess {
+            param(
+                $Type,
+                $Devices,
+                $ActionIf,
+                $ProcessedDevices
+            )
+
             @(
                 [PSCustomObject] @{
                     Name                = 'iPhone-01'
@@ -48,7 +55,7 @@ Describe 'Invoke-CloudDevicesCleanup' {
                     ProcessedDeviceKey  = 'entra:entra-1'
                 }
             )
-        } -ParameterFilter { $Type -eq 'Retire' }
+        }
         Mock Request-CloudDevicesRetire {
             @(
                 [PSCustomObject] @{
@@ -59,7 +66,7 @@ Describe 'Invoke-CloudDevicesCleanup' {
             )
         }
 
-        Invoke-CloudDevicesCleanup -Retire -Suppress | Out-Null
+        Invoke-CloudDevicesCleanup -Retire -Confirm:$false -Suppress | Out-Null
 
         Assert-MockCalled Request-CloudDevicesRetire -Times 1 -Exactly
     }
@@ -108,7 +115,7 @@ Describe 'Invoke-CloudDevicesCleanup' {
             )
             $script:capturedRetireExcludeCompanyOwned = $ActionIf.ExcludeCompanyOwned
             @()
-        } -ParameterFilter { $Type -eq 'Retire' }
+        }
 
         Invoke-CloudDevicesCleanup -Retire -IncludeCompanyOwned -Suppress | Out-Null
 
@@ -192,4 +199,19 @@ Describe 'Invoke-CloudDevicesCleanup' {
         $script:capturedDeleteIncludeEntraOnly | Should -BeTrue
         $script:capturedDeleteIncludeIntuneOnly | Should -BeTrue
     }
+
+    It 'skips action request stages when no candidates are selected' {
+        Mock Get-InitialCloudDevices { @() }
+        Mock Get-CloudDevicesToProcess { @() }
+        Mock Request-CloudDevicesRetire { @() }
+        Mock Request-CloudDevicesDisable { @() }
+        Mock Request-CloudDevicesDelete { @() }
+
+        Invoke-CloudDevicesCleanup -Retire -Disable -Delete -Suppress | Out-Null
+
+        Assert-MockCalled Request-CloudDevicesRetire -Times 0 -Exactly
+        Assert-MockCalled Request-CloudDevicesDisable -Times 0 -Exactly
+        Assert-MockCalled Request-CloudDevicesDelete -Times 0 -Exactly
+    }
+
 }

--- a/Tests/Request-CloudDeviceActions.Tests.ps1
+++ b/Tests/Request-CloudDeviceActions.Tests.ps1
@@ -2,10 +2,98 @@ BeforeAll {
     . "$PSScriptRoot\TestHelpers.ps1"
     . (Get-CleanupMonsterPath 'Private/Remove-ProcessedCloudDeviceRecord.ps1')
     . (Get-CleanupMonsterPath 'Private/Set-ProcessedCloudDeviceRecord.ps1')
+    . (Get-CleanupMonsterPath 'Private/Request-CloudDevicesRetire.ps1')
+    . (Get-CleanupMonsterPath 'Private/Request-CloudDevicesDisable.ps1')
     . (Get-CleanupMonsterPath 'Private/Request-CloudDevicesDelete.ps1')
 
+    function Invoke-MyDeviceRetire {}
+    function Disable-MyDevice {}
     function Remove-MyDevice {}
     function Remove-MyDeviceIntuneRecord {}
+}
+
+Describe 'Request-CloudDevicesRetire' {
+    BeforeEach {
+        Mock Invoke-MyDeviceRetire { [PSCustomObject] @{ Success = $true; Message = 'Preview retire' } }
+    }
+
+    It 'does not store WhatIf retire results in pending actions' {
+        $processedDevices = [ordered] @{}
+        $devices = @(
+            [PSCustomObject] @{
+                Name                = 'iPhone-Preview'
+                ManagedDeviceId     = 'managed-preview'
+                ProcessedDeviceKey  = 'intune:managed-preview'
+                ProcessedDeviceKeys = @('intune:managed-preview')
+            }
+        )
+
+        $results = @(Request-CloudDevicesRetire -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -WhatIfRetire)
+
+        $results.Count | Should -Be 1
+        $results[0].ActionStatus | Should -Be 'WhatIf'
+        $processedDevices.Count | Should -Be 0
+    }
+
+    It 'does not store report-only retire results in pending actions' {
+        $processedDevices = [ordered] @{}
+        $devices = @(
+            [PSCustomObject] @{
+                Name                = 'iPhone-ReportOnly'
+                ManagedDeviceId     = 'managed-reportonly'
+                ProcessedDeviceKey  = 'intune:managed-reportonly'
+                ProcessedDeviceKeys = @('intune:managed-reportonly')
+            }
+        )
+
+        $results = @(Request-CloudDevicesRetire -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -ReportOnly)
+
+        $results.Count | Should -Be 1
+        $results[0].ActionStatus | Should -Be 'ReportOnly'
+        $processedDevices.Count | Should -Be 0
+    }
+}
+
+Describe 'Request-CloudDevicesDisable' {
+    BeforeEach {
+        Mock Disable-MyDevice { [PSCustomObject] @{ Success = $true; Message = 'Preview disable' } }
+    }
+
+    It 'does not store WhatIf disable results in pending actions' {
+        $processedDevices = [ordered] @{}
+        $devices = @(
+            [PSCustomObject] @{
+                Name                = 'iPhone-Preview'
+                ManagedDeviceId     = 'managed-preview'
+                ProcessedDeviceKey  = 'intune:managed-preview'
+                ProcessedDeviceKeys = @('intune:managed-preview')
+            }
+        )
+
+        $results = @(Request-CloudDevicesDisable -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -WhatIfDisable)
+
+        $results.Count | Should -Be 1
+        $results[0].ActionStatus | Should -Be 'WhatIf'
+        $processedDevices.Count | Should -Be 0
+    }
+
+    It 'does not store report-only disable results in pending actions' {
+        $processedDevices = [ordered] @{}
+        $devices = @(
+            [PSCustomObject] @{
+                Name                = 'iPhone-ReportOnly'
+                ManagedDeviceId     = 'managed-reportonly'
+                ProcessedDeviceKey  = 'intune:managed-reportonly'
+                ProcessedDeviceKeys = @('intune:managed-reportonly')
+            }
+        )
+
+        $results = @(Request-CloudDevicesDisable -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -ReportOnly)
+
+        $results.Count | Should -Be 1
+        $results[0].ActionStatus | Should -Be 'ReportOnly'
+        $processedDevices.Count | Should -Be 0
+    }
 }
 
 Describe 'Request-CloudDevicesDelete' {


### PR DESCRIPTION
## Summary

- Prevent cloud-device follow-up stages from advancing when Entra or Intune activity has changed since the device was staged.
- Align Intune-only delete selection reasons with the delete executor so previews no longer promise an Entra delete that is intentionally skipped.
- Add regression coverage for reactivated devices, unchanged stale devices, and Intune-only delete messaging.

## Root cause

Pending-age gates could promote previously processed cloud devices without rechecking whether activity timestamps had advanced. The delete selection reason also looked only at `HasIntuneRecord` and `HasEntraRecord`, while the executor uses `RecordState` to skip Entra deletion for `IntuneOnly` records.

## Validation

- `Invoke-Pester -Path . -Output Normal` passed `58/58` tests.
