### PR TITLE
Fix cleanup safety guard behavior

### DIFF
--- a/Docs/Invoke-ADServiceAccountsCleanup.md
+++ b/Docs/Invoke-ADServiceAccountsCleanup.md
@@ -78,3 +78,8 @@ Wildcards are supported.
 ### -ExcludeAccounts
 Exclude matching `SamAccountName` values from processing.
 Wildcards are supported.
+
+### Missing timestamp switches
+Missing `LastLogonDate`, `PasswordLastSet`, or `WhenCreated` values are not treated as stale by default when the matching age filter is used.
+Use `-DisableTreatMissingLastLogonDateAsStale`, `-DisableTreatMissingPasswordLastSetAsStale`,
+`-DisableTreatMissingWhenCreatedAsStale`, and their `Delete*` equivalents only when that is the intended policy.

--- a/Docs/Invoke-ADServiceAccountsCleanup.md
+++ b/Docs/Invoke-ADServiceAccountsCleanup.md
@@ -30,6 +30,7 @@ $invokeADServiceAccountsCleanupSplat = @{
     Disable                        = $true
     DisableLastLogonDateMoreThan   = 90
     DisablePasswordLastSetMoreThan = 90
+    DisableNoPrincipalsAllowedToRetrieveManagedPassword = $true
     DisableLimit                   = 2
 
     Delete                         = $true
@@ -83,3 +84,8 @@ Wildcards are supported.
 Missing `LastLogonDate`, `PasswordLastSet`, or `WhenCreated` values are not treated as stale by default when the matching age filter is used.
 Use `-DisableTreatMissingLastLogonDateAsStale`, `-DisableTreatMissingPasswordLastSetAsStale`,
 `-DisableTreatMissingWhenCreatedAsStale`, and their `Delete*` equivalents only when that is the intended policy.
+
+### gMSA password retrieval principals
+CleanupMonster reads and reports `PrincipalsAllowedToRetrieveManagedPassword` for gMSA objects.
+Use `-DisableNoPrincipalsAllowedToRetrieveManagedPassword` or `-DeleteNoPrincipalsAllowedToRetrieveManagedPassword`
+when an action should only include gMSAs that have no principals allowed to retrieve the managed password.

--- a/Private/Get-ADComputersToProcess.ps1
+++ b/Private/Get-ADComputersToProcess.ps1
@@ -60,6 +60,13 @@
                     $FullComputerName = "$($Computer.SamAccountName)@$($Computer.DomainName)"
                     $FoundComputer = $ProcessedComputers[$FullComputerName]
                     if ($FoundComputer) {
+                        $ProcessedActionSucceeded = $FoundComputer.ActionStatus -is [bool] -and $FoundComputer.ActionStatus
+                        if (-not $ProcessedActionSucceeded) {
+                            $ProcessedActionSucceeded = [string] $FoundComputer.ActionStatus -eq 'True'
+                        }
+                        if (-not $ProcessedActionSucceeded) {
+                            continue SkipComputer
+                        }
                         if ($FoundComputer.ActionDate -is [DateTime]) {
                             $TimeSpan = New-TimeSpan -Start $FoundComputer.ActionDate -End $Today
                             # Lets calculate how many days it's been on the list

--- a/Private/Get-ADServiceAccountsToProcess.ps1
+++ b/Private/Get-ADServiceAccountsToProcess.ps1
@@ -50,6 +50,21 @@ function Get-ADServiceAccountsToProcess {
                 $Include = $false
             }
         }
+        if ($ActionIf.NoPrincipalsAllowedToRetrieveManagedPassword) {
+            $ObjectClass = @($Account.ObjectClass)[-1]
+            if ($ObjectClass -ne 'msDS-GroupManagedServiceAccount') {
+                $Include = $false
+            } else {
+                if ($null -ne $Account.PSObject.Properties['PrincipalsAllowedToRetrieveManagedPasswordCount']) {
+                    $PrincipalCount = $Account.PrincipalsAllowedToRetrieveManagedPasswordCount
+                } else {
+                    $PrincipalCount = Get-ServiceAccountPrincipalCount -Account $Account
+                }
+                if ($null -eq $PrincipalCount -or $PrincipalCount -gt 0) {
+                    $Include = $false
+                }
+            }
+        }
         if ($Include) {
             $AccountData = [ordered] @{}
             foreach ($Property in $Account.PSObject.Properties) {

--- a/Private/Get-ADServiceAccountsToProcess.ps1
+++ b/Private/Get-ADServiceAccountsToProcess.ps1
@@ -30,18 +30,24 @@ function Get-ADServiceAccountsToProcess {
             if ($Account.LastLogonDate) {
                 $LastLogonDays = (New-TimeSpan -Start $Account.LastLogonDate -End $Today).Days
                 if ($LastLogonDays -le $ActionIf.LastLogonDateMoreThan) { $Include = $false }
+            } elseif (-not $ActionIf.TreatMissingLastLogonDateAsStale) {
+                $Include = $false
             }
         }
         if ($ActionIf.PasswordLastSetMoreThan) {
             if ($Account.PasswordLastSet) {
                 $PasswordDays = (New-TimeSpan -Start $Account.PasswordLastSet -End $Today).Days
                 if ($PasswordDays -le $ActionIf.PasswordLastSetMoreThan) { $Include = $false }
+            } elseif (-not $ActionIf.TreatMissingPasswordLastSetAsStale) {
+                $Include = $false
             }
         }
         if ($ActionIf.WhenCreatedMoreThan) {
             if ($Account.WhenCreated) {
                 $CreatedDays = (New-TimeSpan -Start $Account.WhenCreated -End $Today).Days
                 if ($CreatedDays -le $ActionIf.WhenCreatedMoreThan) { $Include = $false }
+            } elseif (-not $ActionIf.TreatMissingWhenCreatedAsStale) {
+                $Include = $false
             }
         }
         if ($Include) {

--- a/Private/Get-InitialADServiceAccounts.ps1
+++ b/Private/Get-InitialADServiceAccounts.ps1
@@ -1,3 +1,28 @@
+function Get-ServiceAccountPrincipalCount {
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory)][object] $Account
+    )
+
+    $Property = $Account.PSObject.Properties['PrincipalsAllowedToRetrieveManagedPassword']
+    if ($null -eq $Property) {
+        return $null
+    }
+    if ($null -eq $Property.Value) {
+        return 0
+    }
+    if ($Property.Value -is [string]) {
+        if ([string]::IsNullOrWhiteSpace($Property.Value)) {
+            return 0
+        }
+        return 1
+    }
+    if ($Property.Value -is [System.Collections.IEnumerable]) {
+        return @($Property.Value).Count
+    }
+    1
+}
+
 function Get-InitialADServiceAccounts {
     [CmdletBinding()]
     param(
@@ -9,8 +34,8 @@ function Get-InitialADServiceAccounts {
     foreach ($Domain in $ForestInformation.Domains) {
         $Server = $ForestInformation['QueryServers'][$Domain].HostName[0]
         Write-Color -Text "[i] ", "Getting service accounts for domain ", $Domain, " from ", $Server -Color Yellow, Magenta, Yellow, Magenta
-        $Accounts = Get-ADServiceAccount -Filter * -Server $Server -Properties SamAccountName,Enabled,LastLogonDate,PasswordLastSet,WhenCreated,DistinguishedName,ObjectClass |
-            Select-Object *, @{Name='DomainName';Expression={$Domain}}, @{Name='Server';Expression={$Server}}
+        $Accounts = Get-ADServiceAccount -Filter * -Server $Server -Properties SamAccountName,Enabled,LastLogonDate,PasswordLastSet,WhenCreated,DistinguishedName,ObjectClass,PrincipalsAllowedToRetrieveManagedPassword |
+            Select-Object *, @{Name='PrincipalsAllowedToRetrieveManagedPasswordCount';Expression={ Get-ServiceAccountPrincipalCount -Account $_ }}, @{Name='DomainName';Expression={$Domain}}, @{Name='Server';Expression={$Server}}
         if ($IncludeAccounts) {
             $IncludePattern = [string]::Join('|', ($IncludeAccounts | ForEach-Object { [regex]::Escape($_).Replace('\*','.*') }))
             $Accounts = $Accounts | Where-Object { $_.SamAccountName -match "^($IncludePattern)$" }

--- a/Private/Request-ADComputersDisable.ps1
+++ b/Private/Request-ADComputersDisable.ps1
@@ -88,13 +88,15 @@
                     $Computer.ActionStatus = $Success
                 }
 
-                # We add computer to pending list in all cases because otherwise we would be going in circles
-                # if move or delete were not enabled
-                # please use -DoNotAddToPendingList if you don't want to add computer to pending list
-                if (-not $DoNotAddToPendingList) {
+                # Only successful real disable actions should enter the pending list.
+                if ($Success -and -not $WhatIfDisable.IsPresent -and -not $DoNotAddToPendingList) {
                     $FullComputerName = -join ($Computer.SamAccountName, '@', $Domain)
                     # Lets add computer to pending list, and lets set time how long it's there so it can be easily visible in reports
-                    $Computer.TimeOnPendingList = 0
+                    if ($Computer.PSObject.Properties.Name -contains 'TimeOnPendingList') {
+                        $Computer.TimeOnPendingList = 0
+                    } else {
+                        Add-Member -InputObject $Computer -MemberType NoteProperty -Name 'TimeOnPendingList' -Value 0 -Force
+                    }
                     $ProcessedComputers[$FullComputerName] = $Computer
                 }
 

--- a/Private/Request-CloudDevicesDelete.ps1
+++ b/Private/Request-CloudDevicesDelete.ps1
@@ -20,10 +20,10 @@ function Request-CloudDevicesDelete {
     )
 
     $results = [System.Collections.Generic.List[object]]::new()
-    $processedCount = 0
+    $attemptedCount = 0
 
     foreach ($device in $Devices) {
-        if ($DeleteLimit -gt 0 -and $processedCount -ge $DeleteLimit) {
+        if ($DeleteLimit -gt 0 -and $attemptedCount -ge $DeleteLimit) {
             break
         }
 
@@ -79,12 +79,12 @@ function Request-CloudDevicesDelete {
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionNotes' -Value ($subActionMessages -join '; ') -Force
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ProcessedDeviceKeys' -Value $device.ProcessedDeviceKeys -Force
         $results.Add($result)
+        $attemptedCount++
 
         if (($subActionExecuted -and ($subActionSuccess -or $WhatIf -or $WhatIfDelete)) -or $ReportOnly) {
             if (-not ($WhatIf -or $WhatIfDelete -or $ReportOnly)) {
                 Remove-ProcessedCloudDeviceRecord -ProcessedDevices $ProcessedDevices -Device $device
             }
-            $processedCount++
         }
     }
 

--- a/Private/Request-CloudDevicesDisable.ps1
+++ b/Private/Request-CloudDevicesDisable.ps1
@@ -18,10 +18,10 @@ function Request-CloudDevicesDisable {
     )
 
     $results = [System.Collections.Generic.List[object]]::new()
-    $processedCount = 0
+    $attemptedCount = 0
 
     foreach ($device in $Devices) {
-        if ($DisableLimit -gt 0 -and $processedCount -ge $DisableLimit) {
+        if ($DisableLimit -gt 0 -and $attemptedCount -ge $DisableLimit) {
             break
         }
 
@@ -40,12 +40,10 @@ function Request-CloudDevicesDisable {
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'Action' -Value 'Disable' -Force
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ProcessedDeviceKeys' -Value $device.ProcessedDeviceKeys -Force
         $results.Add($result)
+        $attemptedCount++
 
         if ($actionSucceeded -and -not ($WhatIf -or $WhatIfDisable -or $ReportOnly)) {
             Set-ProcessedCloudDeviceRecord -ProcessedDevices $ProcessedDevices -Device $device -Result $result
-            $processedCount++
-        } elseif ($actionSucceeded -or $WhatIf -or $WhatIfDisable -or $ReportOnly) {
-            $processedCount++
         }
     }
 

--- a/Private/Request-CloudDevicesRetire.ps1
+++ b/Private/Request-CloudDevicesRetire.ps1
@@ -18,10 +18,10 @@ function Request-CloudDevicesRetire {
     )
 
     $results = [System.Collections.Generic.List[object]]::new()
-    $processedCount = 0
+    $attemptedCount = 0
 
     foreach ($device in $Devices) {
-        if ($RetireLimit -gt 0 -and $processedCount -ge $RetireLimit) {
+        if ($RetireLimit -gt 0 -and $attemptedCount -ge $RetireLimit) {
             break
         }
 
@@ -40,12 +40,10 @@ function Request-CloudDevicesRetire {
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'Action' -Value 'Retire' -Force
         Add-Member -InputObject $result -MemberType NoteProperty -Name 'ProcessedDeviceKeys' -Value $device.ProcessedDeviceKeys -Force
         $results.Add($result)
+        $attemptedCount++
 
         if ($actionSucceeded -and -not ($WhatIf -or $WhatIfRetire -or $ReportOnly)) {
             Set-ProcessedCloudDeviceRecord -ProcessedDevices $ProcessedDevices -Device $device -Result $result
-            $processedCount++
-        } elseif ($actionSucceeded -or $WhatIf -or $WhatIfRetire -or $ReportOnly) {
-            $processedCount++
         }
     }
 

--- a/Public/Invoke-ADSIDHistoryCleanup.ps1
+++ b/Public/Invoke-ADSIDHistoryCleanup.ps1
@@ -179,7 +179,7 @@
 
     $Export = [ordered] @{
         Date             = Get-Date
-        Version          = Get-GitHubVersion -Cmdlet 'Invoke-ADComputersCleanup' -RepositoryOwner 'evotecit' -RepositoryName 'CleanupMonster'
+        Version          = Get-GitHubVersion -Cmdlet 'Invoke-ADSIDHistoryCleanup' -RepositoryOwner 'evotecit' -RepositoryName 'CleanupMonster'
         ObjectsToProcess = $null
         CurrentRun       = $null
         History          = [System.Collections.Generic.List[PSCustomObject]]::new()
@@ -244,7 +244,7 @@
     # Get SID history information
     $Output = Get-WinADSIDHistory -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -All
 
-    if ($SafetyADLimit -and $Output.All.Count -le $SafetyADLimit) {
+    if ($SafetyADLimit -and $Output.All.Count -lt $SafetyADLimit) {
         Write-Color -Text "[i] ", "Number of objects returned with SIDHistory in AD is less than SafetyADLimit ", $SafetyADLimit, ". Stopping processing." -Color Yellow, White, Green, White
         return
     }

--- a/Public/Invoke-ADServiceAccountsCleanup.ps1
+++ b/Public/Invoke-ADServiceAccountsCleanup.ps1
@@ -39,6 +39,15 @@ function Invoke-ADServiceAccountsCleanup {
     .PARAMETER DisableWhenCreatedMoreThan
     Disable accounts created more than the specified number of days ago.
 
+    .PARAMETER DisableTreatMissingLastLogonDateAsStale
+    Treat accounts with missing LastLogonDate as matching DisableLastLogonDateMoreThan.
+
+    .PARAMETER DisableTreatMissingPasswordLastSetAsStale
+    Treat accounts with missing PasswordLastSet as matching DisablePasswordLastSetMoreThan.
+
+    .PARAMETER DisableTreatMissingWhenCreatedAsStale
+    Treat accounts with missing WhenCreated as matching DisableWhenCreatedMoreThan.
+
     .PARAMETER DeleteLastLogonDateMoreThan
     Delete accounts that have not logged on for the specified number of days.
 
@@ -47,6 +56,15 @@ function Invoke-ADServiceAccountsCleanup {
 
     .PARAMETER DeleteWhenCreatedMoreThan
     Delete accounts created more than the specified number of days ago.
+
+    .PARAMETER DeleteTreatMissingLastLogonDateAsStale
+    Treat accounts with missing LastLogonDate as matching DeleteLastLogonDateMoreThan.
+
+    .PARAMETER DeleteTreatMissingPasswordLastSetAsStale
+    Treat accounts with missing PasswordLastSet as matching DeletePasswordLastSetMoreThan.
+
+    .PARAMETER DeleteTreatMissingWhenCreatedAsStale
+    Treat accounts with missing WhenCreated as matching DeleteWhenCreatedMoreThan.
 
     .PARAMETER DisableLimit
     Limit the number of service accounts that will be disabled. 0 = unlimited. Default is 1.
@@ -126,10 +144,16 @@ function Invoke-ADServiceAccountsCleanup {
         [int] $DisableLastLogonDateMoreThan,
         [int] $DisablePasswordLastSetMoreThan,
         [int] $DisableWhenCreatedMoreThan,
+        [switch] $DisableTreatMissingLastLogonDateAsStale,
+        [switch] $DisableTreatMissingPasswordLastSetAsStale,
+        [switch] $DisableTreatMissingWhenCreatedAsStale,
         [int] $DisableLimit = 1,
         [int] $DeleteLastLogonDateMoreThan,
         [int] $DeletePasswordLastSetMoreThan,
         [int] $DeleteWhenCreatedMoreThan,
+        [switch] $DeleteTreatMissingLastLogonDateAsStale,
+        [switch] $DeleteTreatMissingPasswordLastSetAsStale,
+        [switch] $DeleteTreatMissingWhenCreatedAsStale,
         [int] $DeleteLimit = 1,
         [nullable[int]] $SafetyADLimit,
         [switch] $ReportOnly,
@@ -157,6 +181,15 @@ function Invoke-ADServiceAccountsCleanup {
 
     Write-Color -Text "[i] ", "Started process of cleaning up service accounts" -Color Yellow, White
     Write-Color -Text "[i] ", "Executed by: ", $Env:USERNAME, ' from domain ', $Env:USERDNSDOMAIN -Color Yellow, White, Green, White
+
+    if ($WhatIfPreference) {
+        if (-not $PSBoundParameters.ContainsKey('WhatIfDisable')) {
+            $WhatIfDisable = $true
+        }
+        if (-not $PSBoundParameters.ContainsKey('WhatIfDelete')) {
+            $WhatIfDelete = $true
+        }
+    }
 
     try {
         $ForestInformation = Get-WinADForestDetails -PreferWritable -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains
@@ -206,14 +239,28 @@ function Invoke-ADServiceAccountsCleanup {
     foreach ($Domain in $Report.Keys) {
         $Accounts = $Report[$Domain]['Accounts']
         if ($Disable) {
-            $DisableOnlyIf = @{ LastLogonDateMoreThan = $DisableLastLogonDateMoreThan; PasswordLastSetMoreThan = $DisablePasswordLastSetMoreThan; WhenCreatedMoreThan = $DisableWhenCreatedMoreThan }
+            $DisableOnlyIf = @{
+                LastLogonDateMoreThan             = $DisableLastLogonDateMoreThan
+                PasswordLastSetMoreThan           = $DisablePasswordLastSetMoreThan
+                WhenCreatedMoreThan               = $DisableWhenCreatedMoreThan
+                TreatMissingLastLogonDateAsStale  = $DisableTreatMissingLastLogonDateAsStale.IsPresent
+                TreatMissingPasswordLastSetAsStale = $DisableTreatMissingPasswordLastSetAsStale.IsPresent
+                TreatMissingWhenCreatedAsStale    = $DisableTreatMissingWhenCreatedAsStale.IsPresent
+            }
             $ToDisable = Get-ADServiceAccountsToProcess -Type 'Disable' -Accounts $Accounts -ActionIf $DisableOnlyIf -Exclusions $ExcludeAccounts
             $ScheduledForDisableByDomain[$Domain] = @($ToDisable | ForEach-Object { $_.DistinguishedName })
             $Report[$Domain]['AccountsToBeDisabled'] = $ToDisable.Count
             $Processed += Request-ADServiceAccountsDisable -Accounts $ToDisable -ReportOnly:$ReportOnly -WhatIfDisable:$WhatIfDisable -DisableLimit $DisableLimit -Today $Today -DontWriteToEventLog:$DontWriteToEventLog
         }
         if ($Delete) {
-            $DeleteOnlyIf = @{ LastLogonDateMoreThan = $DeleteLastLogonDateMoreThan; PasswordLastSetMoreThan = $DeletePasswordLastSetMoreThan; WhenCreatedMoreThan = $DeleteWhenCreatedMoreThan }
+            $DeleteOnlyIf = @{
+                LastLogonDateMoreThan             = $DeleteLastLogonDateMoreThan
+                PasswordLastSetMoreThan           = $DeletePasswordLastSetMoreThan
+                WhenCreatedMoreThan               = $DeleteWhenCreatedMoreThan
+                TreatMissingLastLogonDateAsStale  = $DeleteTreatMissingLastLogonDateAsStale.IsPresent
+                TreatMissingPasswordLastSetAsStale = $DeleteTreatMissingPasswordLastSetAsStale.IsPresent
+                TreatMissingWhenCreatedAsStale    = $DeleteTreatMissingWhenCreatedAsStale.IsPresent
+            }
             $ToDelete = Get-ADServiceAccountsToProcess -Type 'Delete' -Accounts $Accounts -ActionIf $DeleteOnlyIf -Exclusions $ExcludeAccounts
             if ($ScheduledForDisableByDomain[$Domain].Count -gt 0) {
                 $AccountsScheduledForDisable = $ScheduledForDisableByDomain[$Domain]

--- a/Public/Invoke-ADServiceAccountsCleanup.ps1
+++ b/Public/Invoke-ADServiceAccountsCleanup.ps1
@@ -48,6 +48,9 @@ function Invoke-ADServiceAccountsCleanup {
     .PARAMETER DisableTreatMissingWhenCreatedAsStale
     Treat accounts with missing WhenCreated as matching DisableWhenCreatedMoreThan.
 
+    .PARAMETER DisableNoPrincipalsAllowedToRetrieveManagedPassword
+    Disable only gMSA accounts with no principals allowed to retrieve the managed password.
+
     .PARAMETER DeleteLastLogonDateMoreThan
     Delete accounts that have not logged on for the specified number of days.
 
@@ -65,6 +68,9 @@ function Invoke-ADServiceAccountsCleanup {
 
     .PARAMETER DeleteTreatMissingWhenCreatedAsStale
     Treat accounts with missing WhenCreated as matching DeleteWhenCreatedMoreThan.
+
+    .PARAMETER DeleteNoPrincipalsAllowedToRetrieveManagedPassword
+    Delete only gMSA accounts with no principals allowed to retrieve the managed password.
 
     .PARAMETER DisableLimit
     Limit the number of service accounts that will be disabled. 0 = unlimited. Default is 1.
@@ -147,6 +153,7 @@ function Invoke-ADServiceAccountsCleanup {
         [switch] $DisableTreatMissingLastLogonDateAsStale,
         [switch] $DisableTreatMissingPasswordLastSetAsStale,
         [switch] $DisableTreatMissingWhenCreatedAsStale,
+        [switch] $DisableNoPrincipalsAllowedToRetrieveManagedPassword,
         [int] $DisableLimit = 1,
         [int] $DeleteLastLogonDateMoreThan,
         [int] $DeletePasswordLastSetMoreThan,
@@ -154,6 +161,7 @@ function Invoke-ADServiceAccountsCleanup {
         [switch] $DeleteTreatMissingLastLogonDateAsStale,
         [switch] $DeleteTreatMissingPasswordLastSetAsStale,
         [switch] $DeleteTreatMissingWhenCreatedAsStale,
+        [switch] $DeleteNoPrincipalsAllowedToRetrieveManagedPassword,
         [int] $DeleteLimit = 1,
         [nullable[int]] $SafetyADLimit,
         [switch] $ReportOnly,
@@ -206,10 +214,12 @@ function Invoke-ADServiceAccountsCleanup {
     $DisableHasSelectionCriteria = $DisableLastLogonDateMoreThan -gt 0 -or
         $DisablePasswordLastSetMoreThan -gt 0 -or
         $DisableWhenCreatedMoreThan -gt 0 -or
+        $DisableNoPrincipalsAllowedToRetrieveManagedPassword.IsPresent -or
         $IncludeAccounts.Count -gt 0
     $DeleteHasSelectionCriteria = $DeleteLastLogonDateMoreThan -gt 0 -or
         $DeletePasswordLastSetMoreThan -gt 0 -or
         $DeleteWhenCreatedMoreThan -gt 0 -or
+        $DeleteNoPrincipalsAllowedToRetrieveManagedPassword.IsPresent -or
         $IncludeAccounts.Count -gt 0
     $DisablePreviewOnly = $ReportOnly -or $WhatIfPreference -or $WhatIfDisable.IsPresent
     $DeletePreviewOnly = $ReportOnly -or $WhatIfPreference -or $WhatIfDelete.IsPresent
@@ -246,6 +256,7 @@ function Invoke-ADServiceAccountsCleanup {
                 TreatMissingLastLogonDateAsStale  = $DisableTreatMissingLastLogonDateAsStale.IsPresent
                 TreatMissingPasswordLastSetAsStale = $DisableTreatMissingPasswordLastSetAsStale.IsPresent
                 TreatMissingWhenCreatedAsStale    = $DisableTreatMissingWhenCreatedAsStale.IsPresent
+                NoPrincipalsAllowedToRetrieveManagedPassword = $DisableNoPrincipalsAllowedToRetrieveManagedPassword.IsPresent
             }
             $ToDisable = Get-ADServiceAccountsToProcess -Type 'Disable' -Accounts $Accounts -ActionIf $DisableOnlyIf -Exclusions $ExcludeAccounts
             $ScheduledForDisableByDomain[$Domain] = @($ToDisable | ForEach-Object { $_.DistinguishedName })
@@ -260,6 +271,7 @@ function Invoke-ADServiceAccountsCleanup {
                 TreatMissingLastLogonDateAsStale  = $DeleteTreatMissingLastLogonDateAsStale.IsPresent
                 TreatMissingPasswordLastSetAsStale = $DeleteTreatMissingPasswordLastSetAsStale.IsPresent
                 TreatMissingWhenCreatedAsStale    = $DeleteTreatMissingWhenCreatedAsStale.IsPresent
+                NoPrincipalsAllowedToRetrieveManagedPassword = $DeleteNoPrincipalsAllowedToRetrieveManagedPassword.IsPresent
             }
             $ToDelete = Get-ADServiceAccountsToProcess -Type 'Delete' -Accounts $Accounts -ActionIf $DeleteOnlyIf -Exclusions $ExcludeAccounts
             if ($ScheduledForDisableByDomain[$Domain].Count -gt 0) {

--- a/README.MD
+++ b/README.MD
@@ -317,6 +317,7 @@ What matters most:
 - `IncludeAccounts` counts as an explicit selector
 - preview scenarios with `-ReportOnly`, `-WhatIf`, `-WhatIfDisable`, or `-WhatIfDelete` are allowed even without destructive selectors
 - accounts scheduled for disable in a run are skipped from delete in that same run
+- missing `LastLogonDate`, `PasswordLastSet`, or `WhenCreated` values are not treated as stale unless you explicitly enable the matching `TreatMissing*AsStale` switch
 
 Good starter profiles:
 

--- a/README.MD
+++ b/README.MD
@@ -318,12 +318,13 @@ What matters most:
 - preview scenarios with `-ReportOnly`, `-WhatIf`, `-WhatIfDisable`, or `-WhatIfDelete` are allowed even without destructive selectors
 - accounts scheduled for disable in a run are skipped from delete in that same run
 - missing `LastLogonDate`, `PasswordLastSet`, or `WhenCreated` values are not treated as stale unless you explicitly enable the matching `TreatMissing*AsStale` switch
+- gMSA password retrieval principals are reported, and `-DisableNoPrincipalsAllowedToRetrieveManagedPassword` / `-DeleteNoPrincipalsAllowedToRetrieveManagedPassword` can require a gMSA to have no assigned retrieval principals before action
 
 Good starter profiles:
 
 - preview by name pattern: `-Disable -ReportOnly -WhatIf -IncludeAccounts 'gmsa-*'`
 - safer scheduled run: explicit include/exclude patterns plus low `DisableLimit` and `DeleteLimit`
-- age-based hygiene: combine `LastLogonDateMoreThan`, `PasswordLastSetMoreThan`, and `WhenCreatedMoreThan`
+- age-based hygiene: combine `LastLogonDateMoreThan`, `PasswordLastSetMoreThan`, `WhenCreatedMoreThan`, and optional gMSA assignment checks
 
 Relevant examples:
 

--- a/Tests/Invoke-ADSIDHistoryCleanup.Tests.ps1
+++ b/Tests/Invoke-ADSIDHistoryCleanup.Tests.ps1
@@ -24,4 +24,38 @@ Describe 'Invoke-ADSIDHistoryCleanup' {
         $result | Should -BeNullOrEmpty
         Assert-MockCalled Get-WinADSIDHistory -Times 0
     }
+
+    It 'does not stop when SID-history inventory equals SafetyADLimit' {
+        Mock Get-WinADSIDHistory {
+            [ordered] @{
+                All        = @([PSCustomObject] @{ Name = 'User1' })
+                DomainSIDs = @{}
+            }
+        }
+        Mock Request-ADSIDHistory {}
+
+        Invoke-ADSIDHistoryCleanup -ReportOnly -SafetyADLimit 1 -Suppress
+
+        Assert-MockCalled Request-ADSIDHistory -Times 1 -Exactly
+    }
+
+    It 'requests version metadata for the SIDHistory cleanup cmdlet' {
+        $script:capturedVersionCmdlet = $null
+        Mock Get-GitHubVersion {
+            param($Cmdlet, $RepositoryOwner, $RepositoryName)
+            $script:capturedVersionCmdlet = $Cmdlet
+            '0.0.0'
+        }
+        Mock Get-WinADSIDHistory {
+            [ordered] @{
+                All        = @()
+                DomainSIDs = @{}
+            }
+        }
+        Mock Request-ADSIDHistory {}
+
+        Invoke-ADSIDHistoryCleanup -ReportOnly -Suppress
+
+        $script:capturedVersionCmdlet | Should -Be 'Invoke-ADSIDHistoryCleanup'
+    }
 }

--- a/Tests/Invoke-ADServiceAccountsCleanup.Tests.ps1
+++ b/Tests/Invoke-ADServiceAccountsCleanup.Tests.ps1
@@ -27,6 +27,16 @@ Describe 'Invoke-ADServiceAccountsCleanup' {
         $res = Get-ADServiceAccountsToProcess -Type 'Disable' -Accounts @($acc1,$acc2) -ActionIf @{ LastLogonDateMoreThan = 30 }
         $res.SamAccountName | Should -Be @('gmsa1')
     }
+    It 'does not treat missing LastLogonDate as stale by default' {
+        $acc = [pscustomobject]@{ SamAccountName='gmsa-missing'; DistinguishedName='CN=gmsa-missing,DC=lab,DC=local'; LastLogonDate=$null; PasswordLastSet=(Get-Date).AddDays(-100); WhenCreated=(Get-Date).AddYears(-1) }
+        $res = Get-ADServiceAccountsToProcess -Type 'Disable' -Accounts @($acc) -ActionIf @{ LastLogonDateMoreThan = 30 }
+        $res | Should -BeNullOrEmpty
+    }
+    It 'can explicitly treat missing LastLogonDate as stale' {
+        $acc = [pscustomobject]@{ SamAccountName='gmsa-missing'; DistinguishedName='CN=gmsa-missing,DC=lab,DC=local'; LastLogonDate=$null; PasswordLastSet=(Get-Date).AddDays(-100); WhenCreated=(Get-Date).AddYears(-1) }
+        $res = Get-ADServiceAccountsToProcess -Type 'Disable' -Accounts @($acc) -ActionIf @{ LastLogonDateMoreThan = 30; TreatMissingLastLogonDateAsStale = $true }
+        $res.SamAccountName | Should -Be 'gmsa-missing'
+    }
     It 'supports WhatIf' {
         { Invoke-ADServiceAccountsCleanup -Disable -ReportOnly -WhatIfDisable } | Should -Not -Throw
     }
@@ -299,5 +309,26 @@ Describe 'Invoke-ADServiceAccountsCleanup' {
         $result | Should -BeNullOrEmpty
         Assert-MockCalled Get-ADServiceAccount -Times 0
         Assert-MockCalled Remove-ADObject -Times 0
+    }
+
+    It 'propagates top-level WhatIf to service-account disable reporting' {
+        Mock -CommandName Get-ADServiceAccount -MockWith {
+            @(
+                [pscustomobject]@{
+                    SamAccountName    = 'gmsa1'
+                    DistinguishedName = 'CN=gmsa1,DC=domain,DC=local'
+                    LastLogonDate     = (Get-Date).AddDays(-120)
+                    PasswordLastSet   = (Get-Date).AddDays(-120)
+                    WhenCreated       = (Get-Date).AddYears(-1)
+                }
+            )
+        }
+        Mock -CommandName Disable-ADAccount {}
+
+        $result = Invoke-ADServiceAccountsCleanup -Disable -DisableLastLogonDateMoreThan 30 -WhatIf
+
+        $result.CurrentRun | Should -HaveCount 1
+        $result.CurrentRun[0].ActionStatus | Should -Be 'WhatIf'
+        Assert-MockCalled Disable-ADAccount -Times 0
     }
 }

--- a/Tests/Invoke-ADServiceAccountsCleanup.Tests.ps1
+++ b/Tests/Invoke-ADServiceAccountsCleanup.Tests.ps1
@@ -58,6 +58,63 @@ Describe 'Invoke-ADServiceAccountsCleanup' {
         $report['lab.local'].Accounts.SamAccountName | Should -Be @('gmsa1')
     }
 
+    It 'requests and reports gMSA password retrieval principals' {
+        Mock -CommandName Get-ADServiceAccount -MockWith {
+            $script:RequestedServiceAccountProperties = $Properties
+            @(
+                [pscustomobject]@{
+                    SamAccountName = 'gmsa1'
+                    DistinguishedName = 'CN=gmsa1,DC=lab,DC=local'
+                    ObjectClass = 'msDS-GroupManagedServiceAccount'
+                    PrincipalsAllowedToRetrieveManagedPassword = @('CN=WEB01,DC=lab,DC=local', 'CN=WEB02,DC=lab,DC=local')
+                    LastLogonDate = $null
+                    PasswordLastSet = $null
+                    WhenCreated = $null
+                }
+            )
+        }
+        $forest = @{ Domains=@('lab.local'); QueryServers=@{ 'lab.local'=@{ HostName=@('dc1') } } }
+        $report = Get-InitialADServiceAccounts -ForestInformation $forest
+
+        $script:RequestedServiceAccountProperties | Should -Contain 'PrincipalsAllowedToRetrieveManagedPassword'
+        $report['lab.local'].Accounts[0].PrincipalsAllowedToRetrieveManagedPasswordCount | Should -Be 2
+    }
+
+    It 'can require a gMSA to have no password retrieval principals' {
+        $accounts = @(
+            [pscustomobject]@{
+                SamAccountName = 'gmsa-assigned'
+                DistinguishedName = 'CN=gmsa-assigned,DC=lab,DC=local'
+                ObjectClass = 'msDS-GroupManagedServiceAccount'
+                PrincipalsAllowedToRetrieveManagedPasswordCount = 1
+                LastLogonDate = (Get-Date).AddDays(-120)
+                PasswordLastSet = (Get-Date).AddDays(-120)
+                WhenCreated = (Get-Date).AddYears(-1)
+            },
+            [pscustomobject]@{
+                SamAccountName = 'gmsa-unassigned'
+                DistinguishedName = 'CN=gmsa-unassigned,DC=lab,DC=local'
+                ObjectClass = 'msDS-GroupManagedServiceAccount'
+                PrincipalsAllowedToRetrieveManagedPasswordCount = 0
+                LastLogonDate = (Get-Date).AddDays(-120)
+                PasswordLastSet = (Get-Date).AddDays(-120)
+                WhenCreated = (Get-Date).AddYears(-1)
+            },
+            [pscustomobject]@{
+                SamAccountName = 'msa1'
+                DistinguishedName = 'CN=msa1,DC=lab,DC=local'
+                ObjectClass = 'msDS-ManagedServiceAccount'
+                LastLogonDate = (Get-Date).AddDays(-120)
+                PasswordLastSet = (Get-Date).AddDays(-120)
+                WhenCreated = (Get-Date).AddYears(-1)
+            }
+        )
+
+        $res = Get-ADServiceAccountsToProcess -Type 'Disable' -Accounts $accounts -ActionIf @{ LastLogonDateMoreThan = 30; NoPrincipalsAllowedToRetrieveManagedPassword = $true }
+
+        $res.SamAccountName | Should -Be @('gmsa-unassigned')
+    }
+
     It 'does not delete accounts that are already scheduled for disable in the same run' {
         Mock -CommandName Get-ADServiceAccount -MockWith {
             @(

--- a/Tests/Move-Workflow.Tests.ps1
+++ b/Tests/Move-Workflow.Tests.ps1
@@ -44,6 +44,7 @@ Describe 'Move workflow helpers' {
             'PC1$@contoso.com' = [PSCustomObject] @{
                 SamAccountName      = 'PC1$'
                 DistinguishedName   = $computer.DistinguishedName
+                ActionStatus        = $true
                 ActionDate          = (Get-Date).AddDays(-5)
                 TimeToLeavePendingList = $null
             }

--- a/Tests/Request-ADComputersDisable.Tests.ps1
+++ b/Tests/Request-ADComputersDisable.Tests.ps1
@@ -1,0 +1,121 @@
+BeforeAll {
+    . "$PSScriptRoot\TestHelpers.ps1"
+    . (Get-CleanupMonsterPath 'Private/Get-ADComputersToProcess.ps1')
+    . (Get-CleanupMonsterPath 'Private/Request-ADComputersDisable.ps1')
+
+    function Write-Color { param([Parameter(ValueFromRemainingArguments = $true)] $Text, [object[]] $Color) }
+    function Disable-WinADComputer {}
+    function Move-WinADComputer {}
+}
+
+Describe 'Request-ADComputersDisable pending state' {
+    BeforeEach {
+        Mock Write-Color {}
+        Mock Move-WinADComputer {
+            param(
+                [bool] $Success
+            )
+
+            $Success
+        }
+    }
+
+    It 'does not add WhatIf disable results to the pending list' {
+        Mock Disable-WinADComputer { $true }
+
+        $processedComputers = [ordered] @{}
+        $computer = [PSCustomObject] @{
+            SamAccountName    = 'PC1$'
+            DistinguishedName = 'CN=PC1,DC=contoso,DC=com'
+            Action            = 'Disable'
+            ActionStatus      = $null
+            ActionDate        = $null
+        }
+        $report = [ordered] @{
+            'contoso.com' = [ordered] @{
+                Server    = 'dc1.contoso.com'
+                Computers = @($computer)
+            }
+        }
+
+        $result = @(Request-ADComputersDisable -Report $report -ProcessedComputers $processedComputers -DisableOnlyIf @{} -DisableLimit 1 -Today (Get-Date) -WhatIfDisable)
+
+        $result | Should -HaveCount 1
+        $result[0].ActionStatus | Should -Be 'WhatIf'
+        $processedComputers.Count | Should -Be 0
+    }
+
+    It 'does not add failed disable results to the pending list' {
+        Mock Disable-WinADComputer { $false }
+
+        $processedComputers = [ordered] @{}
+        $computer = [PSCustomObject] @{
+            SamAccountName    = 'PC2$'
+            DistinguishedName = 'CN=PC2,DC=contoso,DC=com'
+            Action            = 'Disable'
+            ActionStatus      = $null
+            ActionDate        = $null
+        }
+        $report = [ordered] @{
+            'contoso.com' = [ordered] @{
+                Server    = 'dc1.contoso.com'
+                Computers = @($computer)
+            }
+        }
+
+        $result = @(Request-ADComputersDisable -Report $report -ProcessedComputers $processedComputers -DisableOnlyIf @{} -DisableLimit 1 -Today (Get-Date))
+
+        $result | Should -HaveCount 1
+        $result[0].ActionStatus | Should -BeFalse
+        $processedComputers.Count | Should -Be 0
+    }
+
+    It 'adds successful real disable results to the pending list' {
+        Mock Disable-WinADComputer { $true }
+
+        $processedComputers = [ordered] @{}
+        $computer = [PSCustomObject] @{
+            SamAccountName    = 'PC3$'
+            DistinguishedName = 'CN=PC3,DC=contoso,DC=com'
+            Action            = 'Disable'
+            ActionStatus      = $null
+            ActionDate        = $null
+        }
+        $report = [ordered] @{
+            'contoso.com' = [ordered] @{
+                Server    = 'dc1.contoso.com'
+                Computers = @($computer)
+            }
+        }
+
+        Request-ADComputersDisable -Report $report -ProcessedComputers $processedComputers -DisableOnlyIf @{} -DisableLimit 1 -Today (Get-Date) | Out-Null
+
+        $processedComputers.Keys | Should -Contain 'PC3$@contoso.com'
+        $processedComputers['PC3$@contoso.com'].ActionStatus | Should -BeTrue
+    }
+
+    It 'does not promote pending records that were not successful real actions' {
+        $computer = [PSCustomObject] @{
+            SamAccountName       = 'PC4$'
+            DomainName           = 'contoso.com'
+            DistinguishedName    = 'CN=PC4,DC=contoso,DC=com'
+            DNSHostName          = 'pc4.contoso.com'
+            OperatingSystem      = 'Windows 11'
+            ServicePrincipalName = @()
+            Enabled              = $false
+            Action               = 'Not required'
+        }
+        $processedComputers = [ordered] @{
+            'PC4$@contoso.com' = [PSCustomObject] @{
+                SamAccountName = 'PC4$'
+                ActionStatus   = 'WhatIf'
+                ActionDate     = (Get-Date).AddDays(-45)
+            }
+        }
+
+        $count = Get-ADComputersToProcess -Type Delete -Computers @($computer) -ActionIf @{ ListProcessedMoreThan = 30 } -Exclusions @() -ProcessedComputers $processedComputers
+
+        $count | Should -Be 0
+        $computer.Action | Should -Be 'Not required'
+    }
+}

--- a/Tests/Request-CloudDeviceActions.Tests.ps1
+++ b/Tests/Request-CloudDeviceActions.Tests.ps1
@@ -52,6 +52,26 @@ Describe 'Request-CloudDevicesRetire' {
         $results[0].ActionStatus | Should -Be 'ReportOnly'
         $processedDevices.Count | Should -Be 0
     }
+
+    It 'counts failed retire attempts toward the retire limit' {
+        Mock Invoke-MyDeviceRetire { [PSCustomObject] @{ Success = $false; Message = 'Retire failed' } }
+
+        $processedDevices = [ordered] @{}
+        $devices = 1..3 | ForEach-Object {
+            [PSCustomObject] @{
+                Name                = "iPhone-Fail-$_"
+                ManagedDeviceId     = "managed-fail-$_"
+                ProcessedDeviceKey  = "intune:managed-fail-$_"
+                ProcessedDeviceKeys = @("intune:managed-fail-$_")
+            }
+        }
+
+        $results = @(Request-CloudDevicesRetire -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -RetireLimit 1)
+
+        $results | Should -HaveCount 1
+        $results[0].ActionStatus | Should -Be 'False'
+        Assert-MockCalled Invoke-MyDeviceRetire -Times 1 -Exactly
+    }
 }
 
 Describe 'Request-CloudDevicesDisable' {
@@ -93,6 +113,26 @@ Describe 'Request-CloudDevicesDisable' {
         $results.Count | Should -Be 1
         $results[0].ActionStatus | Should -Be 'ReportOnly'
         $processedDevices.Count | Should -Be 0
+    }
+
+    It 'counts failed disable attempts toward the disable limit' {
+        Mock Disable-MyDevice { [PSCustomObject] @{ Success = $false; Message = 'Disable failed' } }
+
+        $processedDevices = [ordered] @{}
+        $devices = 1..3 | ForEach-Object {
+            [PSCustomObject] @{
+                Name                = "iPhone-Fail-$_"
+                ManagedDeviceId     = "managed-fail-$_"
+                ProcessedDeviceKey  = "intune:managed-fail-$_"
+                ProcessedDeviceKeys = @("intune:managed-fail-$_")
+            }
+        }
+
+        $results = @(Request-CloudDevicesDisable -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -DisableLimit 1)
+
+        $results | Should -HaveCount 1
+        $results[0].ActionStatus | Should -Be 'False'
+        Assert-MockCalled Disable-MyDevice -Times 1 -Exactly
     }
 }
 
@@ -160,5 +200,29 @@ Describe 'Request-CloudDevicesDelete' {
         $results[0].ActionNotes | Should -Match 'Intune: Removed Intune record'
         Assert-MockCalled Remove-MyDevice -Times 0 -Exactly
         Assert-MockCalled Remove-MyDeviceIntuneRecord -Times 1 -Exactly
+    }
+
+    It 'counts failed delete attempts toward the delete limit' {
+        Mock Remove-MyDevice { [PSCustomObject] @{ Success = $false; Message = 'Delete failed' } }
+        Mock Remove-MyDeviceIntuneRecord {}
+
+        $processedDevices = [ordered] @{}
+        $devices = 1..3 | ForEach-Object {
+            [PSCustomObject] @{
+                Name                = "iPhone-Fail-$_"
+                EntraDeviceObjectId = "entra-fail-$_"
+                HasEntraRecord      = $true
+                HasIntuneRecord     = $false
+                RecordState         = 'EntraOnly'
+                ProcessedDeviceKey  = "entra:entra-fail-$_"
+                ProcessedDeviceKeys = @("entra:entra-fail-$_")
+            }
+        }
+
+        $results = @(Request-CloudDevicesDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -DeleteLimit 1)
+
+        $results | Should -HaveCount 1
+        $results[0].ActionStatus | Should -Be 'False'
+        Assert-MockCalled Remove-MyDevice -Times 1 -Exactly
     }
 }


### PR DESCRIPTION
## Summary
- require successful real AD computer disable actions before adding records to the pending cleanup list
- make cloud retire, disable, and delete limits cap attempted actions, including failures
- align service-account WhatIf reporting, make missing timestamp handling explicit, and fix SIDHistory safety/version metadata
- add regression tests for the cleanup safety guard behavior

## Validation
- ./CleanupMonster.Tests.ps1
- git diff --cached --check before commit
- git diff --check
