### PR TITLE
Add staged cloud device cleanup with Autopilot removal

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,9 @@
-﻿### 3.1.11 - 2026.05.18
+﻿### 3.1.12 - 2026.05.22
+
+- Added opt-in Autopilot identity removal during cloud-device delete cleanup through `-DeleteAutopilotIdentity`.
+- Bumped the required `GraphEssentials` version for cloud-device cleanup to `0.0.58` so Autopilot identity deletion is available.
+
+### 3.1.11 - 2026.05.18
 
 - Added advanced cloud-device cleanup filters for join type, OS version, Autopilot state/group tag, owner presence, management/MDM state, compliance state, enabled state, enrollment type, device registration state, and registration age.
 - Bumped the required `GraphEssentials` version for cloud-device cleanup to `0.0.57` so Autopilot-aware filtering can rely on enriched inventory.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,7 @@
 ﻿### 3.1.12 - 2026.05.22
 
 - Added opt-in Autopilot identity removal during cloud-device delete cleanup through `-DeleteAutopilotIdentity`.
+- Added `-StageDisabledForDelete` so already-disabled stale devices can enter the pending-action queue before deletion.
 - Bumped the required `GraphEssentials` version for cloud-device cleanup to `0.0.58` so Autopilot identity deletion is available.
 
 ### 3.1.11 - 2026.05.18

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,9 @@
-﻿### 3.1.4 - 2025.06.25
+﻿### 3.1.11 - 2026.05.18
+
+- Added advanced cloud-device cleanup filters for join type, OS version, Autopilot state/group tag, owner presence, management/MDM state, compliance state, enabled state, enrollment type, device registration state, and registration age.
+- Bumped the required `GraphEssentials` version for cloud-device cleanup to `0.0.57` so Autopilot-aware filtering can rely on enriched inventory.
+
+### 3.1.4 - 2025.06.25
 #### What's new
 - Downgrade requirement for PowerJamf
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,7 @@
 
 - Added opt-in Autopilot identity removal during cloud-device delete cleanup through `-DeleteAutopilotIdentity`.
 - Added `-StageDisabledForDelete` so already-disabled stale devices can enter the pending-action queue before deletion.
+- Added `-IncludeUnknownActivity` so blank Entra/Intune activity can explicitly match stale activity filters.
 - Bumped the required `GraphEssentials` version for cloud-device cleanup to `0.0.58` so Autopilot identity deletion is available.
 
 ### 3.1.11 - 2026.05.18

--- a/CleanupMonster.psd1
+++ b/CleanupMonster.psd1
@@ -8,7 +8,7 @@
     Description          = 'This module provides an easy way to cleanup Active Directory and cloud devices from dead/old objects based on various criteria. It can also disable, move, retire or delete objects. It can utilize Azure AD, Intune and Jamf to get additional information about objects before deleting them.'
     FunctionsToExport    = @('Invoke-ADComputersCleanup', 'Invoke-ADSIDHistoryCleanup', 'Invoke-ADServiceAccountsCleanup', 'Invoke-CloudDevicesCleanup')
     GUID                 = 'cd1f9987-6242-452c-a7db-6337d4a6b639'
-    ModuleVersion        = '3.1.11'
+    ModuleVersion        = '3.1.12'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/CleanupMonster.psd1
+++ b/CleanupMonster.psd1
@@ -8,7 +8,7 @@
     Description          = 'This module provides an easy way to cleanup Active Directory and cloud devices from dead/old objects based on various criteria. It can also disable, move, retire or delete objects. It can utilize Azure AD, Intune and Jamf to get additional information about objects before deleting them.'
     FunctionsToExport    = @('Invoke-ADComputersCleanup', 'Invoke-ADSIDHistoryCleanup', 'Invoke-ADServiceAccountsCleanup', 'Invoke-CloudDevicesCleanup')
     GUID                 = 'cd1f9987-6242-452c-a7db-6337d4a6b639'
-    ModuleVersion        = '3.1.10'
+    ModuleVersion        = '3.1.11'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Docs/Invoke-CloudDevicesCleanup.md
+++ b/Docs/Invoke-CloudDevicesCleanup.md
@@ -35,6 +35,7 @@ Orphan records are still discovered by default, but actioning them is intentiona
 Destructive cloud cleanup treats missing Graph data as unsafe:
 
 - blank activity timestamps are excluded from destructive action selection
+- add `-IncludeUnknownActivity` only when blank activity should be treated like "never synced/seen"
 - only `AzureAD registered` records are included by default; add `-IncludeJoinType 'AzureAD joined'` explicitly for Windows cloud-joined cleanup
 - pending devices are not promoted if current inventory loses activity that existed when staged
 - Entra-backed disable requires `Enabled -eq $true`
@@ -88,6 +89,8 @@ Invoke-CloudDevicesCleanup `
     -StageDisabledForDeleteLimit 25 `
     -IncludeJoinType 'AzureAD joined','AzureAD registered' `
     -IncludeOperatingSystem '*' `
+    -IncludeUnknownOperatingSystem `
+    -IncludeUnknownActivity `
     -DeleteLastSeenEntraMoreThan 90 `
     -DeleteAutopilotIdentity `
     -WhatIfStageDelete `
@@ -140,5 +143,6 @@ Preview disabling Windows 10 22H2 cloud-joined devices that are inactive, ownerl
 - Inventory includes `Matched`, `EntraOnly`, and `IntuneOnly` record states.
 - Default behavior excludes company-owned devices unless explicitly included.
 - Stage already-disabled devices with `-StageDisabledForDelete` when they were disabled outside CleanupMonster but should still wait before deletion.
+- Use `-IncludeUnknownActivity` to intentionally treat blank Entra/Intune activity as stale, matching "never synced/seen" hybrid cleanup semantics.
 - Autopilot identity removal is opt-in via `-DeleteAutopilotIdentity`; use `-WhatIfDelete` to preview the full delete stage.
 - Use `-Confirm` when running interactively and keep `RetireLimit`, `DisableLimit`, and `DeleteLimit` low during rollout.

--- a/Docs/Invoke-CloudDevicesCleanup.md
+++ b/Docs/Invoke-CloudDevicesCleanup.md
@@ -8,11 +8,11 @@ schema: 2.0.0
 # Invoke-CloudDevicesCleanup
 
 ## SYNOPSIS
-Stages cleanup for stale Microsoft Entra registered mobile devices from Microsoft Entra ID and Intune.
+Stages cleanup for stale Microsoft Entra and Intune cloud devices from Microsoft Entra ID and Intune.
 
 ## DESCRIPTION
 `Invoke-CloudDevicesCleanup` is the cloud-side companion to AD computer cleanup.
-It targets Microsoft Entra registered mobile devices, builds a combined Entra and Intune inventory,
+It targets Microsoft Entra registered mobile devices by default, builds a combined Entra and Intune inventory,
 classifies records as matched or orphaned, and supports staged actions:
 
 - `Retire` for Intune-managed devices
@@ -33,11 +33,12 @@ Orphan records are still discovered by default, but actioning them is intentiona
 Destructive cloud cleanup treats missing Graph data as unsafe:
 
 - blank activity timestamps are excluded from destructive action selection
-- hybrid Azure AD joined, Azure AD joined, synchronized, non-registered, and unknown registration states are excluded; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
+- only `AzureAD registered` records are included by default; add `-IncludeJoinType 'AzureAD joined'` explicitly for Windows cloud-joined cleanup
 - pending devices are not promoted if current inventory loses activity that existed when staged
 - Entra-backed disable requires `Enabled -eq $true`
 - Entra-backed delete requires `Enabled -eq $false`
 - unknown Entra enabled state is excluded from disable/delete
+- `-AutopilotState NotOnboarded` only matches when Autopilot inventory was loaded successfully
 
 ## EXAMPLES
 
@@ -76,9 +77,46 @@ Invoke-CloudDevicesCleanup `
 
 Preview all stages, stop on suspiciously low Graph inventory, and generate an HTML report.
 
+### Example 4
+```powershell
+Invoke-CloudDevicesCleanup `
+    -Delete `
+    -WhatIfDelete `
+    -IncludeJoinType 'AzureAD joined' `
+    -IncludeOperatingSystem 'Windows*' `
+    -DeleteLastSeenEntraMoreThan 180 `
+    -DeleteRegisteredMoreThan 365 `
+    -AutopilotState Onboarded `
+    -OwnerState WithoutOwner `
+    -ManagementState Mdm `
+    -ComplianceState NonCompliant `
+    -EnabledState Disabled `
+    -SafetyEntraLimit 1000 `
+    -SafetyIntuneLimit 1000 `
+    -ShowHTML
+```
+
+Preview deletion of disabled, old, inactive Windows cloud-joined devices that are Autopilot onboarded, MDM-managed, noncompliant, and have no owner.
+
+### Example 5
+```powershell
+Invoke-CloudDevicesCleanup `
+    -Disable `
+    -WhatIfDisable `
+    -IncludeJoinType 'AzureAD joined' `
+    -IncludeOperatingSystem 'Windows*' `
+    -IncludeOperatingSystemVersion '10.0.19045*' `
+    -AutopilotState NotOnboarded `
+    -OwnerState WithoutOwner `
+    -DisableLastSeenEntraMoreThan 180 `
+    -ShowHTML
+```
+
+Preview disabling Windows 10 22H2 cloud-joined devices that are inactive, ownerless, and confirmed not present in Autopilot inventory.
+
 ## NOTES
 
-- Designed primarily for `iOS` and `Android` Microsoft Entra registered devices.
+- Designed primarily for `iOS` and `Android` Microsoft Entra registered devices, with explicit opt-in filters for Windows and AzureAD joined devices.
 - Inventory includes `Matched`, `EntraOnly`, and `IntuneOnly` record states.
 - Default behavior excludes company-owned devices unless explicitly included.
 - Use `-Confirm` when running interactively and keep `RetireLimit`, `DisableLimit`, and `DeleteLimit` low during rollout.

--- a/Docs/Invoke-CloudDevicesCleanup.md
+++ b/Docs/Invoke-CloudDevicesCleanup.md
@@ -39,6 +39,7 @@ Destructive cloud cleanup treats missing Graph data as unsafe:
 - Entra-backed delete requires `Enabled -eq $false`
 - unknown Entra enabled state is excluded from disable/delete
 - `-AutopilotState NotOnboarded` only matches when Autopilot inventory was loaded successfully
+- `-DeleteAutopilotIdentity` requires Autopilot inventory and removes the Autopilot identity before Intune/Entra records
 
 ## EXAMPLES
 
@@ -86,6 +87,7 @@ Invoke-CloudDevicesCleanup `
     -IncludeOperatingSystem 'Windows*' `
     -DeleteLastSeenEntraMoreThan 180 `
     -DeleteRegisteredMoreThan 365 `
+    -DeleteAutopilotIdentity `
     -AutopilotState Onboarded `
     -OwnerState WithoutOwner `
     -ManagementState Mdm `
@@ -96,7 +98,7 @@ Invoke-CloudDevicesCleanup `
     -ShowHTML
 ```
 
-Preview deletion of disabled, old, inactive Windows cloud-joined devices that are Autopilot onboarded, MDM-managed, noncompliant, and have no owner.
+Preview deletion of disabled, old, inactive Windows cloud-joined devices that are Autopilot onboarded, MDM-managed, noncompliant, and have no owner, including the Autopilot identity delete sub-action.
 
 ### Example 5
 ```powershell
@@ -119,4 +121,5 @@ Preview disabling Windows 10 22H2 cloud-joined devices that are inactive, ownerl
 - Designed primarily for `iOS` and `Android` Microsoft Entra registered devices, with explicit opt-in filters for Windows and AzureAD joined devices.
 - Inventory includes `Matched`, `EntraOnly`, and `IntuneOnly` record states.
 - Default behavior excludes company-owned devices unless explicitly included.
+- Autopilot identity removal is opt-in via `-DeleteAutopilotIdentity`; use `-WhatIfDelete` to preview the full delete stage.
 - Use `-Confirm` when running interactively and keep `RetireLimit`, `DisableLimit`, and `DeleteLimit` low during rollout.

--- a/Docs/Invoke-CloudDevicesCleanup.md
+++ b/Docs/Invoke-CloudDevicesCleanup.md
@@ -22,6 +22,8 @@ classifies records as matched or orphaned, and supports staged actions:
 The workflow keeps its own pending datastore so actions can be separated across multiple runs.
 Real successful retire and disable actions are stored in `PendingActions`; `-ReportOnly`,
 top-level `-WhatIf`, and action-specific preview switches do not mutate pending cleanup state.
+Use `-StageDisabledForDelete` to add already-disabled stale devices to the same pending queue
+without deleting them immediately.
 
 Orphan records are still discovered by default, but actioning them is intentionally explicit:
 
@@ -40,6 +42,7 @@ Destructive cloud cleanup treats missing Graph data as unsafe:
 - unknown Entra enabled state is excluded from disable/delete
 - `-AutopilotState NotOnboarded` only matches when Autopilot inventory was loaded successfully
 - `-DeleteAutopilotIdentity` requires Autopilot inventory and removes the Autopilot identity before Intune/Entra records
+- `-StageDisabledForDelete` lets already-disabled devices wait the normal delete grace period instead of bypassing pending state
 
 ## EXAMPLES
 
@@ -81,6 +84,21 @@ Preview all stages, stop on suspiciously low Graph inventory, and generate an HT
 ### Example 4
 ```powershell
 Invoke-CloudDevicesCleanup `
+    -StageDisabledForDelete `
+    -StageDisabledForDeleteLimit 25 `
+    -IncludeJoinType 'AzureAD joined','AzureAD registered' `
+    -IncludeOperatingSystem '*' `
+    -DeleteLastSeenEntraMoreThan 90 `
+    -DeleteAutopilotIdentity `
+    -WhatIfStageDelete `
+    -ShowHTML
+```
+
+Preview staging already-disabled stale devices into `PendingActions` so daily automation can delete them after the configured grace period.
+
+### Example 5
+```powershell
+Invoke-CloudDevicesCleanup `
     -Delete `
     -WhatIfDelete `
     -IncludeJoinType 'AzureAD joined' `
@@ -100,7 +118,7 @@ Invoke-CloudDevicesCleanup `
 
 Preview deletion of disabled, old, inactive Windows cloud-joined devices that are Autopilot onboarded, MDM-managed, noncompliant, and have no owner, including the Autopilot identity delete sub-action.
 
-### Example 5
+### Example 6
 ```powershell
 Invoke-CloudDevicesCleanup `
     -Disable `
@@ -121,5 +139,6 @@ Preview disabling Windows 10 22H2 cloud-joined devices that are inactive, ownerl
 - Designed primarily for `iOS` and `Android` Microsoft Entra registered devices, with explicit opt-in filters for Windows and AzureAD joined devices.
 - Inventory includes `Matched`, `EntraOnly`, and `IntuneOnly` record states.
 - Default behavior excludes company-owned devices unless explicitly included.
+- Stage already-disabled devices with `-StageDisabledForDelete` when they were disabled outside CleanupMonster but should still wait before deletion.
 - Autopilot identity removal is opt-in via `-DeleteAutopilotIdentity`; use `-WhatIfDelete` to preview the full delete stage.
 - Use `-Confirm` when running interactively and keep `RetireLimit`, `DisableLimit`, and `DeleteLimit` low during rollout.

--- a/Private/Assert-CloudDeviceCleanupSettings.ps1
+++ b/Private/Assert-CloudDeviceCleanupSettings.ps1
@@ -8,7 +8,7 @@ function Assert-CloudDeviceCleanupSettings {
         return $false
     }
 
-    $minimumVersion = [version] '0.0.57'
+    $minimumVersion = [version] '0.0.58'
     if ($moduleAvailable.Version -lt $minimumVersion) {
         Write-Color -Text '[e] ', "'GraphEssentials' module is outdated for cloud-device cleanup. Please update to minimum version '$minimumVersion'. Terminating." -Color Yellow, Red
         return $false
@@ -19,6 +19,7 @@ function Assert-CloudDeviceCleanupSettings {
         'Get-MyDeviceIntune'
         'Invoke-MyDeviceRetire'
         'Disable-MyDevice'
+        'Remove-MyAutopilotDevice'
         'Remove-MyDevice'
         'Remove-MyDeviceIntuneRecord'
     )

--- a/Private/Assert-CloudDeviceCleanupSettings.ps1
+++ b/Private/Assert-CloudDeviceCleanupSettings.ps1
@@ -8,7 +8,7 @@ function Assert-CloudDeviceCleanupSettings {
         return $false
     }
 
-    $minimumVersion = [version] '0.0.56'
+    $minimumVersion = [version] '0.0.57'
     if ($moduleAvailable.Version -lt $minimumVersion) {
         Write-Color -Text '[e] ', "'GraphEssentials' module is outdated for cloud-device cleanup. Please update to minimum version '$minimumVersion'. Terminating." -Color Yellow, Red
         return $false

--- a/Private/Get-CloudDeviceJoinTypeFromRegistrationState.ps1
+++ b/Private/Get-CloudDeviceJoinTypeFromRegistrationState.ps1
@@ -7,7 +7,7 @@ function Get-CloudDeviceJoinTypeFromRegistrationState {
     )
 
     if ([string]::IsNullOrWhiteSpace($DeviceRegistrationState)) {
-        return $null
+        return 'Not available'
     }
 
     switch ($DeviceRegistrationState.ToLowerInvariant()) {

--- a/Private/Get-CloudDeviceJoinTypeFromRegistrationState.ps1
+++ b/Private/Get-CloudDeviceJoinTypeFromRegistrationState.ps1
@@ -1,0 +1,18 @@
+function Get-CloudDeviceJoinTypeFromRegistrationState {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string] $DeviceRegistrationState
+    )
+
+    if ([string]::IsNullOrWhiteSpace($DeviceRegistrationState)) {
+        return $null
+    }
+
+    switch ($DeviceRegistrationState.ToLowerInvariant()) {
+        'registered' { 'AzureAD registered'; break }
+        'joined' { 'AzureAD joined'; break }
+        default { 'Not available' }
+    }
+}

--- a/Private/Get-CloudDevicePropertyValue.ps1
+++ b/Private/Get-CloudDevicePropertyValue.ps1
@@ -1,0 +1,23 @@
+function Get-CloudDevicePropertyValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [object] $InputObject,
+
+        [Parameter(Mandatory)]
+        [string[]] $Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    foreach ($propertyName in $Name) {
+        if ($InputObject.PSObject.Properties[$propertyName]) {
+            return $InputObject.$propertyName
+        }
+    }
+
+    $null
+}

--- a/Private/Get-CloudDeviceSelectionReason.ps1
+++ b/Private/Get-CloudDeviceSelectionReason.ps1
@@ -20,10 +20,14 @@ function Get-CloudDeviceSelectionReason {
 
     if ($null -ne $ActionIf.LastSeenEntraMoreThan -and $null -ne $Device.EntraLastSeenDays) {
         $reasons.Add("EntraLastSeenDays=$($Device.EntraLastSeenDays) > $($ActionIf.LastSeenEntraMoreThan)")
+    } elseif ($null -ne $ActionIf.LastSeenEntraMoreThan -and $ActionIf.IncludeUnknownActivity -and $null -eq $Device.EntraLastSeenDays) {
+        $reasons.Add("EntraLastSeenDays=Unknown allowed")
     }
 
     if ($null -ne $ActionIf.LastSeenIntuneMoreThan -and $null -ne $Device.IntuneLastSeenDays) {
         $reasons.Add("IntuneLastSeenDays=$($Device.IntuneLastSeenDays) > $($ActionIf.LastSeenIntuneMoreThan)")
+    } elseif ($null -ne $ActionIf.LastSeenIntuneMoreThan -and $ActionIf.IncludeUnknownActivity -and $null -eq $Device.IntuneLastSeenDays) {
+        $reasons.Add("IntuneLastSeenDays=Unknown allowed")
     }
 
     if ($null -ne $ActionIf.RegisteredMoreThan -and $null -ne $Device.RegisteredDays) {

--- a/Private/Get-CloudDeviceSelectionReason.ps1
+++ b/Private/Get-CloudDeviceSelectionReason.ps1
@@ -26,6 +26,36 @@ function Get-CloudDeviceSelectionReason {
         $reasons.Add("IntuneLastSeenDays=$($Device.IntuneLastSeenDays) > $($ActionIf.LastSeenIntuneMoreThan)")
     }
 
+    if ($null -ne $ActionIf.RegisteredMoreThan -and $null -ne $Device.RegisteredDays) {
+        $reasons.Add("RegisteredDays=$($Device.RegisteredDays) > $($ActionIf.RegisteredMoreThan)")
+    }
+
+    if ($ActionIf.EnabledState -and $ActionIf.EnabledState -ne 'Any') {
+        $reasons.Add("EnabledState=$($ActionIf.EnabledState)")
+    }
+
+    if ($ActionIf.AutopilotState -and $ActionIf.AutopilotState -ne 'Any') {
+        $reasons.Add("AutopilotState=$($ActionIf.AutopilotState)")
+    }
+
+    if ($ActionIf.OwnerState -and $ActionIf.OwnerState -ne 'Any') {
+        $reasons.Add("OwnerState=$($ActionIf.OwnerState)")
+    }
+
+    if ($ActionIf.ManagementState -and $ActionIf.ManagementState -ne 'Any') {
+        $reasons.Add("ManagementState=$($ActionIf.ManagementState)")
+    }
+
+    if ($ActionIf.ComplianceState -and $ActionIf.ComplianceState -ne 'Any') {
+        $reasons.Add("ComplianceState=$($ActionIf.ComplianceState)")
+    }
+
+    foreach ($key in @('IncludeManagementAgent', 'ExcludeManagementAgent', 'IncludeEnrollmentType', 'ExcludeEnrollmentType', 'IncludeDeviceRegistrationState', 'ExcludeDeviceRegistrationState', 'IncludeAutopilotGroupTag', 'ExcludeAutopilotGroupTag')) {
+        if ($ActionIf.Contains($key) -and $ActionIf[$key] -and $ActionIf[$key].Count -gt 0) {
+            $reasons.Add("$key=$($ActionIf[$key] -join ',')")
+        }
+    }
+
     if ($null -ne $ActionIf.ListProcessedMoreThan -and $ProcessedDevice -and $ProcessedDevice.ActionDate) {
         $pendingDays = (New-TimeSpan -Start $ProcessedDevice.ActionDate -End (Get-Date)).Days
         $reasons.Add("PendingDays=$pendingDays >= $($ActionIf.ListProcessedMoreThan)")

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -229,6 +229,9 @@ function Get-CloudDevicesToProcess {
         }
 
         if ($ActionIf.OwnerState -and $ActionIf.OwnerState -ne 'Any') {
+            if ($device.OperatingSystem -like 'Windows*' -and $device.AutopilotInventoryLoaded -eq $false) {
+                continue
+            }
             $hasOwner = Test-CloudDeviceOwnerPresence -Device $device
             if ($ActionIf.OwnerState -eq 'WithOwner' -and -not $hasOwner) {
                 continue
@@ -270,6 +273,11 @@ function Get-CloudDevicesToProcess {
         }
 
         if (-not (Test-CloudDeviceValuePattern -Value $device.DeviceRegistrationState -Include $ActionIf.IncludeDeviceRegistrationState -Exclude $ActionIf.ExcludeDeviceRegistrationState)) {
+            continue
+        }
+
+        $hasAutopilotGroupTagFilter = ($ActionIf.IncludeAutopilotGroupTag -and $ActionIf.IncludeAutopilotGroupTag.Count -gt 0) -or ($ActionIf.ExcludeAutopilotGroupTag -and $ActionIf.ExcludeAutopilotGroupTag.Count -gt 0)
+        if ($hasAutopilotGroupTagFilter -and -not $device.AutopilotInventoryLoaded) {
             continue
         }
 

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -195,13 +195,21 @@ function Get-CloudDevicesToProcess {
         }
 
         if ($null -ne $ActionIf.LastSeenEntraMoreThan) {
-            if ($null -eq $device.EntraLastSeenDays -or $device.EntraLastSeenDays -le $ActionIf.LastSeenEntraMoreThan) {
+            if ($null -eq $device.EntraLastSeenDays) {
+                if (-not $ActionIf.IncludeUnknownActivity) {
+                    continue
+                }
+            } elseif ($device.EntraLastSeenDays -le $ActionIf.LastSeenEntraMoreThan) {
                 continue
             }
         }
 
         if ($null -ne $ActionIf.LastSeenIntuneMoreThan) {
-            if ($null -eq $device.IntuneLastSeenDays -or $device.IntuneLastSeenDays -le $ActionIf.LastSeenIntuneMoreThan) {
+            if ($null -eq $device.IntuneLastSeenDays) {
+                if (-not $ActionIf.IncludeUnknownActivity) {
+                    continue
+                }
+            } elseif ($device.IntuneLastSeenDays -le $ActionIf.LastSeenIntuneMoreThan) {
                 continue
             }
         }

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -15,6 +15,98 @@ function Get-CloudDevicesToProcess {
         [System.Collections.IDictionary] $ProcessedDevices
     )
 
+    function Test-CloudDeviceValuePattern {
+        param(
+            [AllowNull()]
+            [object[]] $Value,
+            [AllowEmptyCollection()]
+            [Array] $Include,
+            [AllowEmptyCollection()]
+            [Array] $Exclude
+        )
+
+        $values = @($Value | Where-Object { -not [string]::IsNullOrWhiteSpace([string] $_) })
+        if ($Include -and $Include.Count -gt 0) {
+            $matched = $false
+            foreach ($includePattern in $Include) {
+                foreach ($deviceValue in $values) {
+                    if ([string] $deviceValue -like $includePattern) {
+                        $matched = $true
+                        break
+                    }
+                }
+                if ($matched) { break }
+            }
+            if (-not $matched) {
+                return $false
+            }
+        }
+
+        if ($Exclude -and $Exclude.Count -gt 0) {
+            foreach ($excludePattern in $Exclude) {
+                foreach ($deviceValue in $values) {
+                    if ([string] $deviceValue -like $excludePattern) {
+                        return $false
+                    }
+                }
+            }
+        }
+
+        $true
+    }
+
+    function Test-CloudDeviceOwnerPresence {
+        param([Parameter(Mandatory)] [object] $Device)
+
+        $ownerValues = @(
+            $Device.OwnerDisplayName
+            $Device.OwnerUserPrincipalName
+            $Device.IntuneUserDisplayName
+            $Device.IntuneUserPrincipalName
+            $Device.IntuneEmailAddress
+            $Device.AutopilotUserPrincipalName
+        ) | Where-Object { -not [string]::IsNullOrWhiteSpace([string] $_) }
+
+        $ownerValues.Count -gt 0
+    }
+
+    function Test-CloudDeviceManagedState {
+        param([Parameter(Mandatory)] [object] $Device)
+
+        if ($Device.IsManaged -eq $true) {
+            return $true
+        }
+
+        $managementValues = @($Device.ManagementType, $Device.ManagementAgent) | Where-Object { -not [string]::IsNullOrWhiteSpace([string] $_) -and [string] $_ -ne 'none' -and [string] $_ -ne 'unknown' }
+        $managementValues.Count -gt 0
+    }
+
+    function Test-CloudDeviceMdmState {
+        param([Parameter(Mandatory)] [object] $Device)
+
+        $managementValues = @($Device.ManagementType, $Device.ManagementAgent) | Where-Object { -not [string]::IsNullOrWhiteSpace([string] $_) }
+        foreach ($managementValue in $managementValues) {
+            if ([string] $managementValue -like '*mdm*' -or [string] $managementValue -like '*intune*') {
+                return $true
+            }
+        }
+
+        $false
+    }
+
+    function Get-CloudDeviceComplianceState {
+        param([Parameter(Mandatory)] [object] $Device)
+
+        if ($Device.IsCompliant -eq $true -or [string] $Device.ComplianceState -eq 'compliant') {
+            return 'Compliant'
+        }
+        if ($Device.IsCompliant -eq $false -or [string] $Device.ComplianceState -in @('noncompliant', 'inGracePeriod', 'configManager')) {
+            return 'NonCompliant'
+        }
+
+        'Unknown'
+    }
+
     Write-Color -Text '[i] ', "Applying following rules to $Type action:" -Color Yellow, Cyan, Green
     foreach ($key in $ActionIf.Keys) {
         if ($null -eq $ActionIf[$key] -or ($ActionIf[$key] -is [System.Array] -and $ActionIf[$key].Count -eq 0)) {
@@ -104,6 +196,85 @@ function Get-CloudDevicesToProcess {
             if ($null -eq $device.IntuneLastSeenDays -or $device.IntuneLastSeenDays -le $ActionIf.LastSeenIntuneMoreThan) {
                 continue
             }
+        }
+
+        if ($null -ne $ActionIf.RegisteredMoreThan) {
+            if ($null -eq $device.RegisteredDays -or $device.RegisteredDays -le $ActionIf.RegisteredMoreThan) {
+                continue
+            }
+        }
+
+        if ($ActionIf.EnabledState -and $ActionIf.EnabledState -ne 'Any') {
+            if ($ActionIf.EnabledState -eq 'Enabled' -and $device.Enabled -ne $true) {
+                continue
+            }
+            if ($ActionIf.EnabledState -eq 'Disabled' -and $device.Enabled -ne $false) {
+                continue
+            }
+            if ($ActionIf.EnabledState -eq 'Unknown' -and $null -ne $device.Enabled) {
+                continue
+            }
+        }
+
+        if ($ActionIf.AutopilotState -and $ActionIf.AutopilotState -ne 'Any') {
+            if (-not $device.AutopilotInventoryLoaded) {
+                continue
+            }
+            if ($ActionIf.AutopilotState -eq 'Onboarded' -and $device.AutopilotOnboarded -ne $true) {
+                continue
+            }
+            if ($ActionIf.AutopilotState -eq 'NotOnboarded' -and $device.AutopilotOnboarded -ne $false) {
+                continue
+            }
+        }
+
+        if ($ActionIf.OwnerState -and $ActionIf.OwnerState -ne 'Any') {
+            $hasOwner = Test-CloudDeviceOwnerPresence -Device $device
+            if ($ActionIf.OwnerState -eq 'WithOwner' -and -not $hasOwner) {
+                continue
+            }
+            if ($ActionIf.OwnerState -eq 'WithoutOwner' -and $hasOwner) {
+                continue
+            }
+        }
+
+        if ($ActionIf.ManagementState -and $ActionIf.ManagementState -ne 'Any') {
+            $isManaged = Test-CloudDeviceManagedState -Device $device
+            $isMdm = Test-CloudDeviceMdmState -Device $device
+            if ($ActionIf.ManagementState -eq 'Managed' -and -not $isManaged) {
+                continue
+            }
+            if ($ActionIf.ManagementState -eq 'Unmanaged' -and $isManaged) {
+                continue
+            }
+            if ($ActionIf.ManagementState -eq 'Mdm' -and -not $isMdm) {
+                continue
+            }
+            if ($ActionIf.ManagementState -eq 'NotMdm' -and $isMdm) {
+                continue
+            }
+        }
+
+        if ($ActionIf.ComplianceState -and $ActionIf.ComplianceState -ne 'Any') {
+            if ((Get-CloudDeviceComplianceState -Device $device) -ne $ActionIf.ComplianceState) {
+                continue
+            }
+        }
+
+        if (-not (Test-CloudDeviceValuePattern -Value $device.ManagementAgent -Include $ActionIf.IncludeManagementAgent -Exclude $ActionIf.ExcludeManagementAgent)) {
+            continue
+        }
+
+        if (-not (Test-CloudDeviceValuePattern -Value @($device.EnrollmentType, $device.DeviceEnrollmentType) -Include $ActionIf.IncludeEnrollmentType -Exclude $ActionIf.ExcludeEnrollmentType)) {
+            continue
+        }
+
+        if (-not (Test-CloudDeviceValuePattern -Value $device.DeviceRegistrationState -Include $ActionIf.IncludeDeviceRegistrationState -Exclude $ActionIf.ExcludeDeviceRegistrationState)) {
+            continue
+        }
+
+        if (-not (Test-CloudDeviceValuePattern -Value $device.AutopilotGroupTag -Include $ActionIf.IncludeAutopilotGroupTag -Exclude $ActionIf.ExcludeAutopilotGroupTag)) {
+            continue
         }
 
         $candidate = $device | Select-Object *

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -245,7 +245,7 @@ function Get-CloudDevicesToProcess {
         }
 
         if ($ActionIf.OwnerState -and $ActionIf.OwnerState -ne 'Any') {
-            if ($device.OperatingSystem -like 'Windows*' -and $device.AutopilotInventoryLoaded -ne $true) {
+            if ($ActionIf.OwnerState -eq 'WithoutOwner' -and $device.OperatingSystem -like 'Windows*' -and $device.AutopilotInventoryLoaded -ne $true) {
                 continue
             }
             $hasOwner = Test-CloudDeviceOwnerPresence -Device $device

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -97,6 +97,14 @@ function Get-CloudDevicesToProcess {
     function Get-CloudDeviceComplianceState {
         param([Parameter(Mandatory)] [object] $Device)
 
+        if (-not [string]::IsNullOrWhiteSpace([string] $Device.ComplianceState)) {
+            switch ([string] $Device.ComplianceState) {
+                'compliant' { return 'Compliant' }
+                { $_ -in @('noncompliant', 'inGracePeriod', 'configManager') } { return 'NonCompliant' }
+                default { return 'Unknown' }
+            }
+        }
+
         if ($Device.IsCompliant -eq $true -or [string] $Device.ComplianceState -eq 'compliant') {
             return 'Compliant'
         }

--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -229,7 +229,7 @@ function Get-CloudDevicesToProcess {
         }
 
         if ($ActionIf.OwnerState -and $ActionIf.OwnerState -ne 'Any') {
-            if ($device.OperatingSystem -like 'Windows*' -and $device.AutopilotInventoryLoaded -eq $false) {
+            if ($device.OperatingSystem -like 'Windows*' -and $device.AutopilotInventoryLoaded -ne $true) {
                 continue
             }
             $hasOwner = Test-CloudDeviceOwnerPresence -Device $device

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -25,6 +25,23 @@ function Get-InitialCloudDevices {
         }
     }
 
+    $getFirstPropertyValue = {
+        param(
+            [AllowEmptyCollection()]
+            [object[]] $InputObject,
+            [string[]] $Name
+        )
+
+        foreach ($source in $InputObject) {
+            $value = Get-CloudDevicePropertyValue -InputObject $source -Name $Name
+            if (-not [string]::IsNullOrWhiteSpace([string] $value)) {
+                return $value
+            }
+        }
+
+        $null
+    }
+
     Write-Color -Text '[i] ', 'Getting cloud devices from Microsoft Entra ID for join types: ', ($IncludeJoinType -join ', ') -Color Yellow, Cyan, Green
     $entraParameters = @{
         Type          = $IncludeJoinType
@@ -166,12 +183,12 @@ function Get-InitialCloudDevices {
             ManagementAgent         = if ($intuneDevice) { $intuneDevice.ManagementAgent } else { $null }
             AutopilotInventoryLoaded = $autopilotInventoryLoaded
             AutopilotOnboarded      = $autopilotOnboarded
-            AutopilotDeviceId       = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotDeviceId' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotDeviceId' }
-            AutopilotGroupTag       = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotGroupTag' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotGroupTag' }
-            AutopilotSerialNumber   = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotSerialNumber' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotSerialNumber' }
-            AutopilotEnrollmentState = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotEnrollmentState' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotEnrollmentState' }
-            AutopilotLastContacted  = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotLastContacted' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotLastContacted' }
-            AutopilotUserPrincipalName = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotUserPrincipalName' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotUserPrincipalName' }
+            AutopilotDeviceId       = & $getFirstPropertyValue -InputObject @($intuneDevice, $entraDevice) -Name 'AutopilotDeviceId'
+            AutopilotGroupTag       = & $getFirstPropertyValue -InputObject @($intuneDevice, $entraDevice) -Name 'AutopilotGroupTag'
+            AutopilotSerialNumber   = & $getFirstPropertyValue -InputObject @($intuneDevice, $entraDevice) -Name 'AutopilotSerialNumber'
+            AutopilotEnrollmentState = & $getFirstPropertyValue -InputObject @($intuneDevice, $entraDevice) -Name 'AutopilotEnrollmentState'
+            AutopilotLastContacted  = & $getFirstPropertyValue -InputObject @($intuneDevice, $entraDevice) -Name 'AutopilotLastContacted'
+            AutopilotUserPrincipalName = & $getFirstPropertyValue -InputObject @($intuneDevice, $entraDevice) -Name 'AutopilotUserPrincipalName'
             SelectionReason         = $null
         })
     }

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -42,6 +42,23 @@ function Get-InitialCloudDevices {
         $null
     }
 
+    $getFirstNonNullPropertyValue = {
+        param(
+            [AllowEmptyCollection()]
+            [object[]] $InputObject,
+            [string[]] $Name
+        )
+
+        foreach ($source in $InputObject) {
+            $value = Get-CloudDevicePropertyValue -InputObject $source -Name $Name
+            if ($null -ne $value) {
+                return $value
+            }
+        }
+
+        $null
+    }
+
     [Array] $entraJoinType = @($IncludeJoinType | Where-Object { $_ -ne 'Not available' })
     [Array] $entraDevices = @()
     if ($entraJoinType.Count -gt 0) {
@@ -141,16 +158,8 @@ function Get-InitialCloudDevices {
 
         $entraRegisteredDays = & $getAgeDays $entraDevice.FirstSeen
         $intuneRegisteredDays = if ($intuneDevice) { & $getAgeDays $intuneDevice.FirstSeen } else { $null }
-        $autopilotInventoryLoaded = if ($intuneDevice -and $intuneDevice.PSObject.Properties['AutopilotInventoryLoaded']) {
-            $intuneDevice.AutopilotInventoryLoaded
-        } else {
-            Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotInventoryLoaded'
-        }
-        $autopilotOnboarded = if ($intuneDevice -and $intuneDevice.PSObject.Properties['AutopilotOnboarded']) {
-            $intuneDevice.AutopilotOnboarded
-        } else {
-            Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotOnboarded'
-        }
+        $autopilotInventoryLoaded = & $getFirstNonNullPropertyValue -InputObject @($intuneDevice, $entraDevice) -Name 'AutopilotInventoryLoaded'
+        $autopilotOnboarded = & $getFirstNonNullPropertyValue -InputObject @($intuneDevice, $entraDevice) -Name 'AutopilotOnboarded'
 
         $outputDevices.Add([PSCustomObject] [ordered] @{
             Name                    = $entraDevice.Name

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -3,13 +3,38 @@ function Get-InitialCloudDevices {
     param(
         [nullable[int]] $SafetyEntraLimit,
         [nullable[int]] $SafetyIntuneLimit,
+        [ValidateSet('Hybrid AzureAD', 'AzureAD joined', 'AzureAD registered', 'Not available')]
+        [string[]] $IncludeJoinType = @('AzureAD registered'),
         [Array] $IncludeOperatingSystem,
         [Array] $ExcludeOperatingSystem,
-        [Array] $Exclusions
+        [Array] $IncludeOperatingSystemVersion = @(),
+        [Array] $ExcludeOperatingSystemVersion = @(),
+        [switch] $IncludeUnknownOperatingSystem,
+        [switch] $IncludeUnknownOperatingSystemVersion,
+        [Array] $Exclusions,
+        [switch] $IncludeAutopilotInventory
     )
 
-    Write-Color -Text '[i] ', 'Getting AzureAD registered devices from Microsoft Entra ID' -Color Yellow, Cyan, Green
-    [Array] $entraDevices = Get-MyDevice -Type 'AzureAD registered' -WarningAction SilentlyContinue -WarningVariable warningVar
+    $getAgeDays = {
+        param([AllowNull()] $DateValue)
+
+        if ($DateValue) {
+            [math]::Floor((New-TimeSpan -Start $DateValue -End (Get-Date)).TotalDays)
+        } else {
+            $null
+        }
+    }
+
+    Write-Color -Text '[i] ', 'Getting cloud devices from Microsoft Entra ID for join types: ', ($IncludeJoinType -join ', ') -Color Yellow, Cyan, Green
+    $entraParameters = @{
+        Type          = $IncludeJoinType
+        WarningAction = 'SilentlyContinue'
+        WarningVariable = 'warningVar'
+    }
+    if ($IncludeAutopilotInventory) {
+        $entraParameters.IncludeAutopilotInventory = $true
+    }
+    [Array] $entraDevices = Get-MyDevice @entraParameters
     if ($warningVar) {
         Write-Color -Text '[e] ', 'Error getting devices from Microsoft Entra ID: ', $warningVar, ' Terminating!' -Color Yellow, Red, Yellow, Red
         return $false
@@ -26,10 +51,18 @@ function Get-InitialCloudDevices {
         return $false
     }
 
-    Write-Color -Text '[i] ', 'AzureAD registered devices found in Microsoft Entra ID: ', $entraDevices.Count -Color Yellow, Cyan, Green
+    Write-Color -Text '[i] ', 'Cloud devices found in Microsoft Entra ID: ', $entraDevices.Count -Color Yellow, Cyan, Green
 
-    Write-Color -Text '[i] ', 'Getting AzureAD registered devices from Intune' -Color Yellow, Cyan, Green
-    [Array] $intuneDevices = Get-MyDeviceIntune -Type 'AzureAD registered' -WarningAction SilentlyContinue -WarningVariable warningVar
+    Write-Color -Text '[i] ', 'Getting cloud devices from Intune for join types: ', ($IncludeJoinType -join ', ') -Color Yellow, Cyan, Green
+    $intuneParameters = @{
+        Type          = $IncludeJoinType
+        WarningAction = 'SilentlyContinue'
+        WarningVariable = 'warningVar'
+    }
+    if ($IncludeAutopilotInventory) {
+        $intuneParameters.IncludeAutopilotInventory = $true
+    }
+    [Array] $intuneDevices = Get-MyDeviceIntune @intuneParameters
     if ($warningVar) {
         Write-Color -Text '[e] ', 'Error getting devices from Intune: ', $warningVar, ' Terminating!' -Color Yellow, Red, Yellow, Red
         return $false
@@ -40,7 +73,7 @@ function Get-InitialCloudDevices {
         return $false
     }
 
-    Write-Color -Text '[i] ', 'AzureAD registered devices found in Intune: ', $intuneDevices.Count -Color Yellow, Cyan, Green
+    Write-Color -Text '[i] ', 'Cloud devices found in Intune: ', $intuneDevices.Count -Color Yellow, Cyan, Green
 
     $intuneByAzureDeviceId = [ordered] @{}
     $matchedIntuneManagedDeviceIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
@@ -52,7 +85,7 @@ function Get-InitialCloudDevices {
 
     $outputDevices = [System.Collections.Generic.List[object]]::new()
     foreach ($entraDevice in $entraDevices) {
-        if (-not (Test-CloudDeviceRegistrationScope -Device $entraDevice)) {
+        if (-not (Test-CloudDeviceRegistrationScope -Device $entraDevice -IncludeJoinType $IncludeJoinType)) {
             continue
         }
 
@@ -67,13 +100,31 @@ function Get-InitialCloudDevices {
         } else {
             $entraDevice.OperatingSystem
         }
-        $deviceInScope = Test-CloudDeviceInventoryScope -OperatingSystem $operatingSystem -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -Exclusions $Exclusions -Name $entraDevice.Name -DeviceId $entraDevice.DeviceId -EntraDeviceObjectId $entraDevice.EntraDeviceObjectId -ManagedDeviceId $(if ($intuneDevice) { $intuneDevice.ManagedDeviceId } else { $null })
+        $operatingSystemVersion = if ($intuneDevice -and $intuneDevice.OperatingSystemVersion) {
+            $intuneDevice.OperatingSystemVersion
+        } else {
+            $entraDevice.OperatingSystemVersion
+        }
+        $deviceInScope = Test-CloudDeviceInventoryScope -OperatingSystem $operatingSystem -OperatingSystemVersion $operatingSystemVersion -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -IncludeOperatingSystemVersion $IncludeOperatingSystemVersion -ExcludeOperatingSystemVersion $ExcludeOperatingSystemVersion -IncludeUnknownOperatingSystem:$IncludeUnknownOperatingSystem -IncludeUnknownOperatingSystemVersion:$IncludeUnknownOperatingSystemVersion -Exclusions $Exclusions -Name $entraDevice.Name -DeviceId $entraDevice.DeviceId -EntraDeviceObjectId $entraDevice.EntraDeviceObjectId -ManagedDeviceId $(if ($intuneDevice) { $intuneDevice.ManagedDeviceId } else { $null })
         if (-not $deviceInScope) {
             continue
         }
 
         if ($intuneDevice -and $intuneDevice.ManagedDeviceId) {
             $null = $matchedIntuneManagedDeviceIds.Add($intuneDevice.ManagedDeviceId)
+        }
+
+        $entraRegisteredDays = & $getAgeDays $entraDevice.FirstSeen
+        $intuneRegisteredDays = if ($intuneDevice) { & $getAgeDays $intuneDevice.FirstSeen } else { $null }
+        $autopilotInventoryLoaded = if ($intuneDevice -and $intuneDevice.PSObject.Properties['AutopilotInventoryLoaded']) {
+            $intuneDevice.AutopilotInventoryLoaded
+        } else {
+            Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotInventoryLoaded'
+        }
+        $autopilotOnboarded = if ($intuneDevice -and $intuneDevice.PSObject.Properties['AutopilotOnboarded']) {
+            $intuneDevice.AutopilotOnboarded
+        } else {
+            Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotOnboarded'
         }
 
         $outputDevices.Add([PSCustomObject] [ordered] @{
@@ -87,17 +138,21 @@ function Get-InitialCloudDevices {
             RecordSource            = if ($intuneDevice) { 'Microsoft Entra ID + Intune' } else { 'Microsoft Entra ID only' }
             Enabled                 = $entraDevice.Enabled
             OperatingSystem         = if ($intuneDevice -and $intuneDevice.OperatingSystem) { $intuneDevice.OperatingSystem } else { $entraDevice.OperatingSystem }
-            OperatingSystemVersion  = if ($intuneDevice -and $intuneDevice.OperatingSystemVersion) { $intuneDevice.OperatingSystemVersion } else { $entraDevice.OperatingSystemVersion }
+            OperatingSystemVersion  = $operatingSystemVersion
             TrustType               = $entraDevice.TrustType
             EntraLastSeen           = $entraDevice.LastSeen
             EntraLastSeenDays       = $entraDevice.LastSeenDays
             IntuneLastSeen          = if ($intuneDevice) { $intuneDevice.LastSeen } else { $null }
             IntuneLastSeenDays      = if ($intuneDevice) { $intuneDevice.LastSeenDays } else { $null }
             FirstSeen               = $entraDevice.FirstSeen
+            RegisteredDays          = if ($null -ne $entraRegisteredDays) { $entraRegisteredDays } else { $intuneRegisteredDays }
+            EntraRegisteredDays     = $entraRegisteredDays
+            IntuneRegisteredDays    = $intuneRegisteredDays
             IsManaged               = $entraDevice.IsManaged
             IsCompliant             = $entraDevice.IsCompliant
             ManagementType          = $entraDevice.ManagementType
             EnrollmentType          = $entraDevice.EnrollmentType
+            DeviceEnrollmentType    = if ($intuneDevice) { $intuneDevice.DeviceEnrollmentType } else { $null }
             OwnerDisplayName        = $entraDevice.OwnerDisplayName
             OwnerUserPrincipalName  = $entraDevice.OwnerUserPrincipalName
             IntuneUserDisplayName   = if ($intuneDevice) { $intuneDevice.UserDisplayName } else { $null }
@@ -108,12 +163,20 @@ function Get-InitialCloudDevices {
             AzureAdRegistered       = if ($intuneDevice) { $intuneDevice.AzureAdRegistered } else { $null }
             ComplianceState         = if ($intuneDevice) { $intuneDevice.ComplianceState } else { $null }
             ManagementAgent         = if ($intuneDevice) { $intuneDevice.ManagementAgent } else { $null }
+            AutopilotInventoryLoaded = $autopilotInventoryLoaded
+            AutopilotOnboarded      = $autopilotOnboarded
+            AutopilotDeviceId       = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotDeviceId' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotDeviceId' }
+            AutopilotGroupTag       = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotGroupTag' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotGroupTag' }
+            AutopilotSerialNumber   = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotSerialNumber' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotSerialNumber' }
+            AutopilotEnrollmentState = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotEnrollmentState' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotEnrollmentState' }
+            AutopilotLastContacted  = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotLastContacted' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotLastContacted' }
+            AutopilotUserPrincipalName = if ($intuneDevice) { Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotUserPrincipalName' } else { Get-CloudDevicePropertyValue -InputObject $entraDevice -Name 'AutopilotUserPrincipalName' }
             SelectionReason         = $null
         })
     }
 
     foreach ($intuneDevice in $intuneDevices) {
-        if (-not (Test-CloudDeviceRegistrationScope -Device $intuneDevice)) {
+        if (-not (Test-CloudDeviceRegistrationScope -Device $intuneDevice -IncludeJoinType $IncludeJoinType)) {
             continue
         }
 
@@ -122,10 +185,12 @@ function Get-InitialCloudDevices {
         }
 
         $operatingSystem = $intuneDevice.OperatingSystem
-        $deviceInScope = Test-CloudDeviceInventoryScope -OperatingSystem $operatingSystem -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -Exclusions $Exclusions -Name $intuneDevice.Name -DeviceId $intuneDevice.AzureAdDeviceId -EntraDeviceObjectId $intuneDevice.EntraDeviceObjectId -ManagedDeviceId $intuneDevice.ManagedDeviceId
+        $deviceInScope = Test-CloudDeviceInventoryScope -OperatingSystem $operatingSystem -OperatingSystemVersion $intuneDevice.OperatingSystemVersion -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -IncludeOperatingSystemVersion $IncludeOperatingSystemVersion -ExcludeOperatingSystemVersion $ExcludeOperatingSystemVersion -IncludeUnknownOperatingSystem:$IncludeUnknownOperatingSystem -IncludeUnknownOperatingSystemVersion:$IncludeUnknownOperatingSystemVersion -Exclusions $Exclusions -Name $intuneDevice.Name -DeviceId $intuneDevice.AzureAdDeviceId -EntraDeviceObjectId $intuneDevice.EntraDeviceObjectId -ManagedDeviceId $intuneDevice.ManagedDeviceId
         if (-not $deviceInScope) {
             continue
         }
+
+        $intuneRegisteredDays = & $getAgeDays $intuneDevice.FirstSeen
 
         $outputDevices.Add([PSCustomObject] [ordered] @{
             Name                    = $intuneDevice.Name
@@ -145,10 +210,14 @@ function Get-InitialCloudDevices {
             IntuneLastSeen          = $intuneDevice.LastSeen
             IntuneLastSeenDays      = $intuneDevice.LastSeenDays
             FirstSeen               = $intuneDevice.FirstSeen
+            RegisteredDays          = $intuneRegisteredDays
+            EntraRegisteredDays     = $null
+            IntuneRegisteredDays    = $intuneRegisteredDays
             IsManaged               = $true
             IsCompliant             = $null
             ManagementType          = $null
             EnrollmentType          = $null
+            DeviceEnrollmentType    = $intuneDevice.DeviceEnrollmentType
             OwnerDisplayName        = $null
             OwnerUserPrincipalName  = $null
             IntuneUserDisplayName   = $intuneDevice.UserDisplayName
@@ -159,6 +228,14 @@ function Get-InitialCloudDevices {
             AzureAdRegistered       = $intuneDevice.AzureAdRegistered
             ComplianceState         = $intuneDevice.ComplianceState
             ManagementAgent         = $intuneDevice.ManagementAgent
+            AutopilotInventoryLoaded = Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotInventoryLoaded'
+            AutopilotOnboarded      = Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotOnboarded'
+            AutopilotDeviceId       = Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotDeviceId'
+            AutopilotGroupTag       = Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotGroupTag'
+            AutopilotSerialNumber   = Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotSerialNumber'
+            AutopilotEnrollmentState = Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotEnrollmentState'
+            AutopilotLastContacted  = Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotLastContacted'
+            AutopilotUserPrincipalName = Get-CloudDevicePropertyValue -InputObject $intuneDevice -Name 'AutopilotUserPrincipalName'
             SelectionReason         = $null
         })
     }

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -42,30 +42,37 @@ function Get-InitialCloudDevices {
         $null
     }
 
-    Write-Color -Text '[i] ', 'Getting cloud devices from Microsoft Entra ID for join types: ', ($IncludeJoinType -join ', ') -Color Yellow, Cyan, Green
-    $entraParameters = @{
-        Type          = $IncludeJoinType
-        WarningAction = 'SilentlyContinue'
-        WarningVariable = 'warningVar'
-    }
-    if ($IncludeAutopilotInventory) {
-        $entraParameters.IncludeAutopilotInventory = $true
-    }
-    [Array] $entraDevices = Get-MyDevice @entraParameters
-    if ($warningVar) {
-        Write-Color -Text '[e] ', 'Error getting devices from Microsoft Entra ID: ', $warningVar, ' Terminating!' -Color Yellow, Red, Yellow, Red
-        return $false
-    }
+    [Array] $entraJoinType = @($IncludeJoinType | Where-Object { $_ -ne 'Not available' })
+    [Array] $entraDevices = @()
+    if ($entraJoinType.Count -gt 0) {
+        Write-Color -Text '[i] ', 'Getting cloud devices from Microsoft Entra ID for join types: ', ($entraJoinType -join ', ') -Color Yellow, Cyan, Green
+        $entraParameters = @{
+            Type            = $entraJoinType
+            WarningAction   = 'SilentlyContinue'
+            WarningVariable = 'warningVar'
+        }
+        if ($IncludeAutopilotInventory) {
+            $entraParameters.IncludeAutopilotInventory = $true
+        }
+        $warningVar = $null
+        [Array] $entraDevices = Get-MyDevice @entraParameters
+        if ($warningVar) {
+            Write-Color -Text '[e] ', 'Error getting devices from Microsoft Entra ID: ', $warningVar, ' Terminating!' -Color Yellow, Red, Yellow, Red
+            return $false
+        }
 
-    if ($entraDevices.Count -eq 0) {
-        if ($null -ne $SafetyEntraLimit -and $SafetyEntraLimit -gt 0) {
+        if ($entraDevices.Count -eq 0) {
+            if ($null -ne $SafetyEntraLimit -and $SafetyEntraLimit -gt 0) {
+                Write-Color -Text '[e] ', 'Only ', $entraDevices.Count, ' devices found in Microsoft Entra ID, this is less than the safety limit of ', $SafetyEntraLimit, '. Terminating!' -Color Yellow, Cyan, Red, Cyan
+                return $false
+            }
+            Write-Color -Text '[i] ', 'No scoped devices found in Microsoft Entra ID. Continuing with Intune inventory to discover orphan records.' -Color Yellow, Yellow
+        } elseif ($null -ne $SafetyEntraLimit -and $entraDevices.Count -lt $SafetyEntraLimit) {
             Write-Color -Text '[e] ', 'Only ', $entraDevices.Count, ' devices found in Microsoft Entra ID, this is less than the safety limit of ', $SafetyEntraLimit, '. Terminating!' -Color Yellow, Cyan, Red, Cyan
             return $false
         }
-        Write-Color -Text '[i] ', 'No AzureAD registered devices found in Microsoft Entra ID. Continuing with Intune inventory to discover orphan records.' -Color Yellow, Yellow
-    } elseif ($null -ne $SafetyEntraLimit -and $entraDevices.Count -lt $SafetyEntraLimit) {
-        Write-Color -Text '[e] ', 'Only ', $entraDevices.Count, ' devices found in Microsoft Entra ID, this is less than the safety limit of ', $SafetyEntraLimit, '. Terminating!' -Color Yellow, Cyan, Red, Cyan
-        return $false
+    } else {
+        Write-Color -Text '[i] ', 'Skipping Microsoft Entra ID inventory because requested join type is only Not available. Continuing with Intune inventory.' -Color Yellow, Yellow
     }
 
     Write-Color -Text '[i] ', 'Cloud devices found in Microsoft Entra ID: ', $entraDevices.Count -Color Yellow, Cyan, Green

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -53,9 +53,10 @@ function Get-InitialCloudDevices {
 
     Write-Color -Text '[i] ', 'Cloud devices found in Microsoft Entra ID: ', $entraDevices.Count -Color Yellow, Cyan, Green
 
-    Write-Color -Text '[i] ', 'Getting cloud devices from Intune for join types: ', ($IncludeJoinType -join ', ') -Color Yellow, Cyan, Green
+    $includeIntuneJoinType = @($IncludeJoinType + 'Not available') | Select-Object -Unique
+    Write-Color -Text '[i] ', 'Getting cloud devices from Intune for join types: ', ($includeIntuneJoinType -join ', ') -Color Yellow, Cyan, Green
     $intuneParameters = @{
-        Type          = $IncludeJoinType
+        Type          = $includeIntuneJoinType
         WarningAction = 'SilentlyContinue'
         WarningVariable = 'warningVar'
     }
@@ -204,7 +205,7 @@ function Get-InitialCloudDevices {
             Enabled                 = $null
             OperatingSystem         = $intuneDevice.OperatingSystem
             OperatingSystemVersion  = $intuneDevice.OperatingSystemVersion
-            TrustType               = 'AzureAD registered'
+            TrustType               = Get-CloudDeviceJoinTypeFromRegistrationState -DeviceRegistrationState $intuneDevice.DeviceRegistrationState
             EntraLastSeen           = $null
             EntraLastSeenDays       = $null
             IntuneLastSeen          = $intuneDevice.LastSeen

--- a/Private/Request-CloudDevicesDelete.ps1
+++ b/Private/Request-CloudDevicesDelete.ps1
@@ -36,12 +36,9 @@ function Request-CloudDevicesDelete {
 
         if (-not $ReportOnly) {
             if ($DeleteAutopilotIdentity) {
-                if ($device.AutopilotInventoryLoaded -ne $true) {
-                    $subActionExecuted = $true
-                    $subActionSuccess = $false
-                    $continueRecordDelete = $false
-                    $subActionMessages.Add('Autopilot: Inventory was not loaded; record delete was skipped.')
-                } elseif ($device.AutopilotOnboarded -eq $true) {
+                $operatingSystem = [string] $device.OperatingSystem
+                $autopilotMayApply = [string]::IsNullOrWhiteSpace($operatingSystem) -or $operatingSystem -eq 'Unknown' -or $operatingSystem -like 'Windows*'
+                if ($device.AutopilotOnboarded -eq $true) {
                     $subActionExecuted = $true
                     if ([string]::IsNullOrWhiteSpace([string] $device.AutopilotDeviceId)) {
                         $subActionSuccess = $false
@@ -57,6 +54,11 @@ function Request-CloudDevicesDelete {
                             $continueRecordDelete = $false
                         }
                     }
+                } elseif ($autopilotMayApply -and $device.AutopilotInventoryLoaded -ne $true -and $device.AutopilotOnboarded -ne $false) {
+                    $subActionExecuted = $true
+                    $subActionSuccess = $false
+                    $continueRecordDelete = $false
+                    $subActionMessages.Add('Autopilot: Inventory was not loaded; record delete was skipped.')
                 }
             }
 

--- a/Private/Request-CloudDevicesDelete.ps1
+++ b/Private/Request-CloudDevicesDelete.ps1
@@ -14,6 +14,8 @@ function Request-CloudDevicesDelete {
 
         [bool] $DeleteRemoveIntuneRecord = $true,
 
+        [switch] $DeleteAutopilotIdentity,
+
         [switch] $ReportOnly,
         [switch] $WhatIfDelete,
         [switch] $WhatIf
@@ -30,9 +32,35 @@ function Request-CloudDevicesDelete {
         $subActionMessages = [System.Collections.Generic.List[string]]::new()
         $subActionSuccess = $true
         $subActionExecuted = $false
+        $continueRecordDelete = $true
 
         if (-not $ReportOnly) {
-            if ($DeleteRemoveIntuneRecord -and $device.HasIntuneRecord) {
+            if ($DeleteAutopilotIdentity) {
+                if ($device.AutopilotInventoryLoaded -ne $true) {
+                    $subActionExecuted = $true
+                    $subActionSuccess = $false
+                    $continueRecordDelete = $false
+                    $subActionMessages.Add('Autopilot: Inventory was not loaded; record delete was skipped.')
+                } elseif ($device.AutopilotOnboarded -eq $true) {
+                    $subActionExecuted = $true
+                    if ([string]::IsNullOrWhiteSpace([string] $device.AutopilotDeviceId)) {
+                        $subActionSuccess = $false
+                        $continueRecordDelete = $false
+                        $subActionMessages.Add('Autopilot: Device is onboarded but AutopilotDeviceId is missing; record delete was skipped.')
+                    } else {
+                        $removeAutopilotResult = Remove-MyAutopilotDevice -InputObject $device -Confirm:$false -WhatIf:$($WhatIf -or $WhatIfDelete)
+                        if ($removeAutopilotResult.Message) {
+                            $subActionMessages.Add("Autopilot: $($removeAutopilotResult.Message)")
+                        }
+                        if (-not $removeAutopilotResult.Success -and -not ($WhatIf -or $WhatIfDelete)) {
+                            $subActionSuccess = $false
+                            $continueRecordDelete = $false
+                        }
+                    }
+                }
+            }
+
+            if ($continueRecordDelete -and $DeleteRemoveIntuneRecord -and $device.HasIntuneRecord) {
                 $subActionExecuted = $true
                 $removeIntuneResult = Remove-MyDeviceIntuneRecord -InputObject $device -Confirm:$false -WhatIf:$($WhatIf -or $WhatIfDelete)
                 if ($removeIntuneResult.Message) {
@@ -43,7 +71,7 @@ function Request-CloudDevicesDelete {
                 }
             }
 
-            if ($device.HasEntraRecord -and $device.RecordState -ne 'IntuneOnly') {
+            if ($continueRecordDelete -and $device.HasEntraRecord -and $device.RecordState -ne 'IntuneOnly') {
                 $subActionExecuted = $true
                 $removeEntraResult = Remove-MyDevice -InputObject $device -Confirm:$false -WhatIf:$($WhatIf -or $WhatIfDelete)
                 if ($removeEntraResult.Message) {

--- a/Private/Request-CloudDevicesStageDelete.ps1
+++ b/Private/Request-CloudDevicesStageDelete.ps1
@@ -1,0 +1,70 @@
+function Request-CloudDevicesStageDelete {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [Array] $Devices,
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $ProcessedDevices,
+
+        [Parameter(Mandatory)]
+        [datetime] $Today,
+
+        [int] $StageLimit = 0,
+
+        [switch] $ReportOnly,
+        [switch] $WhatIfStageDelete,
+        [switch] $WhatIf
+    )
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    $attemptedCount = 0
+
+    foreach ($device in $Devices) {
+        if ($StageLimit -gt 0 -and $attemptedCount -ge $StageLimit) {
+            break
+        }
+
+        $alreadyPending = $false
+        foreach ($processedDeviceKey in @(
+                if ($device.PSObject.Properties['MatchedProcessedDeviceKey'] -and $device.MatchedProcessedDeviceKey) {
+                    $device.MatchedProcessedDeviceKey
+                }
+                if ($device.PSObject.Properties['ProcessedDeviceKey'] -and $device.ProcessedDeviceKey) {
+                    $device.ProcessedDeviceKey
+                }
+            )) {
+            if ($ProcessedDevices.Contains($processedDeviceKey)) {
+                $alreadyPending = $true
+                break
+            }
+        }
+
+        if ($alreadyPending) {
+            continue
+        }
+
+        $actionStatus = if ($ReportOnly) {
+            'ReportOnly'
+        } elseif ($WhatIf -or $WhatIfStageDelete) {
+            'WhatIf'
+        } else {
+            'True'
+        }
+
+        $result = $device | Select-Object *
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionDate' -Value $Today -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionStatus' -Value $actionStatus -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'Action' -Value 'StageDelete' -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ActionNotes' -Value 'Device staged for delete after pending grace period.' -Force
+        Add-Member -InputObject $result -MemberType NoteProperty -Name 'ProcessedDeviceKeys' -Value $device.ProcessedDeviceKeys -Force
+        $results.Add($result)
+        $attemptedCount++
+
+        if (-not ($WhatIf -or $WhatIfStageDelete -or $ReportOnly)) {
+            Set-ProcessedCloudDeviceRecord -ProcessedDevices $ProcessedDevices -Device $device -Result $result
+        }
+    }
+
+    @($results)
+}

--- a/Private/Test-CloudDeviceInventoryScope.ps1
+++ b/Private/Test-CloudDeviceInventoryScope.ps1
@@ -6,6 +6,10 @@ function Test-CloudDeviceInventoryScope {
         [AllowEmptyString()]
         [string] $OperatingSystem,
 
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string] $OperatingSystemVersion,
+
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
         [Array] $IncludeOperatingSystem,
@@ -13,6 +17,16 @@ function Test-CloudDeviceInventoryScope {
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
         [Array] $ExcludeOperatingSystem,
+
+        [AllowEmptyCollection()]
+        [Array] $IncludeOperatingSystemVersion = @(),
+
+        [AllowEmptyCollection()]
+        [Array] $ExcludeOperatingSystemVersion = @(),
+
+        [switch] $IncludeUnknownOperatingSystem,
+
+        [switch] $IncludeUnknownOperatingSystemVersion,
 
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
@@ -24,13 +38,13 @@ function Test-CloudDeviceInventoryScope {
         [string] $ManagedDeviceId
     )
 
-    if ([string]::IsNullOrWhiteSpace($OperatingSystem)) {
+    if ([string]::IsNullOrWhiteSpace($OperatingSystem) -and -not $IncludeUnknownOperatingSystem) {
         if ($IncludeOperatingSystem.Count -gt 0) {
             return $false
         }
     }
 
-    if ($IncludeOperatingSystem.Count -gt 0) {
+    if ($IncludeOperatingSystem.Count -gt 0 -and -not [string]::IsNullOrWhiteSpace($OperatingSystem)) {
         $includeMatch = $false
         foreach ($includePattern in $IncludeOperatingSystem) {
             if ($OperatingSystem -like $includePattern) {
@@ -47,6 +61,34 @@ function Test-CloudDeviceInventoryScope {
     if ($ExcludeOperatingSystem.Count -gt 0) {
         foreach ($excludePattern in $ExcludeOperatingSystem) {
             if ($OperatingSystem -like $excludePattern) {
+                return $false
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($OperatingSystemVersion) -and -not $IncludeUnknownOperatingSystemVersion) {
+        if ($IncludeOperatingSystemVersion.Count -gt 0) {
+            return $false
+        }
+    }
+
+    if ($IncludeOperatingSystemVersion.Count -gt 0 -and -not [string]::IsNullOrWhiteSpace($OperatingSystemVersion)) {
+        $includeVersionMatch = $false
+        foreach ($includePattern in $IncludeOperatingSystemVersion) {
+            if ($OperatingSystemVersion -like $includePattern) {
+                $includeVersionMatch = $true
+                break
+            }
+        }
+
+        if (-not $includeVersionMatch) {
+            return $false
+        }
+    }
+
+    if ($ExcludeOperatingSystemVersion.Count -gt 0 -and -not [string]::IsNullOrWhiteSpace($OperatingSystemVersion)) {
+        foreach ($excludePattern in $ExcludeOperatingSystemVersion) {
+            if ($OperatingSystemVersion -like $excludePattern) {
                 return $false
             }
         }

--- a/Private/Test-CloudDeviceRegistrationScope.ps1
+++ b/Private/Test-CloudDeviceRegistrationScope.ps1
@@ -2,15 +2,22 @@ function Test-CloudDeviceRegistrationScope {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [object] $Device
+        [object] $Device,
+
+        [ValidateSet('Hybrid AzureAD', 'AzureAD joined', 'AzureAD registered', 'Not available')]
+        [string[]] $IncludeJoinType = @('AzureAD registered')
     )
 
+    if (-not $IncludeJoinType -or $IncludeJoinType.Count -eq 0) {
+        return $false
+    }
+
     if ($Device.PSObject.Properties['TrustType'] -and $Device.TrustType) {
-        return $Device.TrustType -eq 'AzureAD registered'
+        return $IncludeJoinType -contains $Device.TrustType
     }
 
     if ($Device.PSObject.Properties['DeviceRegistrationState'] -and $Device.DeviceRegistrationState) {
-        return $Device.DeviceRegistrationState -eq 'registered'
+        return $Device.DeviceRegistrationState -eq 'registered' -and $IncludeJoinType -contains 'AzureAD registered'
     }
 
     if ($Device.PSObject.Properties['IsSynchronized'] -and $Device.IsSynchronized -eq $true) {

--- a/Private/Test-CloudDeviceRegistrationScope.ps1
+++ b/Private/Test-CloudDeviceRegistrationScope.ps1
@@ -29,5 +29,5 @@ function Test-CloudDeviceRegistrationScope {
         return $false
     }
 
-    $false
+    $IncludeJoinType -contains 'Not available'
 }

--- a/Private/Test-CloudDeviceRegistrationScope.ps1
+++ b/Private/Test-CloudDeviceRegistrationScope.ps1
@@ -16,17 +16,17 @@ function Test-CloudDeviceRegistrationScope {
         return $IncludeJoinType -contains $Device.TrustType
     }
 
-    if ($Device.PSObject.Properties['DeviceRegistrationState']) {
-        $joinType = Get-CloudDeviceJoinTypeFromRegistrationState -DeviceRegistrationState $Device.DeviceRegistrationState
-        return $joinType -and $IncludeJoinType -contains $joinType
-    }
-
     if ($Device.PSObject.Properties['IsSynchronized'] -and $Device.IsSynchronized -eq $true) {
         return $false
     }
 
     if ($Device.PSObject.Properties['AzureAdRegistered'] -and $Device.AzureAdRegistered -eq $false) {
         return $false
+    }
+
+    if ($Device.PSObject.Properties['DeviceRegistrationState']) {
+        $joinType = Get-CloudDeviceJoinTypeFromRegistrationState -DeviceRegistrationState $Device.DeviceRegistrationState
+        return $joinType -and $IncludeJoinType -contains $joinType
     }
 
     $IncludeJoinType -contains 'Not available'

--- a/Private/Test-CloudDeviceRegistrationScope.ps1
+++ b/Private/Test-CloudDeviceRegistrationScope.ps1
@@ -16,7 +16,7 @@ function Test-CloudDeviceRegistrationScope {
         return $IncludeJoinType -contains $Device.TrustType
     }
 
-    if ($Device.PSObject.Properties['DeviceRegistrationState'] -and $Device.DeviceRegistrationState) {
+    if ($Device.PSObject.Properties['DeviceRegistrationState']) {
         $joinType = Get-CloudDeviceJoinTypeFromRegistrationState -DeviceRegistrationState $Device.DeviceRegistrationState
         return $joinType -and $IncludeJoinType -contains $joinType
     }

--- a/Private/Test-CloudDeviceRegistrationScope.ps1
+++ b/Private/Test-CloudDeviceRegistrationScope.ps1
@@ -17,7 +17,8 @@ function Test-CloudDeviceRegistrationScope {
     }
 
     if ($Device.PSObject.Properties['DeviceRegistrationState'] -and $Device.DeviceRegistrationState) {
-        return $Device.DeviceRegistrationState -eq 'registered' -and $IncludeJoinType -contains 'AzureAD registered'
+        $joinType = Get-CloudDeviceJoinTypeFromRegistrationState -DeviceRegistrationState $Device.DeviceRegistrationState
+        return $joinType -and $IncludeJoinType -contains $joinType
     }
 
     if ($Device.PSObject.Properties['IsSynchronized'] -and $Device.IsSynchronized -eq $true) {

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -380,7 +380,13 @@ function Invoke-CloudDevicesCleanup {
         return
     }
 
-    if (-not $Retire -and -not $Disable -and -not $StageDisabledForDelete -and -not $Delete) {
+    $processStageDisabledForDelete = $StageDisabledForDelete.IsPresent
+    if ($processStageDisabledForDelete -and $null -eq $DeleteLastSeenEntraMoreThan -and $null -eq $DeleteLastSeenIntuneMoreThan -and $null -eq $DeleteRegisteredMoreThan) {
+        Write-Color -Text '[e] ', 'StageDisabledForDelete requires at least one stale delete filter: DeleteLastSeenEntraMoreThan, DeleteLastSeenIntuneMoreThan, or DeleteRegisteredMoreThan.' -Color Yellow, Red
+        $processStageDisabledForDelete = $false
+    }
+
+    if (-not $Retire -and -not $Disable -and -not $processStageDisabledForDelete -and -not $Delete) {
         Write-Color -Text '[i] ', 'No action can be taken. You need to enable Retire, Disable, StageDisabledForDelete or Delete.' -Color Yellow, Red
         return
     }
@@ -512,7 +518,7 @@ function Invoke-CloudDevicesCleanup {
         }
     }
 
-    if ($StageDisabledForDelete) {
+    if ($processStageDisabledForDelete) {
         $devicesToStageForDelete = @(Get-CloudDevicesToProcess -Type Delete -Devices $allDevices -ActionIf $stageDeleteOnlyIf -ProcessedDevices $processedDevices)
         Write-Color -Text '[i] ', 'Devices to be staged for delete: ', $devicesToStageForDelete.Count, '. Current stage limit: ', $(if ($StageDisabledForDeleteLimit -eq 0) { 'Unlimited' } else { $StageDisabledForDeleteLimit }) -Color Yellow, Cyan, Green, Cyan, Yellow
 

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -35,6 +35,9 @@ function Invoke-CloudDevicesCleanup {
     Retire devices only when the Entra LastSeenDays value is greater than this number.
     Devices with blank Entra activity are not selected by this criterion.
 
+    .PARAMETER RetireRegisteredMoreThan
+    Retire devices only when the device registration/enrollment age is greater than this number of days.
+
     .PARAMETER RetireIncludeIntuneOnly
     Allows retire-stage processing of Intune-only orphan records.
     By default, orphan Intune records are discovered and reported but not actioned.
@@ -52,6 +55,9 @@ function Invoke-CloudDevicesCleanup {
     .PARAMETER DisableLastSeenIntuneMoreThan
     Disable devices only when the Intune LastSeenDays value is greater than this number.
     Devices with blank Intune activity are not selected by this criterion.
+
+    .PARAMETER DisableRegisteredMoreThan
+    Disable devices only when the device registration/enrollment age is greater than this number of days.
 
     .PARAMETER DisableListProcessedMoreThan
     Disable devices only after they were previously actioned and remained pending longer than this number of days.
@@ -75,6 +81,9 @@ function Invoke-CloudDevicesCleanup {
     Delete devices only when the Intune LastSeenDays value is greater than this number.
     Devices with blank Intune activity are not selected by this criterion.
 
+    .PARAMETER DeleteRegisteredMoreThan
+    Delete devices only when the device registration/enrollment age is greater than this number of days.
+
     .PARAMETER DeleteListProcessedMoreThan
     Delete devices only after they were previously actioned and remained pending longer than this number of days.
     Defaults to 30 days.
@@ -96,9 +105,65 @@ function Invoke-CloudDevicesCleanup {
     Operating-system patterns to include when building cloud-device inventory.
     Defaults to iOS and Android patterns. Wildcards are supported.
 
+    .PARAMETER IncludeJoinType
+    Microsoft Entra join-type values to include when building cloud-device inventory.
+    Defaults to AzureAD registered. Add AzureAD joined explicitly for Windows cloud-joined cleanup.
+
     .PARAMETER ExcludeOperatingSystem
     Operating-system patterns to exclude when building cloud-device inventory.
     Wildcards are supported.
+
+    .PARAMETER IncludeOperatingSystemVersion
+    Operating-system version patterns to include when building cloud-device inventory.
+
+    .PARAMETER ExcludeOperatingSystemVersion
+    Operating-system version patterns to exclude when building cloud-device inventory.
+
+    .PARAMETER IncludeUnknownOperatingSystem
+    Allows records with blank operating-system values to remain in inventory.
+
+    .PARAMETER IncludeUnknownOperatingSystemVersion
+    Allows records with blank operating-system-version values when version filters are set.
+
+    .PARAMETER AutopilotState
+    Filters action candidates by Windows Autopilot inventory state: Any, Onboarded, or NotOnboarded.
+    NotOnboarded only matches when Autopilot inventory was loaded successfully.
+
+    .PARAMETER OwnerState
+    Filters action candidates by owner presence: Any, WithOwner, or WithoutOwner.
+
+    .PARAMETER ManagementState
+    Filters action candidates by management state: Any, Managed, Unmanaged, Mdm, or NotMdm.
+
+    .PARAMETER ComplianceState
+    Filters action candidates by compliance state: Any, Compliant, NonCompliant, or Unknown.
+
+    .PARAMETER EnabledState
+    Filters action candidates by Microsoft Entra enabled state: Any, Enabled, Disabled, or Unknown.
+
+    .PARAMETER IncludeManagementAgent
+    Management-agent patterns to include for action candidates. Wildcards are supported.
+
+    .PARAMETER ExcludeManagementAgent
+    Management-agent patterns to exclude for action candidates. Wildcards are supported.
+
+    .PARAMETER IncludeEnrollmentType
+    Enrollment-type patterns to include for action candidates. Wildcards are supported.
+
+    .PARAMETER ExcludeEnrollmentType
+    Enrollment-type patterns to exclude for action candidates. Wildcards are supported.
+
+    .PARAMETER IncludeDeviceRegistrationState
+    Intune device-registration-state patterns to include for action candidates. Wildcards are supported.
+
+    .PARAMETER ExcludeDeviceRegistrationState
+    Intune device-registration-state patterns to exclude for action candidates. Wildcards are supported.
+
+    .PARAMETER IncludeAutopilotGroupTag
+    Autopilot group-tag patterns to include for action candidates. Wildcards are supported.
+
+    .PARAMETER ExcludeAutopilotGroupTag
+    Autopilot group-tag patterns to exclude for action candidates. Wildcards are supported.
 
     .PARAMETER Exclusions
     Device names, Entra object IDs, Intune managed-device IDs, or other supported identifiers to exclude from cleanup.
@@ -187,12 +252,14 @@ function Invoke-CloudDevicesCleanup {
         [switch] $Retire,
         [nullable[int]] $RetireLastSeenIntuneMoreThan = 120,
         [nullable[int]] $RetireLastSeenEntraMoreThan,
+        [nullable[int]] $RetireRegisteredMoreThan,
         [switch] $RetireIncludeIntuneOnly,
         [int] $RetireLimit = 10,
 
         [switch] $Disable,
         [nullable[int]] $DisableLastSeenEntraMoreThan,
         [nullable[int]] $DisableLastSeenIntuneMoreThan,
+        [nullable[int]] $DisableRegisteredMoreThan,
         [nullable[int]] $DisableListProcessedMoreThan = 30,
         [switch] $DisableIncludeEntraOnly,
         [int] $DisableLimit = 10,
@@ -200,14 +267,39 @@ function Invoke-CloudDevicesCleanup {
         [switch] $Delete,
         [nullable[int]] $DeleteLastSeenEntraMoreThan,
         [nullable[int]] $DeleteLastSeenIntuneMoreThan,
+        [nullable[int]] $DeleteRegisteredMoreThan,
         [nullable[int]] $DeleteListProcessedMoreThan = 30,
         [switch] $DeleteIncludeEntraOnly,
         [switch] $DeleteIncludeIntuneOnly,
         [int] $DeleteLimit = 10,
         [bool] $DeleteRemoveIntuneRecord = $true,
 
+        [ValidateSet('Hybrid AzureAD', 'AzureAD joined', 'AzureAD registered', 'Not available')]
+        [string[]] $IncludeJoinType = @('AzureAD registered'),
         [Array] $IncludeOperatingSystem = @('iOS*', 'Android*'),
         [Array] $ExcludeOperatingSystem = @(),
+        [Array] $IncludeOperatingSystemVersion = @(),
+        [Array] $ExcludeOperatingSystemVersion = @(),
+        [switch] $IncludeUnknownOperatingSystem,
+        [switch] $IncludeUnknownOperatingSystemVersion,
+        [ValidateSet('Any', 'Onboarded', 'NotOnboarded')]
+        [string] $AutopilotState = 'Any',
+        [ValidateSet('Any', 'WithOwner', 'WithoutOwner')]
+        [string] $OwnerState = 'Any',
+        [ValidateSet('Any', 'Managed', 'Unmanaged', 'Mdm', 'NotMdm')]
+        [string] $ManagementState = 'Any',
+        [ValidateSet('Any', 'Compliant', 'NonCompliant', 'Unknown')]
+        [string] $ComplianceState = 'Any',
+        [ValidateSet('Any', 'Enabled', 'Disabled', 'Unknown')]
+        [string] $EnabledState = 'Any',
+        [Array] $IncludeManagementAgent = @(),
+        [Array] $ExcludeManagementAgent = @(),
+        [Array] $IncludeEnrollmentType = @(),
+        [Array] $ExcludeEnrollmentType = @(),
+        [Array] $IncludeDeviceRegistrationState = @(),
+        [Array] $ExcludeDeviceRegistrationState = @(),
+        [Array] $IncludeAutopilotGroupTag = @(),
+        [Array] $ExcludeAutopilotGroupTag = @(),
         [Array] $Exclusions = @(),
         [switch] $IncludeCompanyOwned,
 
@@ -268,25 +360,67 @@ function Invoke-CloudDevicesCleanup {
     $retireOnlyIf = [ordered] @{
         LastSeenIntuneMoreThan = $RetireLastSeenIntuneMoreThan
         LastSeenEntraMoreThan  = $RetireLastSeenEntraMoreThan
+        RegisteredMoreThan     = $RetireRegisteredMoreThan
         ExcludeCompanyOwned    = -not $IncludeCompanyOwned
         IncludeIntuneOnly      = $RetireIncludeIntuneOnly.IsPresent
+        AutopilotState         = $AutopilotState
+        OwnerState             = $OwnerState
+        ManagementState        = $ManagementState
+        ComplianceState        = $ComplianceState
+        EnabledState           = $EnabledState
+        IncludeManagementAgent = $IncludeManagementAgent
+        ExcludeManagementAgent = $ExcludeManagementAgent
+        IncludeEnrollmentType  = $IncludeEnrollmentType
+        ExcludeEnrollmentType  = $ExcludeEnrollmentType
+        IncludeDeviceRegistrationState = $IncludeDeviceRegistrationState
+        ExcludeDeviceRegistrationState = $ExcludeDeviceRegistrationState
+        IncludeAutopilotGroupTag = $IncludeAutopilotGroupTag
+        ExcludeAutopilotGroupTag = $ExcludeAutopilotGroupTag
     }
 
     $disableOnlyIf = [ordered] @{
         LastSeenEntraMoreThan  = $DisableLastSeenEntraMoreThan
         LastSeenIntuneMoreThan = $DisableLastSeenIntuneMoreThan
+        RegisteredMoreThan     = $DisableRegisteredMoreThan
         ListProcessedMoreThan  = $DisableListProcessedMoreThan
         ExcludeCompanyOwned    = -not $IncludeCompanyOwned
         IncludeEntraOnly       = $DisableIncludeEntraOnly.IsPresent
+        AutopilotState         = $AutopilotState
+        OwnerState             = $OwnerState
+        ManagementState        = $ManagementState
+        ComplianceState        = $ComplianceState
+        EnabledState           = $EnabledState
+        IncludeManagementAgent = $IncludeManagementAgent
+        ExcludeManagementAgent = $ExcludeManagementAgent
+        IncludeEnrollmentType  = $IncludeEnrollmentType
+        ExcludeEnrollmentType  = $ExcludeEnrollmentType
+        IncludeDeviceRegistrationState = $IncludeDeviceRegistrationState
+        ExcludeDeviceRegistrationState = $ExcludeDeviceRegistrationState
+        IncludeAutopilotGroupTag = $IncludeAutopilotGroupTag
+        ExcludeAutopilotGroupTag = $ExcludeAutopilotGroupTag
     }
 
     $deleteOnlyIf = [ordered] @{
         LastSeenEntraMoreThan  = $DeleteLastSeenEntraMoreThan
         LastSeenIntuneMoreThan = $DeleteLastSeenIntuneMoreThan
+        RegisteredMoreThan     = $DeleteRegisteredMoreThan
         ListProcessedMoreThan  = $DeleteListProcessedMoreThan
         ExcludeCompanyOwned    = -not $IncludeCompanyOwned
         IncludeEntraOnly       = $DeleteIncludeEntraOnly.IsPresent
         IncludeIntuneOnly      = $DeleteIncludeIntuneOnly.IsPresent
+        AutopilotState         = $AutopilotState
+        OwnerState             = $OwnerState
+        ManagementState        = $ManagementState
+        ComplianceState        = $ComplianceState
+        EnabledState           = $EnabledState
+        IncludeManagementAgent = $IncludeManagementAgent
+        ExcludeManagementAgent = $ExcludeManagementAgent
+        IncludeEnrollmentType  = $IncludeEnrollmentType
+        ExcludeEnrollmentType  = $ExcludeEnrollmentType
+        IncludeDeviceRegistrationState = $IncludeDeviceRegistrationState
+        ExcludeDeviceRegistrationState = $ExcludeDeviceRegistrationState
+        IncludeAutopilotGroupTag = $IncludeAutopilotGroupTag
+        ExcludeAutopilotGroupTag = $ExcludeAutopilotGroupTag
     }
 
     $export = [ordered] @{
@@ -301,7 +435,8 @@ function Invoke-CloudDevicesCleanup {
         return
     }
 
-    $allDevices = Get-InitialCloudDevices -SafetyEntraLimit $SafetyEntraLimit -SafetyIntuneLimit $SafetyIntuneLimit -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -Exclusions $Exclusions
+    $includeAutopilotInventory = $AutopilotState -ne 'Any' -or $IncludeAutopilotGroupTag.Count -gt 0 -or $ExcludeAutopilotGroupTag.Count -gt 0
+    $allDevices = Get-InitialCloudDevices -SafetyEntraLimit $SafetyEntraLimit -SafetyIntuneLimit $SafetyIntuneLimit -IncludeJoinType $IncludeJoinType -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -IncludeOperatingSystemVersion $IncludeOperatingSystemVersion -ExcludeOperatingSystemVersion $ExcludeOperatingSystemVersion -IncludeUnknownOperatingSystem:$IncludeUnknownOperatingSystem -IncludeUnknownOperatingSystemVersion:$IncludeUnknownOperatingSystemVersion -Exclusions $Exclusions -IncludeAutopilotInventory:$includeAutopilotInventory
     if ($allDevices -eq $false) {
         return
     }

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -73,6 +73,15 @@ function Invoke-CloudDevicesCleanup {
     .PARAMETER Delete
     Enables the final delete stage.
 
+    .PARAMETER StageDisabledForDelete
+    Adds already-disabled delete candidates to PendingActions without deleting them.
+    Use this for daily automation where pre-disabled stale devices should wait the
+    same DeleteListProcessedMoreThan grace period as devices disabled by CleanupMonster.
+
+    .PARAMETER StageDisabledForDeleteLimit
+    Maximum number of already-disabled devices to stage for later delete in one run.
+    0 means unlimited. Default is 10.
+
     .PARAMETER DeleteLastSeenEntraMoreThan
     Delete devices only when the Entra LastSeenDays value is greater than this number.
     Entra-backed devices must have Enabled equal to $false; unknown enabled state is treated as unsafe.
@@ -190,6 +199,9 @@ function Invoke-CloudDevicesCleanup {
     .PARAMETER WhatIfDisable
     Previews disable actions only. Preview results are shown in the current report but are not stored as pending actions or history.
 
+    .PARAMETER WhatIfStageDelete
+    Previews staging already-disabled delete candidates without updating the pending-action datastore.
+
     .PARAMETER WhatIfDelete
     Previews delete actions only. Preview results are shown in the current report but are not stored as pending actions or history.
 
@@ -269,6 +281,9 @@ function Invoke-CloudDevicesCleanup {
         [switch] $DisableIncludeEntraOnly,
         [int] $DisableLimit = 10,
 
+        [switch] $StageDisabledForDelete,
+        [int] $StageDisabledForDeleteLimit = 10,
+
         [switch] $Delete,
         [nullable[int]] $DeleteLastSeenEntraMoreThan,
         [nullable[int]] $DeleteLastSeenIntuneMoreThan,
@@ -313,6 +328,7 @@ function Invoke-CloudDevicesCleanup {
         [switch] $ReportOnly,
         [switch] $WhatIfRetire,
         [switch] $WhatIfDisable,
+        [switch] $WhatIfStageDelete,
         [switch] $WhatIfDelete,
         [string] $LogPath,
         [int] $LogMaximum = 5,
@@ -332,6 +348,9 @@ function Invoke-CloudDevicesCleanup {
         }
         if (-not $PSBoundParameters.ContainsKey('WhatIfDisable')) {
             $WhatIfDisable = $true
+        }
+        if (-not $PSBoundParameters.ContainsKey('WhatIfStageDelete')) {
+            $WhatIfStageDelete = $true
         }
         if (-not $PSBoundParameters.ContainsKey('WhatIfDelete')) {
             $WhatIfDelete = $true
@@ -356,8 +375,8 @@ function Invoke-CloudDevicesCleanup {
         return
     }
 
-    if (-not $Retire -and -not $Disable -and -not $Delete) {
-        Write-Color -Text '[i] ', 'No action can be taken. You need to enable Retire, Disable or Delete.' -Color Yellow, Red
+    if (-not $Retire -and -not $Disable -and -not $StageDisabledForDelete -and -not $Delete) {
+        Write-Color -Text '[i] ', 'No action can be taken. You need to enable Retire, Disable, StageDisabledForDelete or Delete.' -Color Yellow, Red
         return
     }
 
@@ -429,6 +448,12 @@ function Invoke-CloudDevicesCleanup {
         ExcludeAutopilotGroupTag = $ExcludeAutopilotGroupTag
     }
 
+    $stageDeleteOnlyIf = [ordered] @{}
+    foreach ($key in $deleteOnlyIf.Keys) {
+        $stageDeleteOnlyIf[$key] = $deleteOnlyIf[$key]
+    }
+    $stageDeleteOnlyIf.ListProcessedMoreThan = $null
+
     $export = [ordered] @{
         Version        = Get-GitHubVersion -Cmdlet 'Invoke-CloudDevicesCleanup' -RepositoryOwner 'evotecit' -RepositoryName 'CleanupMonster'
         CurrentRun     = @()
@@ -450,6 +475,7 @@ function Invoke-CloudDevicesCleanup {
     $today = Get-Date
     $reportRetired = @()
     $reportDisabled = @()
+    $reportStagedForDelete = @()
     $reportDeleted = @()
 
     if ($Retire) {
@@ -478,6 +504,19 @@ function Invoke-CloudDevicesCleanup {
         }
     }
 
+    if ($StageDisabledForDelete) {
+        $devicesToStageForDelete = @(Get-CloudDevicesToProcess -Type Delete -Devices $allDevices -ActionIf $stageDeleteOnlyIf -ProcessedDevices $processedDevices)
+        Write-Color -Text '[i] ', 'Devices to be staged for delete: ', $devicesToStageForDelete.Count, '. Current stage limit: ', $(if ($StageDisabledForDeleteLimit -eq 0) { 'Unlimited' } else { $StageDisabledForDeleteLimit }) -Color Yellow, Cyan, Green, Cyan, Yellow
+
+        $processStageDelete = $devicesToStageForDelete.Count -gt 0
+        if ($processStageDelete -and $confirmActions -and -not ($ReportOnly -or $WhatIfPreference -or $WhatIfStageDelete)) {
+            $processStageDelete = $PSCmdlet.ShouldProcess("$($devicesToStageForDelete.Count) cloud device(s)", 'Stage for delete')
+        }
+        if ($processStageDelete) {
+            $reportStagedForDelete = @(Request-CloudDevicesStageDelete -Devices $devicesToStageForDelete -ProcessedDevices $processedDevices -Today $today -StageLimit $StageDisabledForDeleteLimit -ReportOnly:$ReportOnly -WhatIfStageDelete:$WhatIfStageDelete -WhatIf:$WhatIfPreference)
+        }
+    }
+
     if ($Delete) {
         $devicesToDelete = @(Get-CloudDevicesToProcess -Type Delete -Devices $allDevices -ActionIf $deleteOnlyIf -ProcessedDevices $processedDevices)
         Write-Color -Text '[i] ', 'Devices to be deleted: ', $devicesToDelete.Count, '. Current delete limit: ', $(if ($DeleteLimit -eq 0) { 'Unlimited' } else { $DeleteLimit }) -Color Yellow, Cyan, Green, Cyan, Yellow
@@ -495,6 +534,7 @@ function Invoke-CloudDevicesCleanup {
     $export.CurrentRun = @(
         if ($reportRetired.Count -gt 0) { $reportRetired }
         if ($reportDisabled.Count -gt 0) { $reportDisabled }
+        if ($reportStagedForDelete.Count -gt 0) { $reportStagedForDelete }
         if ($reportDeleted.Count -gt 0) { $reportDeleted }
     )
     $persistedRun = @()
@@ -503,6 +543,9 @@ function Invoke-CloudDevicesCleanup {
     }
     if ($reportDisabled.Count -gt 0) {
         $persistedRun += @($reportDisabled | Where-Object { $_.ActionStatus -notin 'WhatIf', 'ReportOnly' })
+    }
+    if ($reportStagedForDelete.Count -gt 0) {
+        $persistedRun += @($reportStagedForDelete | Where-Object { $_.ActionStatus -notin 'WhatIf', 'ReportOnly' })
     }
     if ($reportDeleted.Count -gt 0) {
         $persistedRun += @($reportDeleted | Where-Object { $_.ActionStatus -notin 'WhatIf', 'ReportOnly' })

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -101,6 +101,11 @@ function Invoke-CloudDevicesCleanup {
     Controls whether delete-stage processing also removes eligible Intune managed-device records.
     Defaults to $true.
 
+    .PARAMETER DeleteAutopilotIdentity
+    Removes Windows Autopilot device identities before deleting Intune or Entra records.
+    When enabled, Autopilot inventory must load successfully. If an onboarded device cannot
+    have its Autopilot identity removed, the Intune and Entra record delete sub-actions are skipped.
+
     .PARAMETER IncludeOperatingSystem
     Operating-system patterns to include when building cloud-device inventory.
     Defaults to iOS and Android patterns. Wildcards are supported.
@@ -273,6 +278,7 @@ function Invoke-CloudDevicesCleanup {
         [switch] $DeleteIncludeIntuneOnly,
         [int] $DeleteLimit = 10,
         [bool] $DeleteRemoveIntuneRecord = $true,
+        [switch] $DeleteAutopilotIdentity,
 
         [ValidateSet('Hybrid AzureAD', 'AzureAD joined', 'AzureAD registered', 'Not available')]
         [string[]] $IncludeJoinType = @('AzureAD registered'),
@@ -435,7 +441,7 @@ function Invoke-CloudDevicesCleanup {
         return
     }
 
-    $includeAutopilotInventory = $AutopilotState -ne 'Any' -or $OwnerState -ne 'Any' -or $IncludeAutopilotGroupTag.Count -gt 0 -or $ExcludeAutopilotGroupTag.Count -gt 0
+    $includeAutopilotInventory = $DeleteAutopilotIdentity -or $AutopilotState -ne 'Any' -or $OwnerState -ne 'Any' -or $IncludeAutopilotGroupTag.Count -gt 0 -or $ExcludeAutopilotGroupTag.Count -gt 0
     $allDevices = Get-InitialCloudDevices -SafetyEntraLimit $SafetyEntraLimit -SafetyIntuneLimit $SafetyIntuneLimit -IncludeJoinType $IncludeJoinType -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -IncludeOperatingSystemVersion $IncludeOperatingSystemVersion -ExcludeOperatingSystemVersion $ExcludeOperatingSystemVersion -IncludeUnknownOperatingSystem:$IncludeUnknownOperatingSystem -IncludeUnknownOperatingSystemVersion:$IncludeUnknownOperatingSystemVersion -Exclusions $Exclusions -IncludeAutopilotInventory:$includeAutopilotInventory
     if ($allDevices -eq $false) {
         return
@@ -481,7 +487,7 @@ function Invoke-CloudDevicesCleanup {
             $processDelete = $PSCmdlet.ShouldProcess("$($devicesToDelete.Count) cloud device(s)", 'Delete')
         }
         if ($processDelete) {
-            $reportDeleted = @(Request-CloudDevicesDelete -Devices $devicesToDelete -ProcessedDevices $processedDevices -Today $today -DeleteLimit $DeleteLimit -DeleteRemoveIntuneRecord:$DeleteRemoveIntuneRecord -ReportOnly:$ReportOnly -WhatIfDelete:$WhatIfDelete -WhatIf:$WhatIfPreference)
+            $reportDeleted = @(Request-CloudDevicesDelete -Devices $devicesToDelete -ProcessedDevices $processedDevices -Today $today -DeleteLimit $DeleteLimit -DeleteRemoveIntuneRecord:$DeleteRemoveIntuneRecord -DeleteAutopilotIdentity:$DeleteAutopilotIdentity -ReportOnly:$ReportOnly -WhatIfDelete:$WhatIfDelete -WhatIf:$WhatIfPreference)
         }
     }
 

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -435,7 +435,7 @@ function Invoke-CloudDevicesCleanup {
         return
     }
 
-    $includeAutopilotInventory = $AutopilotState -ne 'Any' -or $IncludeAutopilotGroupTag.Count -gt 0 -or $ExcludeAutopilotGroupTag.Count -gt 0
+    $includeAutopilotInventory = $AutopilotState -ne 'Any' -or $OwnerState -ne 'Any' -or $IncludeAutopilotGroupTag.Count -gt 0 -or $ExcludeAutopilotGroupTag.Count -gt 0
     $allDevices = Get-InitialCloudDevices -SafetyEntraLimit $SafetyEntraLimit -SafetyIntuneLimit $SafetyIntuneLimit -IncludeJoinType $IncludeJoinType -IncludeOperatingSystem $IncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -IncludeOperatingSystemVersion $IncludeOperatingSystemVersion -ExcludeOperatingSystemVersion $ExcludeOperatingSystemVersion -IncludeUnknownOperatingSystem:$IncludeUnknownOperatingSystem -IncludeUnknownOperatingSystemVersion:$IncludeUnknownOperatingSystemVersion -Exclusions $Exclusions -IncludeAutopilotInventory:$includeAutopilotInventory
     if ($allDevices -eq $false) {
         return

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -139,6 +139,10 @@ function Invoke-CloudDevicesCleanup {
     .PARAMETER IncludeUnknownOperatingSystemVersion
     Allows records with blank operating-system-version values when version filters are set.
 
+    .PARAMETER IncludeUnknownActivity
+    Allows blank Entra and Intune activity timestamps to satisfy configured LastSeen*MoreThan filters.
+    By default, unknown activity is treated as unsafe and excluded from destructive action selection.
+
     .PARAMETER AutopilotState
     Filters action candidates by Windows Autopilot inventory state: Any, Onboarded, or NotOnboarded.
     NotOnboarded only matches when Autopilot inventory was loaded successfully.
@@ -303,6 +307,7 @@ function Invoke-CloudDevicesCleanup {
         [Array] $ExcludeOperatingSystemVersion = @(),
         [switch] $IncludeUnknownOperatingSystem,
         [switch] $IncludeUnknownOperatingSystemVersion,
+        [switch] $IncludeUnknownActivity,
         [ValidateSet('Any', 'Onboarded', 'NotOnboarded')]
         [string] $AutopilotState = 'Any',
         [ValidateSet('Any', 'WithOwner', 'WithoutOwner')]
@@ -386,6 +391,7 @@ function Invoke-CloudDevicesCleanup {
         LastSeenIntuneMoreThan = $RetireLastSeenIntuneMoreThan
         LastSeenEntraMoreThan  = $RetireLastSeenEntraMoreThan
         RegisteredMoreThan     = $RetireRegisteredMoreThan
+        IncludeUnknownActivity = $IncludeUnknownActivity.IsPresent
         ExcludeCompanyOwned    = -not $IncludeCompanyOwned
         IncludeIntuneOnly      = $RetireIncludeIntuneOnly.IsPresent
         AutopilotState         = $AutopilotState
@@ -408,6 +414,7 @@ function Invoke-CloudDevicesCleanup {
         LastSeenIntuneMoreThan = $DisableLastSeenIntuneMoreThan
         RegisteredMoreThan     = $DisableRegisteredMoreThan
         ListProcessedMoreThan  = $DisableListProcessedMoreThan
+        IncludeUnknownActivity = $IncludeUnknownActivity.IsPresent
         ExcludeCompanyOwned    = -not $IncludeCompanyOwned
         IncludeEntraOnly       = $DisableIncludeEntraOnly.IsPresent
         AutopilotState         = $AutopilotState
@@ -430,6 +437,7 @@ function Invoke-CloudDevicesCleanup {
         LastSeenIntuneMoreThan = $DeleteLastSeenIntuneMoreThan
         RegisteredMoreThan     = $DeleteRegisteredMoreThan
         ListProcessedMoreThan  = $DeleteListProcessedMoreThan
+        IncludeUnknownActivity = $IncludeUnknownActivity.IsPresent
         ExcludeCompanyOwned    = -not $IncludeCompanyOwned
         IncludeEntraOnly       = $DeleteIncludeEntraOnly.IsPresent
         IncludeIntuneOnly      = $DeleteIncludeIntuneOnly.IsPresent

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -124,6 +124,54 @@ Describe 'Cloud device inventory and selection helpers' {
         $devices[0].ManagedDeviceId | Should -Be 'managed-2'
     }
 
+    It 'keeps Entra Autopilot metadata when matched Intune fields are missing' {
+        Mock Get-MyDevice {
+            @(
+                [PSCustomObject] @{
+                    Name                       = 'Windows-Autopilot-Matched'
+                    EntraDeviceObjectId        = 'entra-ap'
+                    DeviceId                   = 'device-ap'
+                    Enabled                    = $false
+                    OperatingSystem            = 'Windows'
+                    TrustType                  = 'AzureAD joined'
+                    LastSeenDays               = 250
+                    FirstSeen                  = (Get-Date).AddDays(-500)
+                    AutopilotInventoryLoaded   = $true
+                    AutopilotOnboarded         = $true
+                    AutopilotDeviceId          = 'entra-autopilot-id'
+                    AutopilotGroupTag          = 'DoNotDelete-Ring'
+                    AutopilotUserPrincipalName = 'assigned.user@contoso.com'
+                }
+            )
+        }
+        Mock Get-MyDeviceIntune {
+            @(
+                [PSCustomObject] @{
+                    Name                    = 'Windows-Autopilot-Matched'
+                    ManagedDeviceId         = 'managed-ap'
+                    EntraDeviceObjectId     = 'entra-ap'
+                    AzureAdDeviceId         = 'device-ap'
+                    OperatingSystem         = 'Windows'
+                    OperatingSystemVersion  = '10.0.22631.5624'
+                    LastSeenDays            = 250
+                    FirstSeen               = (Get-Date).AddDays(-500)
+                    ManagedDeviceOwnerType  = 'company'
+                    DeviceRegistrationState = 'joined'
+                    AzureAdRegistered       = $true
+                    ComplianceState         = 'unknown'
+                    ManagementAgent         = 'mdm'
+                }
+            )
+        }
+
+        $devices = @(Get-InitialCloudDevices -IncludeJoinType 'AzureAD joined' -IncludeOperatingSystem @('Windows*') -ExcludeOperatingSystem @() -Exclusions @())
+
+        $devices | Should -HaveCount 1
+        $devices[0].AutopilotDeviceId | Should -Be 'entra-autopilot-id'
+        $devices[0].AutopilotGroupTag | Should -Be 'DoNotDelete-Ring'
+        $devices[0].AutopilotUserPrincipalName | Should -Be 'assigned.user@contoso.com'
+    }
+
     It 'excludes hybrid and joined records from cloud cleanup inventory' {
         Mock Get-MyDevice {
             @(
@@ -676,6 +724,41 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
 
         $candidates.Count | Should -Be 0
+    }
+
+    It 'allows Windows devices with direct owner data through WithOwner when Autopilot inventory is unavailable' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                     = 'Windows-WithOwner'
+                EntraDeviceObjectId      = 'entra-with-owner'
+                DeviceId                 = 'device-with-owner'
+                ManagedDeviceId          = 'managed-with-owner'
+                HasEntraRecord           = $true
+                HasIntuneRecord          = $true
+                RecordState              = 'Matched'
+                ManagedDeviceOwnerType   = 'personal'
+                OperatingSystem          = 'Windows'
+                EntraLastSeenDays        = 300
+                Enabled                  = $true
+                OwnerDisplayName         = @('User One')
+                AutopilotInventoryLoaded = $false
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = $null
+            RegisteredMoreThan     = $null
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+            OwnerState             = 'WithOwner'
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
+
+        $candidates.Count | Should -Be 1
+        $candidates[0].Name | Should -Be 'Windows-WithOwner'
     }
 
     It 'allows retire candidates after a WhatIf preview entry exists' {

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -904,6 +904,68 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates.Count | Should -Be 0
     }
 
+    It 'does not treat unknown activity as stale unless explicitly included' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'Windows-UnknownActivity'
+                EntraDeviceObjectId    = 'entra-unknown-activity'
+                DeviceId               = 'device-unknown-activity'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $false
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = $null
+                RegisteredDays         = 200
+                Enabled                = $true
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 90
+            LastSeenIntuneMoreThan = $null
+            RegisteredMoreThan     = 90
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
+
+        $candidates.Count | Should -Be 0
+    }
+
+    It 'allows unknown activity to satisfy stale filters when explicitly included' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'Windows-UnknownActivityIncluded'
+                EntraDeviceObjectId    = 'entra-unknown-activity-included'
+                DeviceId               = 'device-unknown-activity-included'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $false
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = $null
+                RegisteredDays         = 200
+                Enabled                = $true
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 90
+            LastSeenIntuneMoreThan = $null
+            RegisteredMoreThan     = 90
+            IncludeUnknownActivity = $true
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
+
+        $candidates.Count | Should -Be 1
+        $candidates[0].SelectionReason | Should -Match 'EntraLastSeenDays=Unknown allowed'
+    }
+
     It 'promotes pending-aged devices when activity has not advanced' {
         $staleEntraLastSeen = (Get-Date).AddDays(-200)
         $staleIntuneLastSeen = (Get-Date).AddDays(-200)

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -323,6 +323,21 @@ Describe 'Cloud device inventory and selection helpers' {
         $result | Should -BeTrue
     }
 
+    It 'keeps synchronized or non-registered records out before mapping missing join metadata' {
+        $synchronized = [PSCustomObject] @{
+            DeviceRegistrationState = ''
+            IsSynchronized          = $true
+            AzureAdRegistered       = $true
+        }
+        $nonRegistered = [PSCustomObject] @{
+            DeviceRegistrationState = ''
+            AzureAdRegistered       = $false
+        }
+
+        Test-CloudDeviceRegistrationScope -Device $synchronized -IncludeJoinType 'Not available' | Should -BeFalse
+        Test-CloudDeviceRegistrationScope -Device $nonRegistered -IncludeJoinType 'Not available' | Should -BeFalse
+    }
+
     It 'applies managed-device exclusions to matched records' {
         Mock Get-MyDevice {
             @(

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -160,6 +160,8 @@ Describe 'Cloud device inventory and selection helpers' {
                     AzureAdRegistered       = $true
                     ComplianceState         = 'unknown'
                     ManagementAgent         = 'mdm'
+                    AutopilotInventoryLoaded = $null
+                    AutopilotOnboarded       = $null
                 }
             )
         }
@@ -167,9 +169,52 @@ Describe 'Cloud device inventory and selection helpers' {
         $devices = @(Get-InitialCloudDevices -IncludeJoinType 'AzureAD joined' -IncludeOperatingSystem @('Windows*') -ExcludeOperatingSystem @() -Exclusions @())
 
         $devices | Should -HaveCount 1
+        $devices[0].AutopilotInventoryLoaded | Should -BeTrue
+        $devices[0].AutopilotOnboarded | Should -BeTrue
         $devices[0].AutopilotDeviceId | Should -Be 'entra-autopilot-id'
         $devices[0].AutopilotGroupTag | Should -Be 'DoNotDelete-Ring'
         $devices[0].AutopilotUserPrincipalName | Should -Be 'assigned.user@contoso.com'
+    }
+
+    It 'preserves explicit false Intune Autopilot state over Entra fallback' {
+        Mock Get-MyDevice {
+            @(
+                [PSCustomObject] @{
+                    Name                     = 'Windows-NotAutopilot'
+                    EntraDeviceObjectId      = 'entra-not-ap'
+                    DeviceId                 = 'device-not-ap'
+                    Enabled                  = $false
+                    OperatingSystem          = 'Windows'
+                    TrustType                = 'AzureAD joined'
+                    LastSeenDays             = 250
+                    FirstSeen                = (Get-Date).AddDays(-500)
+                    AutopilotInventoryLoaded = $true
+                    AutopilotOnboarded       = $true
+                }
+            )
+        }
+        Mock Get-MyDeviceIntune {
+            @(
+                [PSCustomObject] @{
+                    Name                     = 'Windows-NotAutopilot'
+                    ManagedDeviceId          = 'managed-not-ap'
+                    AzureAdDeviceId          = 'device-not-ap'
+                    OperatingSystem          = 'Windows'
+                    OperatingSystemVersion   = '10.0.22631.5624'
+                    DeviceRegistrationState  = 'joined'
+                    AzureAdRegistered        = $true
+                    ManagementAgent          = 'mdm'
+                    AutopilotInventoryLoaded = $false
+                    AutopilotOnboarded       = $false
+                }
+            )
+        }
+
+        $devices = @(Get-InitialCloudDevices -IncludeJoinType 'AzureAD joined' -IncludeOperatingSystem @('Windows*') -ExcludeOperatingSystem @() -Exclusions @())
+
+        $devices | Should -HaveCount 1
+        $devices[0].AutopilotInventoryLoaded | Should -BeFalse
+        $devices[0].AutopilotOnboarded | Should -BeFalse
     }
 
     It 'excludes hybrid and joined records from cloud cleanup inventory' {

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -323,6 +323,48 @@ Describe 'Cloud device inventory and selection helpers' {
         $result | Should -BeTrue
     }
 
+    It 'does not pass Not available to the Entra inventory query' {
+        $script:CapturedEntraJoinType = $null
+        Mock Get-MyDevice {
+            param([string[]] $Type)
+            $script:CapturedEntraJoinType = @($Type)
+            @()
+        }
+        Mock Get-MyDeviceIntune { @() }
+
+        Get-InitialCloudDevices -IncludeJoinType 'AzureAD registered', 'Not available' -IncludeOperatingSystem @('*') -ExcludeOperatingSystem @() -Exclusions @() | Out-Null
+
+        $script:CapturedEntraJoinType | Should -Be @('AzureAD registered')
+    }
+
+    It 'skips Entra inventory when only Not available join type is requested' {
+        Mock Get-MyDevice { throw 'Entra inventory should not be queried' }
+        Mock Get-MyDeviceIntune {
+            @(
+                [PSCustomObject] @{
+                    Name                    = 'Unknown-State-Intune'
+                    ManagedDeviceId         = 'managed-unknown-state'
+                    AzureAdDeviceId         = 'device-unknown-state'
+                    OperatingSystem         = 'Unknown'
+                    OperatingSystemVersion  = 'Unknown'
+                    LastSeenDays            = 400
+                    FirstSeen               = (Get-Date).AddDays(-500)
+                    ManagedDeviceOwnerType  = 'personal'
+                    DeviceRegistrationState = ''
+                    AzureAdRegistered       = $true
+                    ComplianceState         = 'unknown'
+                    ManagementAgent         = 'mdm'
+                }
+            )
+        }
+
+        $devices = @(Get-InitialCloudDevices -IncludeJoinType 'Not available' -IncludeOperatingSystem @('*') -ExcludeOperatingSystem @() -Exclusions @())
+
+        Assert-MockCalled Get-MyDevice -Times 0 -Exactly
+        $devices | Should -HaveCount 1
+        $devices[0].Name | Should -Be 'Unknown-State-Intune'
+    }
+
     It 'keeps synchronized or non-registered records out before mapping missing join metadata' {
         $synchronized = [PSCustomObject] @{
             DeviceRegistrationState = ''

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -255,6 +255,16 @@ Describe 'Cloud device inventory and selection helpers' {
         $devices[0].TrustType | Should -Be 'AzureAD joined'
     }
 
+    It 'maps blank Intune registration state to not available when included' {
+        $device = [PSCustomObject] @{
+            DeviceRegistrationState = $null
+        }
+
+        $result = Test-CloudDeviceRegistrationScope -Device $device -IncludeJoinType 'Not available'
+
+        $result | Should -BeTrue
+    }
+
     It 'applies managed-device exclusions to matched records' {
         Mock Get-MyDevice {
             @(
@@ -584,7 +594,7 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates.Count | Should -Be 0
     }
 
-    It 'does not treat Windows devices as ownerless when Autopilot inventory was not loaded' {
+    It 'does not treat Windows devices as ownerless when Autopilot inventory state is unknown' {
         $devices = @(
             [PSCustomObject] @{
                 Name                     = 'Windows-UnknownOwner'
@@ -602,7 +612,7 @@ Describe 'Cloud device inventory and selection helpers' {
                 OwnerUserPrincipalName   = @()
                 IntuneUserDisplayName    = $null
                 IntuneUserPrincipalName  = $null
-                AutopilotInventoryLoaded = $false
+                AutopilotInventoryLoaded = $null
                 AutopilotUserPrincipalName = $null
             }
         )

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -3,6 +3,7 @@ BeforeAll {
     . (Get-CleanupMonsterPath 'Private/Test-CloudDeviceRegistrationScope.ps1')
     . (Get-CleanupMonsterPath 'Private/Test-CloudDeviceInventoryScope.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceRecordKeys.ps1')
+    . (Get-CleanupMonsterPath 'Private/Get-CloudDevicePropertyValue.ps1')
     . (Get-CleanupMonsterPath 'Private/Find-ProcessedCloudDeviceRecord.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-InitialCloudDevices.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceRecordKey.ps1')
@@ -401,6 +402,123 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates.Count | Should -Be 0
     }
 
+    It 'only treats missing Autopilot as not onboarded when Autopilot inventory was loaded' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                     = 'Windows-UnknownAutopilot'
+                EntraDeviceObjectId      = 'entra-ap-unknown'
+                DeviceId                 = 'device-ap-unknown'
+                ManagedDeviceId          = 'managed-ap-unknown'
+                HasEntraRecord           = $true
+                HasIntuneRecord          = $true
+                RecordState              = 'Matched'
+                ManagedDeviceOwnerType   = 'personal'
+                EntraLastSeenDays        = 300
+                IntuneLastSeenDays       = 300
+                Enabled                  = $true
+                AutopilotInventoryLoaded = $false
+                AutopilotOnboarded       = $null
+            }
+            [PSCustomObject] @{
+                Name                     = 'Windows-NotAutopilot'
+                EntraDeviceObjectId      = 'entra-ap-no'
+                DeviceId                 = 'device-ap-no'
+                ManagedDeviceId          = 'managed-ap-no'
+                HasEntraRecord           = $true
+                HasIntuneRecord          = $true
+                RecordState              = 'Matched'
+                ManagedDeviceOwnerType   = 'personal'
+                EntraLastSeenDays        = 300
+                IntuneLastSeenDays       = 300
+                Enabled                  = $true
+                AutopilotInventoryLoaded = $true
+                AutopilotOnboarded       = $false
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = $null
+            RegisteredMoreThan     = $null
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+            AutopilotState         = 'NotOnboarded'
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
+
+        $candidates.Count | Should -Be 1
+        $candidates[0].Name | Should -Be 'Windows-NotAutopilot'
+    }
+
+    It 'filters action candidates by owner, management, compliance, and registration age' {
+        $oldRegistration = (Get-Date).AddDays(-500)
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'Windows-Delete'
+                EntraDeviceObjectId    = 'entra-delete'
+                DeviceId               = 'device-delete'
+                ManagedDeviceId        = 'managed-delete'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = 400
+                IntuneLastSeenDays     = 400
+                FirstSeen              = $oldRegistration
+                RegisteredDays         = 500
+                Enabled                = $false
+                OwnerDisplayName       = @()
+                OwnerUserPrincipalName = @()
+                IsManaged              = $true
+                ManagementAgent        = 'mdm'
+                IsCompliant            = $false
+                ComplianceState        = 'noncompliant'
+            }
+            [PSCustomObject] @{
+                Name                   = 'Windows-Keep-Owner'
+                EntraDeviceObjectId    = 'entra-owner'
+                DeviceId               = 'device-owner'
+                ManagedDeviceId        = 'managed-owner'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = 400
+                IntuneLastSeenDays     = 400
+                RegisteredDays         = 500
+                Enabled                = $false
+                OwnerDisplayName       = @('User One')
+                IsManaged              = $true
+                ManagementAgent        = 'mdm'
+                IsCompliant            = $false
+                ComplianceState        = 'noncompliant'
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = $null
+            RegisteredMoreThan     = 365
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+            IncludeIntuneOnly      = $false
+            OwnerState             = 'WithoutOwner'
+            ManagementState        = 'Mdm'
+            ComplianceState        = 'NonCompliant'
+            EnabledState           = 'Disabled'
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
+
+        $candidates.Count | Should -Be 1
+        $candidates[0].Name | Should -Be 'Windows-Delete'
+        $candidates[0].SelectionReason | Should -Match 'RegisteredDays=500 > 365'
+        $candidates[0].SelectionReason | Should -Match 'OwnerState=WithoutOwner'
+    }
+
     It 'allows retire candidates after a WhatIf preview entry exists' {
         $devices = @(
             [PSCustomObject] @{
@@ -781,6 +899,12 @@ Describe 'Cloud device inventory and selection helpers' {
         $result = Test-CloudDeviceInventoryScope -OperatingSystem $null -IncludeOperatingSystem @('iOS*') -ExcludeOperatingSystem @() -Exclusions @()
 
         $result | Should -BeFalse
+    }
+
+    It 'can keep missing operating system and version values when explicitly allowed' {
+        $result = Test-CloudDeviceInventoryScope -OperatingSystem $null -OperatingSystemVersion $null -IncludeOperatingSystem @('Windows*') -ExcludeOperatingSystem @() -IncludeOperatingSystemVersion @('10.0*') -ExcludeOperatingSystemVersion @() -IncludeUnknownOperatingSystem -IncludeUnknownOperatingSystemVersion -Exclusions @()
+
+        $result | Should -BeTrue
     }
 
     It 'does not include Intune-only records in disable selection' {

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -1,5 +1,6 @@
 BeforeAll {
     . "$PSScriptRoot\TestHelpers.ps1"
+    . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceJoinTypeFromRegistrationState.ps1')
     . (Get-CleanupMonsterPath 'Private/Test-CloudDeviceRegistrationScope.ps1')
     . (Get-CleanupMonsterPath 'Private/Test-CloudDeviceInventoryScope.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceRecordKeys.ps1')
@@ -222,6 +223,36 @@ Describe 'Cloud device inventory and selection helpers' {
         $devices.Name | Should -Not -Contain 'Hybrid-Intune'
         $devices.Name | Should -Not -Contain 'Joined-State-Intune'
         $devices.Name | Should -Not -Contain 'Unknown-State-Intune'
+    }
+
+    It 'maps joined Intune-only registration state when AzureAD joined is included' {
+        Mock Get-MyDevice { @() }
+        Mock Get-MyDeviceIntune {
+            @(
+                [PSCustomObject] @{
+                    Name                    = 'Windows-Joined-Orphan'
+                    ManagedDeviceId         = 'managed-joined-orphan'
+                    EntraDeviceObjectId     = $null
+                    AzureAdDeviceId         = 'device-joined-orphan'
+                    OperatingSystem         = 'Windows'
+                    OperatingSystemVersion  = '10.0.22631.5624'
+                    LastSeen                = (Get-Date).AddDays(-190)
+                    LastSeenDays            = 190
+                    FirstSeen               = (Get-Date).AddDays(-400)
+                    ManagedDeviceOwnerType  = 'personal'
+                    DeviceRegistrationState = 'joined'
+                    AzureAdRegistered       = $true
+                    ComplianceState         = 'unknown'
+                    ManagementAgent         = 'mdm'
+                }
+            )
+        }
+
+        $devices = @(Get-InitialCloudDevices -IncludeJoinType 'AzureAD joined' -IncludeOperatingSystem @('Windows*') -ExcludeOperatingSystem @() -Exclusions @())
+
+        $devices.Count | Should -Be 1
+        $devices[0].Name | Should -Be 'Windows-Joined-Orphan'
+        $devices[0].TrustType | Should -Be 'AzureAD joined'
     }
 
     It 'applies managed-device exclusions to matched records' {
@@ -517,6 +548,78 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates[0].Name | Should -Be 'Windows-Delete'
         $candidates[0].SelectionReason | Should -Match 'RegisteredDays=500 > 365'
         $candidates[0].SelectionReason | Should -Match 'OwnerState=WithoutOwner'
+    }
+
+    It 'skips Autopilot group-tag exclusion when Autopilot inventory was not loaded' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                     = 'Windows-UnknownTag'
+                EntraDeviceObjectId      = 'entra-unknown-tag'
+                DeviceId                 = 'device-unknown-tag'
+                ManagedDeviceId          = 'managed-unknown-tag'
+                HasEntraRecord           = $true
+                HasIntuneRecord          = $true
+                RecordState              = 'Matched'
+                ManagedDeviceOwnerType   = 'personal'
+                OperatingSystem          = 'Windows'
+                EntraLastSeenDays        = 300
+                Enabled                  = $true
+                AutopilotInventoryLoaded = $false
+                AutopilotGroupTag        = $null
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan    = 180
+            LastSeenIntuneMoreThan   = $null
+            RegisteredMoreThan       = $null
+            ListProcessedMoreThan    = $null
+            ExcludeCompanyOwned      = $true
+            IncludeEntraOnly         = $false
+            ExcludeAutopilotGroupTag = @('DoNotDelete*')
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
+
+        $candidates.Count | Should -Be 0
+    }
+
+    It 'does not treat Windows devices as ownerless when Autopilot inventory was not loaded' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                     = 'Windows-UnknownOwner'
+                EntraDeviceObjectId      = 'entra-unknown-owner'
+                DeviceId                 = 'device-unknown-owner'
+                ManagedDeviceId          = 'managed-unknown-owner'
+                HasEntraRecord           = $true
+                HasIntuneRecord          = $true
+                RecordState              = 'Matched'
+                ManagedDeviceOwnerType   = 'personal'
+                OperatingSystem          = 'Windows'
+                EntraLastSeenDays        = 300
+                Enabled                  = $true
+                OwnerDisplayName         = @()
+                OwnerUserPrincipalName   = @()
+                IntuneUserDisplayName    = $null
+                IntuneUserPrincipalName  = $null
+                AutopilotInventoryLoaded = $false
+                AutopilotUserPrincipalName = $null
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = $null
+            RegisteredMoreThan     = $null
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+            OwnerState             = 'WithoutOwner'
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
+
+        $candidates.Count | Should -Be 0
     }
 
     It 'allows retire candidates after a WhatIf preview entry exists' {

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -265,6 +265,16 @@ Describe 'Cloud device inventory and selection helpers' {
         $result | Should -BeTrue
     }
 
+    It 'maps missing Intune registration state to not available when included' {
+        $device = [PSCustomObject] @{
+            Name = 'Unknown-State-Intune'
+        }
+
+        $result = Test-CloudDeviceRegistrationScope -Device $device -IncludeJoinType 'Not available'
+
+        $result | Should -BeTrue
+    }
+
     It 'applies managed-device exclusions to matched records' {
         Mock Get-MyDevice {
             @(
@@ -558,6 +568,42 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates[0].Name | Should -Be 'Windows-Delete'
         $candidates[0].SelectionReason | Should -Match 'RegisteredDays=500 > 365'
         $candidates[0].SelectionReason | Should -Match 'OwnerState=WithoutOwner'
+    }
+
+    It 'prefers Intune compliance state over Entra compliance flag' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                   = 'Windows-ConflictingCompliance'
+                EntraDeviceObjectId    = 'entra-conflict'
+                DeviceId               = 'device-conflict'
+                ManagedDeviceId        = 'managed-conflict'
+                HasEntraRecord         = $true
+                HasIntuneRecord        = $true
+                RecordState            = 'Matched'
+                ManagedDeviceOwnerType = 'personal'
+                EntraLastSeenDays      = 400
+                RegisteredDays         = 500
+                Enabled                = $false
+                IsCompliant            = $true
+                ComplianceState        = 'noncompliant'
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan  = 180
+            LastSeenIntuneMoreThan = $null
+            RegisteredMoreThan     = $null
+            ListProcessedMoreThan  = $null
+            ExcludeCompanyOwned    = $true
+            IncludeEntraOnly       = $false
+            IncludeIntuneOnly      = $false
+            ComplianceState        = 'NonCompliant'
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Delete -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
+
+        $candidates.Count | Should -Be 1
+        $candidates[0].Name | Should -Be 'Windows-ConflictingCompliance'
     }
 
     It 'skips Autopilot group-tag exclusion when Autopilot inventory was not loaded' {

--- a/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
+++ b/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
@@ -12,6 +12,7 @@ BeforeAll {
     function Get-CloudDevicesToProcess { @() }
     function Request-CloudDevicesRetire { @() }
     function Request-CloudDevicesDisable { @() }
+    function Request-CloudDevicesStageDelete { @() }
     function Request-CloudDevicesDelete { @() }
     function New-HTMLProcessedCloudDevices {}
     function New-EmailBodyCloudDevices { param($CurrentRun) '' }
@@ -258,6 +259,61 @@ Describe 'Invoke-CloudDevicesCleanup' {
 
         $script:capturedIncludeAutopilotInventory | Should -BeTrue
         $script:capturedDeleteAutopilotIdentity | Should -BeTrue
+    }
+
+    It 'stages already disabled delete candidates without running delete' {
+        $script:stageDeleteCalled = $false
+        $script:deleteCalled = $false
+
+        Mock Get-InitialCloudDevices {
+            @(
+                [PSCustomObject] @{
+                    Name                = 'Windows-AlreadyDisabled'
+                    EntraDeviceObjectId = 'entra-stage'
+                    HasEntraRecord      = $true
+                    Enabled             = $false
+                }
+            )
+        }
+        Mock Get-CloudDevicesToProcess {
+            @(
+                [PSCustomObject] @{
+                    Name                = 'Windows-AlreadyDisabled'
+                    EntraDeviceObjectId = 'entra-stage'
+                    HasEntraRecord      = $true
+                    Enabled             = $false
+                    ProcessedDeviceKey  = 'entra:entra-stage'
+                    ProcessedDeviceKeys = @('entra:entra-stage')
+                }
+            )
+        }
+        Mock Request-CloudDevicesStageDelete {
+            param(
+                $StageLimit,
+                [switch] $WhatIfStageDelete,
+                [switch] $WhatIf
+            )
+
+            $script:stageDeleteCalled = $true
+            $StageLimit | Should -Be 7
+            $WhatIfStageDelete.IsPresent | Should -BeTrue
+            @(
+                [PSCustomObject] @{
+                    Name         = 'Windows-AlreadyDisabled'
+                    Action       = 'StageDelete'
+                    ActionStatus = 'WhatIf'
+                }
+            )
+        }
+        Mock Request-CloudDevicesDelete {
+            $script:deleteCalled = $true
+            @()
+        }
+
+        Invoke-CloudDevicesCleanup -StageDisabledForDelete -StageDisabledForDeleteLimit 7 -WhatIfStageDelete -Suppress | Out-Null
+
+        $script:stageDeleteCalled | Should -BeTrue
+        $script:deleteCalled | Should -BeFalse
     }
 
     It 'skips action request stages when no candidates are selected' {

--- a/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
+++ b/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
@@ -123,6 +123,29 @@ Describe 'Invoke-CloudDevicesCleanup' {
         $script:capturedRetireExcludeCompanyOwned | Should -BeFalse
     }
 
+    It 'passes unknown activity inclusion to candidate selection' {
+        $script:capturedIncludeUnknownActivity = $null
+
+        Mock Get-InitialCloudDevices { @() }
+        Mock Get-CloudDevicesToProcess {
+            param(
+                $Type,
+                $Devices,
+                $ActionIf,
+                $ProcessedDevices
+            )
+
+            if ($Type -eq 'Disable') {
+                $script:capturedIncludeUnknownActivity = $ActionIf.IncludeUnknownActivity
+            }
+            @()
+        }
+
+        Invoke-CloudDevicesCleanup -Disable -IncludeUnknownActivity -Suppress | Out-Null
+
+        $script:capturedIncludeUnknownActivity | Should -BeTrue
+    }
+
     It 'does not include orphan states for actions unless explicitly requested' {
         $script:capturedRetireIncludeIntuneOnly = $null
         $script:capturedDisableIncludeEntraOnly = $null

--- a/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
+++ b/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
@@ -200,6 +200,66 @@ Describe 'Invoke-CloudDevicesCleanup' {
         $script:capturedDeleteIncludeIntuneOnly | Should -BeTrue
     }
 
+    It 'loads Autopilot inventory and passes Autopilot delete through when requested' {
+        $script:capturedIncludeAutopilotInventory = $null
+        $script:capturedDeleteAutopilotIdentity = $null
+
+        Mock Get-InitialCloudDevices {
+            param(
+                [switch] $IncludeAutopilotInventory
+            )
+
+            $script:capturedIncludeAutopilotInventory = $IncludeAutopilotInventory.IsPresent
+            @(
+                [PSCustomObject] @{
+                    Name                     = 'Windows-Autopilot'
+                    EntraDeviceObjectId      = 'entra-ap'
+                    ManagedDeviceId          = 'managed-ap'
+                    AutopilotInventoryLoaded = $true
+                    AutopilotOnboarded       = $true
+                    AutopilotDeviceId        = 'autopilot-ap'
+                    HasEntraRecord           = $true
+                    HasIntuneRecord          = $true
+                }
+            )
+        }
+        Mock Get-CloudDevicesToProcess {
+            @(
+                [PSCustomObject] @{
+                    Name                     = 'Windows-Autopilot'
+                    EntraDeviceObjectId      = 'entra-ap'
+                    ManagedDeviceId          = 'managed-ap'
+                    AutopilotInventoryLoaded = $true
+                    AutopilotOnboarded       = $true
+                    AutopilotDeviceId        = 'autopilot-ap'
+                    HasEntraRecord           = $true
+                    HasIntuneRecord          = $true
+                    ProcessedDeviceKey       = 'entra:entra-ap'
+                    ProcessedDeviceKeys      = @('entra:entra-ap', 'intune:managed-ap')
+                }
+            )
+        }
+        Mock Request-CloudDevicesDelete {
+            param(
+                [switch] $DeleteAutopilotIdentity
+            )
+
+            $script:capturedDeleteAutopilotIdentity = $DeleteAutopilotIdentity.IsPresent
+            @(
+                [PSCustomObject] @{
+                    Name         = 'Windows-Autopilot'
+                    Action       = 'Delete'
+                    ActionStatus = 'WhatIf'
+                }
+            )
+        }
+
+        Invoke-CloudDevicesCleanup -Delete -DeleteAutopilotIdentity -WhatIfDelete -Suppress | Out-Null
+
+        $script:capturedIncludeAutopilotInventory | Should -BeTrue
+        $script:capturedDeleteAutopilotIdentity | Should -BeTrue
+    }
+
     It 'skips action request stages when no candidates are selected' {
         Mock Get-InitialCloudDevices { @() }
         Mock Get-CloudDevicesToProcess { @() }

--- a/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
+++ b/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
@@ -333,10 +333,20 @@ Describe 'Invoke-CloudDevicesCleanup' {
             @()
         }
 
-        Invoke-CloudDevicesCleanup -StageDisabledForDelete -StageDisabledForDeleteLimit 7 -WhatIfStageDelete -Suppress | Out-Null
+        Invoke-CloudDevicesCleanup -StageDisabledForDelete -StageDisabledForDeleteLimit 7 -DeleteLastSeenEntraMoreThan 180 -WhatIfStageDelete -Suppress | Out-Null
 
         $script:stageDeleteCalled | Should -BeTrue
         $script:deleteCalled | Should -BeFalse
+    }
+
+    It 'does not stage disabled devices without stale delete criteria' {
+        Mock Get-InitialCloudDevices { throw 'Inventory should not be queried' }
+        Mock Request-CloudDevicesStageDelete { throw 'Stage delete should not run' }
+
+        Invoke-CloudDevicesCleanup -StageDisabledForDelete -Suppress | Out-Null
+
+        Assert-MockCalled Get-InitialCloudDevices -Times 0 -Exactly
+        Assert-MockCalled Request-CloudDevicesStageDelete -Times 0 -Exactly
     }
 
     It 'skips action request stages when no candidates are selected' {

--- a/Tests/Request-CloudDeviceActions.Tests.ps1
+++ b/Tests/Request-CloudDeviceActions.Tests.ps1
@@ -295,6 +295,7 @@ Describe 'Request-CloudDevicesDelete' {
                 Name                     = 'Windows-UnknownAutopilot'
                 EntraDeviceObjectId      = 'entra-unknown-ap'
                 ManagedDeviceId          = 'managed-unknown-ap'
+                OperatingSystem          = 'Windows'
                 AutopilotInventoryLoaded = $false
                 AutopilotOnboarded       = $null
                 HasEntraRecord           = $true
@@ -314,6 +315,45 @@ Describe 'Request-CloudDevicesDelete' {
         Assert-MockCalled Remove-MyDeviceIntuneRecord -Times 0 -Exactly
         Assert-MockCalled Remove-MyDevice -Times 0 -Exactly
         $processedDevices.Contains('entra:entra-unknown-ap') | Should -BeTrue
+    }
+
+    It 'does not require Autopilot inventory before deleting non-Windows records' {
+        Mock Remove-MyDeviceIntuneRecord { [PSCustomObject] @{ Success = $true; Message = 'Removed Intune record' } }
+        Mock Remove-MyDevice { [PSCustomObject] @{ Success = $true; Message = 'Removed Entra record' } }
+
+        $processedDevices = [ordered] @{
+            'entra:entra-ios' = [PSCustomObject] @{
+                Action       = 'Disable'
+                ActionStatus = 'True'
+                ActionDate   = (Get-Date).AddDays(-35)
+            }
+        }
+
+        $devices = @(
+            [PSCustomObject] @{
+                Name                     = 'iPhone-Old'
+                EntraDeviceObjectId      = 'entra-ios'
+                ManagedDeviceId          = 'managed-ios'
+                OperatingSystem          = 'iOS'
+                AutopilotInventoryLoaded = $false
+                AutopilotOnboarded       = $null
+                HasEntraRecord           = $true
+                HasIntuneRecord          = $true
+                RecordState              = 'Matched'
+                ProcessedDeviceKey       = 'entra:entra-ios'
+                ProcessedDeviceKeys      = @('entra:entra-ios', 'intune:managed-ios')
+            }
+        )
+
+        $results = @(Request-CloudDevicesDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -DeleteAutopilotIdentity)
+
+        $results | Should -HaveCount 1
+        $results[0].ActionStatus | Should -Be 'True'
+        $results[0].ActionNotes | Should -Not -Match 'Autopilot: Inventory was not loaded'
+        Assert-MockCalled Remove-MyAutopilotDevice -Times 0 -Exactly
+        Assert-MockCalled Remove-MyDeviceIntuneRecord -Times 1 -Exactly
+        Assert-MockCalled Remove-MyDevice -Times 1 -Exactly
+        $processedDevices.Contains('entra:entra-ios') | Should -BeFalse
     }
 
     It 'does not delete records when an onboarded Autopilot identity cannot be removed' {

--- a/Tests/Request-CloudDeviceActions.Tests.ps1
+++ b/Tests/Request-CloudDeviceActions.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     . (Get-CleanupMonsterPath 'Private/Set-ProcessedCloudDeviceRecord.ps1')
     . (Get-CleanupMonsterPath 'Private/Request-CloudDevicesRetire.ps1')
     . (Get-CleanupMonsterPath 'Private/Request-CloudDevicesDisable.ps1')
+    . (Get-CleanupMonsterPath 'Private/Request-CloudDevicesStageDelete.ps1')
     . (Get-CleanupMonsterPath 'Private/Request-CloudDevicesDelete.ps1')
 
     function Invoke-MyDeviceRetire {}
@@ -134,6 +135,71 @@ Describe 'Request-CloudDevicesDisable' {
         $results | Should -HaveCount 1
         $results[0].ActionStatus | Should -Be 'False'
         Assert-MockCalled Disable-MyDevice -Times 1 -Exactly
+    }
+}
+
+Describe 'Request-CloudDevicesStageDelete' {
+    It 'stages already disabled candidates into pending actions' {
+        $processedDevices = [ordered] @{}
+        $devices = @(
+            [PSCustomObject] @{
+                Name                = 'Windows-AlreadyDisabled'
+                EntraDeviceObjectId = 'entra-stage'
+                HasEntraRecord      = $true
+                Enabled             = $false
+                ProcessedDeviceKey  = 'entra:entra-stage'
+                ProcessedDeviceKeys = @('entra:entra-stage')
+            }
+        )
+
+        $results = @(Request-CloudDevicesStageDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date))
+
+        $results | Should -HaveCount 1
+        $results[0].Action | Should -Be 'StageDelete'
+        $results[0].ActionStatus | Should -Be 'True'
+        $processedDevices.Contains('entra:entra-stage') | Should -BeTrue
+    }
+
+    It 'does not store WhatIf stage-delete results in pending actions' {
+        $processedDevices = [ordered] @{}
+        $devices = @(
+            [PSCustomObject] @{
+                Name                = 'Windows-StagePreview'
+                EntraDeviceObjectId = 'entra-stage-preview'
+                ProcessedDeviceKey  = 'entra:entra-stage-preview'
+                ProcessedDeviceKeys = @('entra:entra-stage-preview')
+            }
+        )
+
+        $results = @(Request-CloudDevicesStageDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -WhatIfStageDelete)
+
+        $results | Should -HaveCount 1
+        $results[0].ActionStatus | Should -Be 'WhatIf'
+        $processedDevices.Count | Should -Be 0
+    }
+
+    It 'skips candidates that are already pending' {
+        $processedDevices = [ordered] @{
+            'entra:entra-stage-existing' = [PSCustomObject] @{
+                Action       = 'StageDelete'
+                ActionStatus = 'True'
+                ActionDate   = (Get-Date).AddDays(-5)
+            }
+        }
+        $devices = @(
+            [PSCustomObject] @{
+                Name                      = 'Windows-AlreadyPending'
+                EntraDeviceObjectId       = 'entra-stage-existing'
+                ProcessedDeviceKey        = 'entra:entra-stage-existing'
+                MatchedProcessedDeviceKey = 'entra:entra-stage-existing'
+                ProcessedDeviceKeys       = @('entra:entra-stage-existing')
+            }
+        )
+
+        $results = @(Request-CloudDevicesStageDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date))
+
+        $results | Should -HaveCount 0
+        $processedDevices.Count | Should -Be 1
     }
 }
 

--- a/Tests/Request-CloudDeviceActions.Tests.ps1
+++ b/Tests/Request-CloudDeviceActions.Tests.ps1
@@ -8,6 +8,7 @@ BeforeAll {
 
     function Invoke-MyDeviceRetire {}
     function Disable-MyDevice {}
+    function Remove-MyAutopilotDevice {}
     function Remove-MyDevice {}
     function Remove-MyDeviceIntuneRecord {}
 }
@@ -138,6 +139,7 @@ Describe 'Request-CloudDevicesDisable' {
 
 Describe 'Request-CloudDevicesDelete' {
     BeforeEach {
+        Mock Remove-MyAutopilotDevice {}
         Mock Remove-MyDevice {}
         Mock Remove-MyDeviceIntuneRecord {}
     }
@@ -168,6 +170,122 @@ Describe 'Request-CloudDevicesDelete' {
         $processedDevices.Contains('device:device-2') | Should -BeTrue
         Assert-MockCalled Remove-MyDevice -Times 0 -Exactly
         Assert-MockCalled Remove-MyDeviceIntuneRecord -Times 0 -Exactly
+        Assert-MockCalled Remove-MyAutopilotDevice -Times 0 -Exactly
+    }
+
+    It 'removes an Autopilot identity before deleting Intune and Entra records when requested' {
+        Mock Remove-MyAutopilotDevice { [PSCustomObject] @{ Success = $true; Message = 'Removed Autopilot identity' } }
+        Mock Remove-MyDeviceIntuneRecord { [PSCustomObject] @{ Success = $true; Message = 'Removed Intune record' } }
+        Mock Remove-MyDevice { [PSCustomObject] @{ Success = $true; Message = 'Removed Entra record' } }
+
+        $processedDevices = [ordered] @{
+            'entra:entra-ap' = [PSCustomObject] @{
+                Action       = 'Disable'
+                ActionStatus = 'True'
+                ActionDate   = (Get-Date).AddDays(-35)
+            }
+        }
+
+        $devices = @(
+            [PSCustomObject] @{
+                Name                     = 'Windows-Autopilot'
+                EntraDeviceObjectId      = 'entra-ap'
+                ManagedDeviceId          = 'managed-ap'
+                AutopilotInventoryLoaded = $true
+                AutopilotOnboarded       = $true
+                AutopilotDeviceId        = 'autopilot-ap'
+                HasEntraRecord           = $true
+                HasIntuneRecord          = $true
+                RecordState              = 'Matched'
+                ProcessedDeviceKey       = 'entra:entra-ap'
+                ProcessedDeviceKeys      = @('entra:entra-ap', 'intune:managed-ap')
+            }
+        )
+
+        $results = @(Request-CloudDevicesDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -DeleteAutopilotIdentity)
+
+        $results | Should -HaveCount 1
+        $results[0].ActionStatus | Should -Be 'True'
+        $results[0].ActionNotes | Should -Match 'Autopilot: Removed Autopilot identity'
+        $results[0].ActionNotes | Should -Match 'Intune: Removed Intune record'
+        $results[0].ActionNotes | Should -Match 'Entra: Removed Entra record'
+        Assert-MockCalled Remove-MyAutopilotDevice -Times 1 -Exactly
+        Assert-MockCalled Remove-MyDeviceIntuneRecord -Times 1 -Exactly
+        Assert-MockCalled Remove-MyDevice -Times 1 -Exactly
+        $processedDevices.Contains('entra:entra-ap') | Should -BeFalse
+    }
+
+    It 'does not delete records when requested Autopilot inventory is unavailable' {
+        $processedDevices = [ordered] @{
+            'entra:entra-unknown-ap' = [PSCustomObject] @{
+                Action       = 'Disable'
+                ActionStatus = 'True'
+                ActionDate   = (Get-Date).AddDays(-35)
+            }
+        }
+
+        $devices = @(
+            [PSCustomObject] @{
+                Name                     = 'Windows-UnknownAutopilot'
+                EntraDeviceObjectId      = 'entra-unknown-ap'
+                ManagedDeviceId          = 'managed-unknown-ap'
+                AutopilotInventoryLoaded = $false
+                AutopilotOnboarded       = $null
+                HasEntraRecord           = $true
+                HasIntuneRecord          = $true
+                RecordState              = 'Matched'
+                ProcessedDeviceKey       = 'entra:entra-unknown-ap'
+                ProcessedDeviceKeys      = @('entra:entra-unknown-ap', 'intune:managed-unknown-ap')
+            }
+        )
+
+        $results = @(Request-CloudDevicesDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -DeleteAutopilotIdentity)
+
+        $results | Should -HaveCount 1
+        $results[0].ActionStatus | Should -Be 'False'
+        $results[0].ActionNotes | Should -Match 'Autopilot: Inventory was not loaded'
+        Assert-MockCalled Remove-MyAutopilotDevice -Times 0 -Exactly
+        Assert-MockCalled Remove-MyDeviceIntuneRecord -Times 0 -Exactly
+        Assert-MockCalled Remove-MyDevice -Times 0 -Exactly
+        $processedDevices.Contains('entra:entra-unknown-ap') | Should -BeTrue
+    }
+
+    It 'does not delete records when an onboarded Autopilot identity cannot be removed' {
+        Mock Remove-MyAutopilotDevice { [PSCustomObject] @{ Success = $false; Message = 'Autopilot removal failed' } }
+
+        $processedDevices = [ordered] @{
+            'entra:entra-ap-fail' = [PSCustomObject] @{
+                Action       = 'Disable'
+                ActionStatus = 'True'
+                ActionDate   = (Get-Date).AddDays(-35)
+            }
+        }
+
+        $devices = @(
+            [PSCustomObject] @{
+                Name                     = 'Windows-Autopilot-Fail'
+                EntraDeviceObjectId      = 'entra-ap-fail'
+                ManagedDeviceId          = 'managed-ap-fail'
+                AutopilotInventoryLoaded = $true
+                AutopilotOnboarded       = $true
+                AutopilotDeviceId        = 'autopilot-ap-fail'
+                HasEntraRecord           = $true
+                HasIntuneRecord          = $true
+                RecordState              = 'Matched'
+                ProcessedDeviceKey       = 'entra:entra-ap-fail'
+                ProcessedDeviceKeys      = @('entra:entra-ap-fail', 'intune:managed-ap-fail')
+            }
+        )
+
+        $results = @(Request-CloudDevicesDelete -Devices $devices -ProcessedDevices $processedDevices -Today (Get-Date) -DeleteAutopilotIdentity)
+
+        $results | Should -HaveCount 1
+        $results[0].ActionStatus | Should -Be 'False'
+        $results[0].ActionNotes | Should -Match 'Autopilot: Autopilot removal failed'
+        Assert-MockCalled Remove-MyAutopilotDevice -Times 1 -Exactly
+        Assert-MockCalled Remove-MyDeviceIntuneRecord -Times 0 -Exactly
+        Assert-MockCalled Remove-MyDevice -Times 0 -Exactly
+        $processedDevices.Contains('entra:entra-ap-fail') | Should -BeTrue
     }
 
     It 'does not remove Entra objects for Intune-only delete candidates' {
@@ -200,6 +318,7 @@ Describe 'Request-CloudDevicesDelete' {
         $results[0].ActionNotes | Should -Match 'Intune: Removed Intune record'
         Assert-MockCalled Remove-MyDevice -Times 0 -Exactly
         Assert-MockCalled Remove-MyDeviceIntuneRecord -Times 1 -Exactly
+        Assert-MockCalled Remove-MyAutopilotDevice -Times 0 -Exactly
     }
 
     It 'counts failed delete attempts toward the delete limit' {


### PR DESCRIPTION
## Summary
- adds advanced cloud-device cleanup filters for join type, OS/version, Autopilot state/group tag, owner presence, management/MDM state, compliance state, enabled state, enrollment type, device registration state, and registration age
- adds `-DeleteAutopilotIdentity` so Autopilot identities are removed before Intune/Entra delete sub-actions
- adds `-StageDisabledForDelete` so already-disabled stale devices can enter `PendingActions` and wait the normal delete grace period
- adds `-IncludeUnknownActivity` to explicitly treat blank Entra/Intune activity as stale when matching hybrid "never synced/seen" semantics
- bumps the cloud cleanup GraphEssentials requirement to `0.0.58`

## Dependency
- Depends on GraphEssentials PR: https://github.com/EvotecIT/GraphEssentials/pull/19

## Safety Notes
- Unknown activity remains excluded by default unless `-IncludeUnknownActivity` is set.
- Autopilot identity removal is opt-in; if Autopilot inventory or identity removal fails, Intune/Entra deletion is skipped for that device.
- Already-disabled devices are staged, not deleted, when using `-StageDisabledForDelete`.

## Validation
- `Invoke-Pester -Path .\Tests -Output Detailed` - 104 passed
- GitHub Actions: PowerShell 7 and Windows PowerShell 5.1 passed
- `git diff --check`
