### PR TITLE
Preserve Autopilot duplicate device groups

### DIFF
--- a/Private/Get-CloudDevicesToProcess.ps1
+++ b/Private/Get-CloudDevicesToProcess.ps1
@@ -165,6 +165,20 @@ function Get-CloudDevicesToProcess {
         $true
     }
 
+    function Test-CloudDeviceDuplicateNameProtection {
+        param([Parameter(Mandatory)] [object] $Device)
+
+        if ($ActionIf.PreserveDuplicateDeviceNames -ne $true) {
+            return $false
+        }
+
+        if ($Device.PSObject.Properties['PreserveDuplicateNameGroup'] -and $Device.PreserveDuplicateNameGroup -eq $true) {
+            return $true
+        }
+
+        $false
+    }
+
     Write-Color -Text '[i] ', "Applying following rules to $Type action:" -Color Yellow, Cyan, Green
     foreach ($key in $ActionIf.Keys) {
         if ($null -eq $ActionIf[$key] -or ($ActionIf[$key] -is [System.Array] -and $ActionIf[$key].Count -eq 0)) {
@@ -189,6 +203,10 @@ function Get-CloudDevicesToProcess {
         }
 
         if ($ActionIf.ExcludeCompanyOwned -and $device.ManagedDeviceOwnerType -eq 'company') {
+            continue
+        }
+
+        if (Test-CloudDeviceDuplicateNameProtection -Device $device) {
             continue
         }
 

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -12,7 +12,8 @@ function Get-InitialCloudDevices {
         [switch] $IncludeUnknownOperatingSystem,
         [switch] $IncludeUnknownOperatingSystemVersion,
         [Array] $Exclusions,
-        [switch] $IncludeAutopilotInventory
+        [switch] $IncludeAutopilotInventory,
+        [switch] $IncludeDuplicateNameProtectionInventory
     )
 
     $getAgeDays = {
@@ -97,6 +98,7 @@ function Get-InitialCloudDevices {
 
     [Array] $entraJoinType = @($IncludeJoinType | Where-Object { $_ -ne 'Not available' })
     [Array] $entraDevices = @()
+    [Array] $duplicateNameReferenceDevices = @()
     if ($entraJoinType.Count -gt 0) {
         Write-Color -Text '[i] ', 'Getting cloud devices from Microsoft Entra ID for join types: ', ($entraJoinType -join ', ') -Color Yellow, Cyan, Green
         $entraParameters = @{
@@ -123,6 +125,22 @@ function Get-InitialCloudDevices {
         } elseif ($null -ne $SafetyEntraLimit -and $entraDevices.Count -lt $SafetyEntraLimit) {
             Write-Color -Text '[e] ', 'Only ', $entraDevices.Count, ' devices found in Microsoft Entra ID, this is less than the safety limit of ', $SafetyEntraLimit, '. Terminating!' -Color Yellow, Cyan, Red, Cyan
             return $false
+        }
+
+        if ($IncludeDuplicateNameProtectionInventory -and $entraJoinType -notcontains 'Hybrid AzureAD') {
+            Write-Color -Text '[i] ', 'Getting Microsoft Entra hybrid devices for duplicate-name protection context' -Color Yellow, Cyan
+            $duplicateReferenceParameters = @{
+                Type            = @('Hybrid AzureAD')
+                WarningAction   = 'SilentlyContinue'
+                WarningVariable = 'warningVar'
+                IncludeAutopilotInventory = $true
+            }
+            $warningVar = $null
+            [Array] $duplicateNameReferenceDevices = Get-MyDevice @duplicateReferenceParameters
+            if ($warningVar) {
+                Write-Color -Text '[e] ', 'Error getting hybrid devices for duplicate-name protection: ', $warningVar, ' Terminating!' -Color Yellow, Red, Yellow, Red
+                return $false
+            }
         }
     } else {
         Write-Color -Text '[i] ', 'Skipping Microsoft Entra ID inventory because requested join type is only Not available. Continuing with Intune inventory.' -Color Yellow, Yellow
@@ -340,7 +358,7 @@ function Get-InitialCloudDevices {
         })
     }
 
-    Set-CloudDeviceDuplicateNameMetadata -Devices $outputDevices
+    Set-CloudDeviceDuplicateNameMetadata -Devices $outputDevices -ReferenceDevices $duplicateNameReferenceDevices
 
     @($outputDevices)
 }

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -340,5 +340,7 @@ function Get-InitialCloudDevices {
         })
     }
 
+    Set-CloudDeviceDuplicateNameMetadata -Devices $outputDevices
+
     @($outputDevices)
 }

--- a/Private/Set-CloudDeviceDuplicateNameMetadata.ps1
+++ b/Private/Set-CloudDeviceDuplicateNameMetadata.ps1
@@ -3,11 +3,14 @@ function Set-CloudDeviceDuplicateNameMetadata {
     param(
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
-        [System.Collections.Generic.List[object]] $Devices
+        [System.Collections.Generic.List[object]] $Devices,
+
+        [AllowEmptyCollection()]
+        [object[]] $ReferenceDevices = @()
     )
 
     $devicesByName = @{}
-    foreach ($device in $Devices) {
+    foreach ($device in @($Devices + $ReferenceDevices)) {
         $name = [string] $device.Name
         if ([string]::IsNullOrWhiteSpace($name)) {
             continue
@@ -35,11 +38,10 @@ function Set-CloudDeviceDuplicateNameMetadata {
 
         $joinTypes = @($duplicateGroup | ForEach-Object { [string] $_.TrustType } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
         $recordStates = @($duplicateGroup | ForEach-Object { [string] $_.RecordState } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-        $hasWindowsDevice = @($duplicateGroup | Where-Object { [string] $_.OperatingSystem -like 'Windows*' }).Count -gt 0
         $hasHybridDevice = $joinTypes -contains 'Hybrid AzureAD'
         $hasCloudJoinedDevice = @($joinTypes | Where-Object { $_ -in @('AzureAD joined', 'AzureAD registered') }).Count -gt 0
         $hasAutopilotDevice = @($duplicateGroup | Where-Object { $_.AutopilotOnboarded -eq $true -or -not [string]::IsNullOrWhiteSpace([string] $_.AutopilotDeviceId) }).Count -gt 0
-        $preserveGroup = $hasWindowsDevice -and (($hasHybridDevice -and $hasCloudJoinedDevice) -or $hasAutopilotDevice)
+        $preserveGroup = ($hasHybridDevice -and $hasCloudJoinedDevice) -or $hasAutopilotDevice
 
         $reason = if ($preserveGroup) {
             if ($hasHybridDevice -and $hasCloudJoinedDevice -and $hasAutopilotDevice) {
@@ -53,12 +55,13 @@ function Set-CloudDeviceDuplicateNameMetadata {
             $null
         }
 
-        foreach ($device in $duplicateGroup) {
+        foreach ($device in @($duplicateGroup | Where-Object { $Devices.Contains($_) })) {
+            $preserveDevice = $preserveGroup -and [string] $device.OperatingSystem -like 'Windows*'
             Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameCount' -Value $duplicateGroup.Count -Force
             Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameJoinTypes' -Value $joinTypes -Force
             Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameRecordStates' -Value $recordStates -Force
-            Add-Member -InputObject $device -MemberType NoteProperty -Name 'PreserveDuplicateNameGroup' -Value $preserveGroup -Force
-            Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameProtectionReason' -Value $reason -Force
+            Add-Member -InputObject $device -MemberType NoteProperty -Name 'PreserveDuplicateNameGroup' -Value $preserveDevice -Force
+            Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameProtectionReason' -Value $(if ($preserveDevice) { $reason } else { $null }) -Force
         }
     }
 }

--- a/Private/Set-CloudDeviceDuplicateNameMetadata.ps1
+++ b/Private/Set-CloudDeviceDuplicateNameMetadata.ps1
@@ -1,0 +1,64 @@
+function Set-CloudDeviceDuplicateNameMetadata {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [System.Collections.Generic.List[object]] $Devices
+    )
+
+    $devicesByName = @{}
+    foreach ($device in $Devices) {
+        $name = [string] $device.Name
+        if ([string]::IsNullOrWhiteSpace($name)) {
+            continue
+        }
+
+        $normalizedName = $name.Trim().ToUpperInvariant()
+        if (-not $devicesByName.ContainsKey($normalizedName)) {
+            $devicesByName[$normalizedName] = [System.Collections.Generic.List[object]]::new()
+        }
+        $devicesByName[$normalizedName].Add($device)
+    }
+
+    foreach ($device in $Devices) {
+        Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameCount' -Value 1 -Force
+        Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameJoinTypes' -Value @() -Force
+        Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameRecordStates' -Value @() -Force
+        Add-Member -InputObject $device -MemberType NoteProperty -Name 'PreserveDuplicateNameGroup' -Value $false -Force
+        Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameProtectionReason' -Value $null -Force
+    }
+
+    foreach ($duplicateGroup in $devicesByName.Values) {
+        if ($duplicateGroup.Count -lt 2) {
+            continue
+        }
+
+        $joinTypes = @($duplicateGroup | ForEach-Object { [string] $_.TrustType } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+        $recordStates = @($duplicateGroup | ForEach-Object { [string] $_.RecordState } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+        $hasWindowsDevice = @($duplicateGroup | Where-Object { [string] $_.OperatingSystem -like 'Windows*' }).Count -gt 0
+        $hasHybridDevice = $joinTypes -contains 'Hybrid AzureAD'
+        $hasCloudJoinedDevice = @($joinTypes | Where-Object { $_ -in @('AzureAD joined', 'AzureAD registered') }).Count -gt 0
+        $hasAutopilotDevice = @($duplicateGroup | Where-Object { $_.AutopilotOnboarded -eq $true -or -not [string]::IsNullOrWhiteSpace([string] $_.AutopilotDeviceId) }).Count -gt 0
+        $preserveGroup = $hasWindowsDevice -and (($hasHybridDevice -and $hasCloudJoinedDevice) -or $hasAutopilotDevice)
+
+        $reason = if ($preserveGroup) {
+            if ($hasHybridDevice -and $hasCloudJoinedDevice -and $hasAutopilotDevice) {
+                'Same-name Windows Autopilot hybrid duplicate'
+            } elseif ($hasHybridDevice -and $hasCloudJoinedDevice) {
+                'Same-name Windows hybrid/cloud join duplicate'
+            } else {
+                'Same-name Windows Autopilot duplicate'
+            }
+        } else {
+            $null
+        }
+
+        foreach ($device in $duplicateGroup) {
+            Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameCount' -Value $duplicateGroup.Count -Force
+            Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameJoinTypes' -Value $joinTypes -Force
+            Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameRecordStates' -Value $recordStates -Force
+            Add-Member -InputObject $device -MemberType NoteProperty -Name 'PreserveDuplicateNameGroup' -Value $preserveGroup -Force
+            Add-Member -InputObject $device -MemberType NoteProperty -Name 'DuplicateNameProtectionReason' -Value $reason -Force
+        }
+    }
+}

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -19,6 +19,11 @@ function Invoke-CloudDevicesCleanup {
     can be reviewed over multiple runs. ReportOnly and WhatIf/action-specific
     WhatIf modes show candidates without mutating pending cleanup state.
 
+    Same-name Windows Autopilot and hybrid/cloud-join duplicate groups are preserved
+    from destructive cloud actions by default. This protects the by-design duplicate
+    Entra objects created during Windows Autopilot Microsoft Entra hybrid deployments.
+    Use PreserveDuplicateDeviceNames:$false only after reviewing the duplicate group.
+
     Blank activity timestamps are intentionally excluded from destructive actions by default.
     This follows Microsoft guidance for stale-device cleanup where activity timestamps can be empty
     even for active devices.
@@ -210,6 +215,10 @@ function Invoke-CloudDevicesCleanup {
     .PARAMETER Exclusions
     Device names, Entra object IDs, Intune managed-device IDs, or other supported identifiers to exclude from cleanup.
 
+    .PARAMETER PreserveDuplicateDeviceNames
+    Preserves same-name Windows Autopilot and hybrid/cloud-join duplicate groups from retire, disable, delete, and standalone Autopilot identity removal.
+    Defaults to $true.
+
     .PARAMETER IncludeCompanyOwned
     Includes company-owned devices in candidate selection. By default company-owned devices are excluded from actions.
 
@@ -374,6 +383,7 @@ function Invoke-CloudDevicesCleanup {
         [Array] $IncludeAutopilotGroupTag = @(),
         [Array] $ExcludeAutopilotGroupTag = @(),
         [Array] $Exclusions = @(),
+        [bool] $PreserveDuplicateDeviceNames = $true,
         [switch] $IncludeCompanyOwned,
 
         [string] $DataStorePath,
@@ -463,6 +473,7 @@ function Invoke-CloudDevicesCleanup {
         LastSeenEntraMoreThan  = $RetireLastSeenEntraMoreThan
         RegisteredMoreThan     = $RetireRegisteredMoreThan
         IncludeUnknownActivity = $IncludeUnknownActivity.IsPresent
+        PreserveDuplicateDeviceNames = $PreserveDuplicateDeviceNames
         ExcludeCompanyOwned    = -not $IncludeCompanyOwned
         IntuneLinkState        = $IntuneLinkState
         IncludeIntuneOnly      = $RetireIncludeIntuneOnly.IsPresent
@@ -487,6 +498,7 @@ function Invoke-CloudDevicesCleanup {
         RegisteredMoreThan     = $DisableRegisteredMoreThan
         ListProcessedMoreThan  = $DisableListProcessedMoreThan
         IncludeUnknownActivity = $IncludeUnknownActivity.IsPresent
+        PreserveDuplicateDeviceNames = $PreserveDuplicateDeviceNames
         ExcludeCompanyOwned    = -not $IncludeCompanyOwned
         IntuneLinkState        = $IntuneLinkState
         IncludeEntraOnly       = $DisableIncludeEntraOnly.IsPresent
@@ -511,6 +523,7 @@ function Invoke-CloudDevicesCleanup {
         RegisteredMoreThan     = $DeleteRegisteredMoreThan
         ListProcessedMoreThan  = $DeleteListProcessedMoreThan
         IncludeUnknownActivity = $IncludeUnknownActivity.IsPresent
+        PreserveDuplicateDeviceNames = $PreserveDuplicateDeviceNames
         ExcludeCompanyOwned    = -not $IncludeCompanyOwned
         IntuneLinkState        = $IntuneLinkState
         IncludeEntraOnly       = $DeleteIncludeEntraOnly.IsPresent
@@ -533,6 +546,7 @@ function Invoke-CloudDevicesCleanup {
     $removeAutopilotIdentityOnlyIf = [ordered] @{
         AutopilotLastContactMoreThan = $RemoveAutopilotIdentityLastContactMoreThan
         IncludeUnknownActivity       = $IncludeUnknownActivity.IsPresent
+        PreserveDuplicateDeviceNames = $PreserveDuplicateDeviceNames
         ExcludeCompanyOwned          = -not $IncludeCompanyOwned
         IntuneLinkState              = $IntuneLinkState
         AutopilotState               = 'Onboarded'

--- a/Public/Invoke-CloudDevicesCleanup.ps1
+++ b/Public/Invoke-CloudDevicesCleanup.ps1
@@ -584,7 +584,7 @@ function Invoke-CloudDevicesCleanup {
         return
     }
 
-    $includeAutopilotInventory = (($RemoveAutopilotIdentity -and -not $useSeparateAutopilotRemovalInventory) -or $DeleteAutopilotIdentity -or $AutopilotState -ne 'Any' -or $OwnerState -ne 'Any' -or $IncludeAutopilotGroupTag.Count -gt 0 -or $ExcludeAutopilotGroupTag.Count -gt 0)
+    $includeAutopilotInventory = ($PreserveDuplicateDeviceNames -or ($RemoveAutopilotIdentity -and -not $useSeparateAutopilotRemovalInventory) -or $DeleteAutopilotIdentity -or $AutopilotState -ne 'Any' -or $OwnerState -ne 'Any' -or $IncludeAutopilotGroupTag.Count -gt 0 -or $ExcludeAutopilotGroupTag.Count -gt 0)
     $initialCloudDeviceParameters = @{
         SafetyEntraLimit                    = $SafetyEntraLimit
         SafetyIntuneLimit                   = $SafetyIntuneLimit
@@ -600,13 +600,16 @@ function Invoke-CloudDevicesCleanup {
     if ($includeAutopilotInventory) {
         $initialCloudDeviceParameters.IncludeAutopilotInventory = $true
     }
+    if ($PreserveDuplicateDeviceNames) {
+        $initialCloudDeviceParameters.IncludeDuplicateNameProtectionInventory = $true
+    }
     $allDevices = Get-InitialCloudDevices @initialCloudDeviceParameters
     if ($allDevices -eq $false) {
         return
     }
     $autopilotRemovalDevices = $allDevices
     if ($useSeparateAutopilotRemovalInventory) {
-        $autopilotRemovalDevices = Get-InitialCloudDevices -SafetyEntraLimit $SafetyEntraLimit -SafetyIntuneLimit $SafetyIntuneLimit -IncludeJoinType $autopilotRemovalIncludeJoinType -IncludeOperatingSystem $autopilotRemovalIncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -IncludeOperatingSystemVersion $IncludeOperatingSystemVersion -ExcludeOperatingSystemVersion $ExcludeOperatingSystemVersion -IncludeUnknownOperatingSystem:$IncludeUnknownOperatingSystem -IncludeUnknownOperatingSystemVersion:$IncludeUnknownOperatingSystemVersion -Exclusions $Exclusions -IncludeAutopilotInventory
+        $autopilotRemovalDevices = Get-InitialCloudDevices -SafetyEntraLimit $SafetyEntraLimit -SafetyIntuneLimit $SafetyIntuneLimit -IncludeJoinType $autopilotRemovalIncludeJoinType -IncludeOperatingSystem $autopilotRemovalIncludeOperatingSystem -ExcludeOperatingSystem $ExcludeOperatingSystem -IncludeOperatingSystemVersion $IncludeOperatingSystemVersion -ExcludeOperatingSystemVersion $ExcludeOperatingSystemVersion -IncludeUnknownOperatingSystem:$IncludeUnknownOperatingSystem -IncludeUnknownOperatingSystemVersion:$IncludeUnknownOperatingSystemVersion -Exclusions $Exclusions -IncludeAutopilotInventory -IncludeDuplicateNameProtectionInventory:$PreserveDuplicateDeviceNames
         if ($autopilotRemovalDevices -eq $false) {
             return
         }

--- a/README.MD
+++ b/README.MD
@@ -259,6 +259,7 @@ What matters most:
 - orphan records are discovered by default, but stage-specific orphan processing now requires explicit switches
 - default scope is mobile-first: `iOS` and `Android`, with company-owned devices excluded unless requested
 - hybrid Azure AD joined, Azure AD joined, synchronized, non-registered, and unknown registration states are excluded from cloud-device cleanup; use `Invoke-ADComputersCleanup` for hybrid device lifecycle cleanup
+- same-name Windows Autopilot hybrid/cloud-join duplicate groups are preserved from cloud cleanup actions by default; use `-PreserveDuplicateDeviceNames:$false` only after reviewing the duplicate set in the report
 - blank current activity is unsafe for destructive selection, including when a pending device had activity before but the current inventory loses it
 - Entra-backed disable requires `Enabled -eq $true`; Entra-backed delete requires `Enabled -eq $false`; unknown enabled state is treated as unsafe
 - `-ReportOnly`, top-level `-WhatIf`, and action-specific preview switches do not add devices to `PendingActions` or persisted `History`

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -409,6 +409,76 @@ Describe 'Cloud device inventory and selection helpers' {
         $devices[0].DuplicateNameProtectionReason | Should -Match 'Same-name Windows'
     }
 
+    It 'uses hybrid reference records to protect scoped cloud-joined duplicates' {
+        Mock Get-MyDevice {
+            param([string[]] $Type)
+
+            if ($Type -contains 'Hybrid AzureAD') {
+                return @(
+                    [PSCustomObject] @{
+                        Name                = 'PL-KAT-KISskRNw'
+                        EntraDeviceObjectId = 'entra-hybrid'
+                        DeviceId            = 'device-hybrid'
+                        Enabled             = $true
+                        OperatingSystem     = 'Windows'
+                        TrustType           = 'Hybrid AzureAD'
+                        LastSeenDays        = 1
+                    }
+                )
+            }
+
+            @(
+                [PSCustomObject] @{
+                    Name                = 'PL-KAT-KISskRNw'
+                    EntraDeviceObjectId = 'entra-joined'
+                    DeviceId            = 'device-joined'
+                    Enabled             = $true
+                    OperatingSystem     = 'Windows'
+                    TrustType           = 'AzureAD joined'
+                    LastSeenDays        = 460
+                    FirstSeen           = (Get-Date).AddDays(-460)
+                    IsManaged           = $true
+                    ManagementType      = 'mdm'
+                }
+            )
+        }
+        Mock Get-MyDeviceIntune { @() }
+
+        $devices = @(Get-InitialCloudDevices -IncludeJoinType 'AzureAD joined' -IncludeOperatingSystem @('Windows*') -ExcludeOperatingSystem @() -Exclusions @() -IncludeDuplicateNameProtectionInventory)
+
+        $devices | Should -HaveCount 1
+        $devices[0].Name | Should -Be 'PL-KAT-KISskRNw'
+        $devices[0].PreserveDuplicateNameGroup | Should -BeTrue
+        $devices[0].DuplicateNameCount | Should -Be 2
+        $devices[0].DuplicateNameJoinTypes | Should -Contain 'Hybrid AzureAD'
+        $devices[0].DuplicateNameJoinTypes | Should -Contain 'AzureAD joined'
+    }
+
+    It 'does not protect non-Windows members of a same-name Autopilot group' {
+        $devices = [System.Collections.Generic.List[object]]::new()
+        $devices.Add([PSCustomObject] @{
+                Name                = 'Shared-Name'
+                OperatingSystem     = 'Windows'
+                TrustType           = 'AzureAD joined'
+                RecordState         = 'Matched'
+                AutopilotOnboarded  = $true
+                AutopilotDeviceId   = 'autopilot-shared-name'
+            })
+        $devices.Add([PSCustomObject] @{
+                Name                = 'Shared-Name'
+                OperatingSystem     = 'iOS'
+                TrustType           = 'AzureAD registered'
+                RecordState         = 'Matched'
+            })
+
+        Set-CloudDeviceDuplicateNameMetadata -Devices $devices
+
+        $devices[0].PreserveDuplicateNameGroup | Should -BeTrue
+        $devices[0].DuplicateNameProtectionReason | Should -Match 'Autopilot'
+        $devices[1].PreserveDuplicateNameGroup | Should -BeFalse
+        $devices[1].DuplicateNameProtectionReason | Should -BeNullOrEmpty
+    }
+
     It 'excludes hybrid and joined records from cloud cleanup inventory' {
         Mock Get-MyDevice {
             @(

--- a/Tests/CloudDeviceInventory.Tests.ps1
+++ b/Tests/CloudDeviceInventory.Tests.ps1
@@ -6,6 +6,7 @@ BeforeAll {
     . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceRecordKeys.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDevicePropertyValue.ps1')
     . (Get-CleanupMonsterPath 'Private/Find-ProcessedCloudDeviceRecord.ps1')
+    . (Get-CleanupMonsterPath 'Private/Set-CloudDeviceDuplicateNameMetadata.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-InitialCloudDevices.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceRecordKey.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-CloudDeviceSelectionReason.ps1')
@@ -341,6 +342,71 @@ Describe 'Cloud device inventory and selection helpers' {
         $devices | Should -HaveCount 1
         $devices[0].AutopilotInventoryLoaded | Should -BeFalse
         $devices[0].AutopilotOnboarded | Should -BeFalse
+    }
+
+    It 'marks same-name Windows hybrid and cloud-joined duplicates for preservation' {
+        Mock Get-MyDevice {
+            @(
+                [PSCustomObject] @{
+                    Name                = 'PL-KAT-KISskRNw'
+                    EntraDeviceObjectId = 'entra-hybrid'
+                    DeviceId            = 'device-hybrid'
+                    Enabled             = $true
+                    OperatingSystem     = 'Windows'
+                    TrustType           = 'Hybrid AzureAD'
+                    LastSeenDays        = 1
+                    FirstSeen           = (Get-Date).AddDays(-90)
+                    IsManaged           = $true
+                    ManagementType      = 'configManager'
+                }
+                [PSCustomObject] @{
+                    Name                     = 'PL-KAT-KISskRNw'
+                    EntraDeviceObjectId      = 'entra-joined'
+                    DeviceId                 = 'device-joined'
+                    Enabled                  = $true
+                    OperatingSystem          = 'Windows'
+                    TrustType                = 'AzureAD joined'
+                    LastSeenDays             = 460
+                    FirstSeen                = (Get-Date).AddDays(-460)
+                    IsManaged                = $true
+                    ManagementType           = 'mdm'
+                    AutopilotInventoryLoaded = $true
+                    AutopilotOnboarded       = $true
+                    AutopilotDeviceId        = 'autopilot-joined'
+                }
+            )
+        }
+        Mock Get-MyDeviceIntune {
+            @(
+                [PSCustomObject] @{
+                    Name                    = 'PL-KAT-KISskRNw'
+                    ManagedDeviceId         = 'managed-joined'
+                    EntraDeviceObjectId     = 'entra-joined'
+                    AzureAdDeviceId         = 'device-joined'
+                    OperatingSystem         = 'Windows'
+                    OperatingSystemVersion  = '10.0.22631.3155'
+                    LastSeenDays            = 460
+                    FirstSeen               = (Get-Date).AddDays(-460)
+                    ManagedDeviceOwnerType  = 'company'
+                    DeviceRegistrationState = 'joined'
+                    AzureAdRegistered       = $true
+                    ComplianceState         = 'noncompliant'
+                    ManagementAgent         = 'mdm'
+                    AutopilotInventoryLoaded = $true
+                    AutopilotOnboarded       = $true
+                    AutopilotDeviceId        = 'autopilot-joined'
+                }
+            )
+        }
+
+        $devices = @(Get-InitialCloudDevices -IncludeJoinType 'Hybrid AzureAD', 'AzureAD joined' -IncludeOperatingSystem @('Windows*') -ExcludeOperatingSystem @() -Exclusions @())
+
+        $devices | Should -HaveCount 2
+        $devices.PreserveDuplicateNameGroup | Should -Be @($true, $true)
+        $devices.DuplicateNameCount | Should -Be @(2, 2)
+        $devices[0].DuplicateNameJoinTypes | Should -Contain 'Hybrid AzureAD'
+        $devices[0].DuplicateNameJoinTypes | Should -Contain 'AzureAD joined'
+        $devices[0].DuplicateNameProtectionReason | Should -Match 'Same-name Windows'
     }
 
     It 'excludes hybrid and joined records from cloud cleanup inventory' {
@@ -948,6 +1014,85 @@ Describe 'Cloud device inventory and selection helpers' {
         $candidates[0].Name | Should -Be 'Windows-BrokenIntuneLink'
         $candidates[0].SelectionReason | Should -Match 'IntuneLinkState=Broken'
         $candidates[0].SelectionReason | Should -Match 'RequiredIntuneLinkState=Broken'
+    }
+
+    It 'skips preserved same-name duplicate groups during destructive cloud selection by default' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                           = 'PL-KAT-KISskRNw'
+                EntraDeviceObjectId            = 'entra-joined'
+                DeviceId                       = 'device-joined'
+                ManagedDeviceId                = 'managed-joined'
+                HasEntraRecord                 = $true
+                HasIntuneRecord                = $true
+                RecordState                    = 'Matched'
+                IntuneLinkState                = 'Healthy'
+                ManagedDeviceOwnerType         = 'personal'
+                OperatingSystem                = 'Windows'
+                TrustType                      = 'AzureAD joined'
+                EntraLastSeenDays              = 460
+                IntuneLastSeenDays             = 460
+                Enabled                        = $true
+                PreserveDuplicateNameGroup     = $true
+                DuplicateNameProtectionReason  = 'Same-name Windows hybrid/cloud join duplicate'
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan        = 90
+            LastSeenIntuneMoreThan       = $null
+            RegisteredMoreThan           = $null
+            ListProcessedMoreThan        = $null
+            IncludeUnknownActivity       = $false
+            PreserveDuplicateDeviceNames = $true
+            ExcludeCompanyOwned          = $true
+            IntuneLinkState              = 'Any'
+            IncludeEntraOnly             = $false
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
+
+        $candidates | Should -HaveCount 0
+    }
+
+    It 'allows same-name duplicate groups when duplicate-name preservation is explicitly disabled' {
+        $devices = @(
+            [PSCustomObject] @{
+                Name                          = 'PL-KAT-KISskRNw'
+                EntraDeviceObjectId           = 'entra-joined'
+                DeviceId                      = 'device-joined'
+                ManagedDeviceId               = 'managed-joined'
+                HasEntraRecord                = $true
+                HasIntuneRecord               = $true
+                RecordState                   = 'Matched'
+                IntuneLinkState               = 'Healthy'
+                ManagedDeviceOwnerType        = 'personal'
+                OperatingSystem               = 'Windows'
+                TrustType                     = 'AzureAD joined'
+                EntraLastSeenDays             = 460
+                IntuneLastSeenDays            = 460
+                Enabled                       = $true
+                PreserveDuplicateNameGroup    = $true
+                DuplicateNameProtectionReason = 'Same-name Windows hybrid/cloud join duplicate'
+            }
+        )
+
+        $actionIf = [ordered] @{
+            LastSeenEntraMoreThan        = 90
+            LastSeenIntuneMoreThan       = $null
+            RegisteredMoreThan           = $null
+            ListProcessedMoreThan        = $null
+            IncludeUnknownActivity       = $false
+            PreserveDuplicateDeviceNames = $false
+            ExcludeCompanyOwned          = $true
+            IntuneLinkState              = 'Any'
+            IncludeEntraOnly             = $false
+        }
+
+        $candidates = @(Get-CloudDevicesToProcess -Type Disable -Devices $devices -ActionIf $actionIf -ProcessedDevices ([ordered] @{}))
+
+        $candidates | Should -HaveCount 1
+        $candidates[0].Name | Should -Be 'PL-KAT-KISskRNw'
     }
 
     It 'filters action candidates by owner, management, compliance, and registration age' {

--- a/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
+++ b/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
@@ -194,6 +194,28 @@ Describe 'Invoke-CloudDevicesCleanup' {
         $script:capturedPreserveDuplicateDeviceNames | Should -BeFalse
     }
 
+    It 'loads Autopilot and duplicate reference inventory when duplicate-name preservation is enabled' {
+        $script:capturedIncludeAutopilotInventory = $null
+        $script:capturedIncludeDuplicateNameProtectionInventory = $null
+
+        Mock Get-InitialCloudDevices {
+            param(
+                [switch] $IncludeAutopilotInventory,
+                [switch] $IncludeDuplicateNameProtectionInventory
+            )
+
+            $script:capturedIncludeAutopilotInventory = $IncludeAutopilotInventory.IsPresent
+            $script:capturedIncludeDuplicateNameProtectionInventory = $IncludeDuplicateNameProtectionInventory.IsPresent
+            @()
+        }
+        Mock Get-CloudDevicesToProcess { @() }
+
+        Invoke-CloudDevicesCleanup -Disable -Suppress | Out-Null
+
+        $script:capturedIncludeAutopilotInventory | Should -BeTrue
+        $script:capturedIncludeDuplicateNameProtectionInventory | Should -BeTrue
+    }
+
     It 'passes broken Intune link filtering to candidate selection' {
         $script:capturedIntuneLinkState = $null
 
@@ -480,7 +502,7 @@ Describe 'Invoke-CloudDevicesCleanup' {
         }
         Mock Get-CloudDevicesToProcess { @() }
 
-        Invoke-CloudDevicesCleanup -Disable -RemoveAutopilotIdentity -Suppress | Out-Null
+        Invoke-CloudDevicesCleanup -Disable -RemoveAutopilotIdentity -PreserveDuplicateDeviceNames:$false -Suppress | Out-Null
 
         $script:capturedInventoryScopes | Should -HaveCount 2
         $script:capturedInventoryScopes[0].IncludeOperatingSystem | Should -Contain 'iOS*'

--- a/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
+++ b/Tests/Invoke-CloudDevicesCleanup.Tests.ps1
@@ -148,6 +148,52 @@ Describe 'Invoke-CloudDevicesCleanup' {
         $script:capturedIncludeUnknownActivity | Should -BeTrue
     }
 
+    It 'preserves duplicate device names by default for candidate selection' {
+        $script:capturedPreserveDuplicateDeviceNames = $null
+
+        Mock Get-InitialCloudDevices { @() }
+        Mock Get-CloudDevicesToProcess {
+            param(
+                $Type,
+                $Devices,
+                $ActionIf,
+                $ProcessedDevices
+            )
+
+            if ($Type -eq 'Disable') {
+                $script:capturedPreserveDuplicateDeviceNames = $ActionIf.PreserveDuplicateDeviceNames
+            }
+            @()
+        }
+
+        Invoke-CloudDevicesCleanup -Disable -Suppress | Out-Null
+
+        $script:capturedPreserveDuplicateDeviceNames | Should -BeTrue
+    }
+
+    It 'passes explicit duplicate-name preservation opt-out to candidate selection' {
+        $script:capturedPreserveDuplicateDeviceNames = $null
+
+        Mock Get-InitialCloudDevices { @() }
+        Mock Get-CloudDevicesToProcess {
+            param(
+                $Type,
+                $Devices,
+                $ActionIf,
+                $ProcessedDevices
+            )
+
+            if ($Type -eq 'Disable') {
+                $script:capturedPreserveDuplicateDeviceNames = $ActionIf.PreserveDuplicateDeviceNames
+            }
+            @()
+        }
+
+        Invoke-CloudDevicesCleanup -Disable -PreserveDuplicateDeviceNames:$false -Suppress | Out-Null
+
+        $script:capturedPreserveDuplicateDeviceNames | Should -BeFalse
+    }
+
     It 'passes broken Intune link filtering to candidate selection' {
         $script:capturedIntuneLinkState = $null
 


### PR DESCRIPTION
## Summary
- preserve same-name Windows Autopilot and hybrid/cloud-join duplicate groups from cloud cleanup actions by default
- annotate cloud inventory rows with duplicate-name metadata so operators can review why a group was protected
- add an explicit `-PreserveDuplicateDeviceNames:$false` opt-out for reviewed cleanup runs

## Validation
- `Invoke-Pester -Path 'Tests' -PassThru`