### PR TITLE
Reduce AD cleanup memory use and bound stalled multi-domain inventory

### DIFF
--- a/Private/ConvertFrom-ADComputerInventoryRow.ps1
+++ b/Private/ConvertFrom-ADComputerInventoryRow.ps1
@@ -1,0 +1,39 @@
+function ConvertFrom-ADComputerInventoryRow {
+    <#
+    .SYNOPSIS
+    Restores AD computer property types from the bounded child-process transport.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [psobject] $InputObject
+    )
+
+    process {
+        $ServicePrincipalNames = if ([string]::IsNullOrWhiteSpace($InputObject.ServicePrincipalNameJson) -or $InputObject.ServicePrincipalNameJson -eq 'null') {
+            @()
+        } else {
+            @(ConvertFrom-Json -InputObject $InputObject.ServicePrincipalNameJson)
+        }
+
+        [PSCustomObject] [ordered] @{
+            Name                            = $InputObject.Name
+            DNSHostName                     = $InputObject.DNSHostName
+            SamAccountName                  = $InputObject.SamAccountName
+            DistinguishedName               = $InputObject.DistinguishedName
+            Enabled                         = if ($InputObject.Enabled) { [bool]::Parse($InputObject.Enabled) } else { $null }
+            OperatingSystem                 = $InputObject.OperatingSystem
+            OperatingSystemVersion          = $InputObject.OperatingSystemVersion
+            LastLogonDate                   = if ($InputObject.LastLogonDateBinary) { [DateTime]::FromBinary([long] $InputObject.LastLogonDateBinary) } else { $null }
+            PasswordLastSet                 = if ($InputObject.PasswordLastSetBinary) { [DateTime]::FromBinary([long] $InputObject.PasswordLastSetBinary) } else { $null }
+            PasswordExpired                 = if ($InputObject.PasswordExpired) { [bool]::Parse($InputObject.PasswordExpired) } else { $null }
+            servicePrincipalName            = $ServicePrincipalNames
+            logonCount                      = if ($InputObject.LogonCount) { [int] $InputObject.LogonCount } else { $null }
+            ManagedBy                       = $InputObject.ManagedBy
+            Description                     = $InputObject.Description
+            WhenCreated                     = if ($InputObject.WhenCreatedBinary) { [DateTime]::FromBinary([long] $InputObject.WhenCreatedBinary) } else { $null }
+            WhenChanged                     = if ($InputObject.WhenChangedBinary) { [DateTime]::FromBinary([long] $InputObject.WhenChangedBinary) } else { $null }
+            ProtectedFromAccidentalDeletion = if ($InputObject.ProtectedFromAccidentalDeletion) { [bool]::Parse($InputObject.ProtectedFromAccidentalDeletion) } else { $null }
+        }
+    }
+}

--- a/Private/ConvertFrom-ADComputerInventoryRow.ps1
+++ b/Private/ConvertFrom-ADComputerInventoryRow.ps1
@@ -16,7 +16,7 @@ function ConvertFrom-ADComputerInventoryRow {
             @(ConvertFrom-Json -InputObject $InputObject.ServicePrincipalNameJson)
         }
 
-        [PSCustomObject] [ordered] @{
+        [PSCustomObject] @{
             Name                            = $InputObject.Name
             DNSHostName                     = $InputObject.DNSHostName
             SamAccountName                  = $InputObject.SamAccountName

--- a/Private/ConvertTo-PreparedComputer.ps1
+++ b/Private/ConvertTo-PreparedComputer.ps1
@@ -2,7 +2,7 @@ function ConvertTo-PreparedComputer {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, ValueFromPipeline)]
-        [Microsoft.ActiveDirectory.Management.ADComputer[]] $Computers,
+        [object[]] $Computers,
         [System.Collections.IDictionary] $AzureInformationCache,
         [System.Collections.IDictionary] $JamfInformationCache,
         [switch] $IncludeAzureAD,

--- a/Private/ConvertTo-PreparedComputer.ps1
+++ b/Private/ConvertTo-PreparedComputer.ps1
@@ -1,6 +1,7 @@
 function ConvertTo-PreparedComputer {
     [CmdletBinding()]
     param(
+        [Parameter(Mandatory, ValueFromPipeline)]
         [Microsoft.ActiveDirectory.Management.ADComputer[]] $Computers,
         [System.Collections.IDictionary] $AzureInformationCache,
         [System.Collections.IDictionary] $JamfInformationCache,
@@ -10,100 +11,102 @@ function ConvertTo-PreparedComputer {
         [DateTime] $Today = (Get-Date)
     )
 
-    foreach ($Computer in $Computers) {
-        $LookupCandidates = Get-ComputerLookupCandidates -Name $Computer.Name -DNSHostName $Computer.DNSHostName -SamAccountName $Computer.SamAccountName
-        if ($IncludeAzureAD) {
-            $AzureADComputer = Get-CloudCacheComputer -Cache $AzureInformationCache['AzureAD'] -Candidates $LookupCandidates
-            $DataAzureAD = [ordered] @{
-                'AzureLastSeen'     = $AzureADComputer.LastSeen
-                'AzureLastSeenDays' = $AzureADComputer.LastSeenDays
-                'AzureLastSync'     = $AzureADComputer.LastSynchronized
-                'AzureLastSyncDays' = $AzureADComputer.LastSynchronizedDays
-                'AzureOwner'        = $AzureADComputer.OwnerDisplayName
-                'AzureOwnerStatus'  = $AzureADComputer.OwnerEnabled
-                'AzureOwnerUPN'     = $AzureADComputer.OwnerUserPrincipalName
+    process {
+        foreach ($Computer in $Computers) {
+            $LookupCandidates = Get-ComputerLookupCandidates -Name $Computer.Name -DNSHostName $Computer.DNSHostName -SamAccountName $Computer.SamAccountName
+            if ($IncludeAzureAD) {
+                $AzureADComputer = Get-CloudCacheComputer -Cache $AzureInformationCache['AzureAD'] -Candidates $LookupCandidates
+                $DataAzureAD = [ordered] @{
+                    'AzureLastSeen'     = $AzureADComputer.LastSeen
+                    'AzureLastSeenDays' = $AzureADComputer.LastSeenDays
+                    'AzureLastSync'     = $AzureADComputer.LastSynchronized
+                    'AzureLastSyncDays' = $AzureADComputer.LastSynchronizedDays
+                    'AzureOwner'        = $AzureADComputer.OwnerDisplayName
+                    'AzureOwnerStatus'  = $AzureADComputer.OwnerEnabled
+                    'AzureOwnerUPN'     = $AzureADComputer.OwnerUserPrincipalName
+                }
             }
-        }
-        if ($IncludeIntune) {
-            # data was requested from Intune
-            $IntuneComputer = Get-CloudCacheComputer -Cache $AzureInformationCache['Intune'] -Candidates $LookupCandidates
-            $DataIntune = [ordered] @{
-                'IntuneLastSeen'     = $IntuneComputer.LastSeen
-                'IntuneLastSeenDays' = $IntuneComputer.LastSeenDays
-                'IntuneUser'         = $IntuneComputer.UserDisplayName
-                'IntuneUserUPN'      = $IntuneComputer.UserPrincipalName
-                'IntuneUserEmail'    = $IntuneComputer.EmailAddress
+            if ($IncludeIntune) {
+                # data was requested from Intune
+                $IntuneComputer = Get-CloudCacheComputer -Cache $AzureInformationCache['Intune'] -Candidates $LookupCandidates
+                $DataIntune = [ordered] @{
+                    'IntuneLastSeen'     = $IntuneComputer.LastSeen
+                    'IntuneLastSeenDays' = $IntuneComputer.LastSeenDays
+                    'IntuneUser'         = $IntuneComputer.UserDisplayName
+                    'IntuneUserUPN'      = $IntuneComputer.UserPrincipalName
+                    'IntuneUserEmail'    = $IntuneComputer.EmailAddress
+                }
             }
-        }
-        if ($IncludeJamf) {
-            $JamfComputer = $JamfInformationCache["$($Computer.Name)"]
-            $DataJamf = [ordered] @{
-                JamfLastContactTime     = $JamfComputer.lastContactTime
-                JamfLastContactTimeDays = $JamfComputer.lastContactTimeDays
-                JamfCapableUsers        = $JamfComputer.mdmCapableCapableUsers
+            if ($IncludeJamf) {
+                $JamfComputer = $JamfInformationCache["$($Computer.Name)"]
+                $DataJamf = [ordered] @{
+                    JamfLastContactTime     = $JamfComputer.lastContactTime
+                    JamfLastContactTimeDays = $JamfComputer.lastContactTimeDays
+                    JamfCapableUsers        = $JamfComputer.mdmCapableCapableUsers
+                }
             }
-        }
-        $LastLogonDays = if ($null -ne $Computer.LastLogonDate) {
-            - $($Computer.LastLogonDate - $Today).Days
-        } else {
-            $null
-        }
-        $PasswordLastChangedDays = if ($null -ne $Computer.PasswordLastSet) {
-            - $($Computer.PasswordLastSet - $Today).Days
-        } else {
-            $null
-        }
+            $LastLogonDays = if ($null -ne $Computer.LastLogonDate) {
+                - $($Computer.LastLogonDate - $Today).Days
+            } else {
+                $null
+            }
+            $PasswordLastChangedDays = if ($null -ne $Computer.PasswordLastSet) {
+                - $($Computer.PasswordLastSet - $Today).Days
+            } else {
+                $null
+            }
 
 
-        $DataStart = [ordered] @{
-            'DNSHostName'                     = $Computer.DNSHostName
-            'SamAccountName'                  = $Computer.SamAccountName
-            'DomainName'                      = ConvertFrom-DistinguishedName -DistinguishedName $Computer.DistinguishedName -ToDomainCN
-            'Enabled'                         = $Computer.Enabled
-            'Action'                          = 'Not required'
-            'ActionStatus'                    = $null
-            'ActionDate'                      = $null
-            'ActionComment'                   = $null
-            'OperatingSystem'                 = $Computer.OperatingSystem
-            'OperatingSystemVersion'          = $Computer.OperatingSystemVersion
-            'OperatingSystemLong'             = ConvertTo-OperatingSystem -OperatingSystem $Computer.OperatingSystem -OperatingSystemVersion $Computer.OperatingSystemVersion
-            'LastLogonDate'                   = $Computer.LastLogonDate
-            'LastLogonDays'                   = $LastLogonDays
-            'PasswordLastSet'                 = $Computer.PasswordLastSet
-            'PasswordLastChangedDays'         = $PasswordLastChangedDays
-            'ProtectedFromAccidentalDeletion' = $Computer.ProtectedFromAccidentalDeletion
+            $DataStart = [ordered] @{
+                'DNSHostName'                     = $Computer.DNSHostName
+                'SamAccountName'                  = $Computer.SamAccountName
+                'DomainName'                      = ConvertFrom-DistinguishedName -DistinguishedName $Computer.DistinguishedName -ToDomainCN
+                'Enabled'                         = $Computer.Enabled
+                'Action'                          = 'Not required'
+                'ActionStatus'                    = $null
+                'ActionDate'                      = $null
+                'ActionComment'                   = $null
+                'OperatingSystem'                 = $Computer.OperatingSystem
+                'OperatingSystemVersion'          = $Computer.OperatingSystemVersion
+                'OperatingSystemLong'             = ConvertTo-OperatingSystem -OperatingSystem $Computer.OperatingSystem -OperatingSystemVersion $Computer.OperatingSystemVersion
+                'LastLogonDate'                   = $Computer.LastLogonDate
+                'LastLogonDays'                   = $LastLogonDays
+                'PasswordLastSet'                 = $Computer.PasswordLastSet
+                'PasswordLastChangedDays'         = $PasswordLastChangedDays
+                'ProtectedFromAccidentalDeletion' = $Computer.ProtectedFromAccidentalDeletion
+            }
+            $DataEnd = [ordered] @{
+                'PasswordExpired'            = $Computer.PasswordExpired
+                'LogonCount'                 = $Computer.logonCount
+                'ManagedBy'                  = $Computer.ManagedBy
+                'DistinguishedName'          = $Computer.DistinguishedName
+                'OrganizationalUnit'         = ConvertFrom-DistinguishedName -DistinguishedName $Computer.DistinguishedName -ToOrganizationalUnit
+                'Description'                = $Computer.Description
+                'WhenCreated'                = $Computer.WhenCreated
+                'WhenChanged'                = $Computer.WhenChanged
+                'ServicePrincipalName'       = $Computer.servicePrincipalName #-join [System.Environment]::NewLine
+                'DistinguishedNameAfterMove' = $null
+                'TimeOnPendingList'          = $null
+                'TimeToLeavePendingList'     = $null
+            }
+            if ($IncludeAzureAD -and $IncludeIntune -and $IncludeJamf) {
+                $Data = $DataStart + $DataAzureAD + $DataIntune + $DataJamf + $DataEnd
+            } elseif ($IncludeAzureAD -and $IncludeIntune) {
+                $Data = $DataStart + $DataAzureAD + $DataIntune + $DataEnd
+            } elseif ($IncludeAzureAD -and $IncludeJamf) {
+                $Data = $DataStart + $DataAzureAD + $DataJamf + $DataEnd
+            } elseif ($IncludeIntune -and $IncludeJamf) {
+                $Data = $DataStart + $DataIntune + $DataJamf + $DataEnd
+            } elseif ($IncludeAzureAD) {
+                $Data = $DataStart + $DataAzureAD + $DataEnd
+            } elseif ($IncludeIntune) {
+                $Data = $DataStart + $DataIntune + $DataEnd
+            } elseif ($IncludeJamf) {
+                $Data = $DataStart + $DataJamf + $DataEnd
+            } else {
+                $Data = $DataStart + $DataEnd
+            }
+            [PSCustomObject] $Data
         }
-        $DataEnd = [ordered] @{
-            'PasswordExpired'            = $Computer.PasswordExpired
-            'LogonCount'                 = $Computer.logonCount
-            'ManagedBy'                  = $Computer.ManagedBy
-            'DistinguishedName'          = $Computer.DistinguishedName
-            'OrganizationalUnit'         = ConvertFrom-DistinguishedName -DistinguishedName $Computer.DistinguishedName -ToOrganizationalUnit
-            'Description'                = $Computer.Description
-            'WhenCreated'                = $Computer.WhenCreated
-            'WhenChanged'                = $Computer.WhenChanged
-            'ServicePrincipalName'       = $Computer.servicePrincipalName #-join [System.Environment]::NewLine
-            'DistinguishedNameAfterMove' = $null
-            'TimeOnPendingList'          = $null
-            'TimeToLeavePendingList'     = $null
-        }
-        if ($IncludeAzureAD -and $IncludeIntune -and $IncludeJamf) {
-            $Data = $DataStart + $DataAzureAD + $DataIntune + $DataJamf + $DataEnd
-        } elseif ($IncludeAzureAD -and $IncludeIntune) {
-            $Data = $DataStart + $DataAzureAD + $DataIntune + $DataEnd
-        } elseif ($IncludeAzureAD -and $IncludeJamf) {
-            $Data = $DataStart + $DataAzureAD + $DataJamf + $DataEnd
-        } elseif ($IncludeIntune -and $IncludeJamf) {
-            $Data = $DataStart + $DataIntune + $DataJamf + $DataEnd
-        } elseif ($IncludeAzureAD) {
-            $Data = $DataStart + $DataAzureAD + $DataEnd
-        } elseif ($IncludeIntune) {
-            $Data = $DataStart + $DataIntune + $DataEnd
-        } elseif ($IncludeJamf) {
-            $Data = $DataStart + $DataJamf + $DataEnd
-        } else {
-            $Data = $DataStart + $DataEnd
-        }
-        [PSCustomObject] $Data
     }
 }

--- a/Private/Export-ADComputerReportData.ps1
+++ b/Private/Export-ADComputerReportData.ps1
@@ -11,12 +11,25 @@ function Export-ADComputerReportData {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
         [Array] $Computers,
         [Parameter(Mandatory)]
         [string] $FilePath,
         [ValidateRange(1, 10000)]
         [int] $ChunkSize = 2000,
-        [string[]] $ExcludeProperty = @('TimeOnPendingList', 'TimeToLeavePendingList', 'DistinguishedNameAfterMove')
+        [string[]] $ExcludeProperty = @('TimeOnPendingList', 'TimeToLeavePendingList', 'DistinguishedNameAfterMove'),
+        [AllowEmptyString()]
+        [string] $DateTimeFormat = '',
+        [System.Collections.IDictionary] $NewLineFormat = @{
+            NewLineCarriage = '<br>'
+            NewLine         = '\n'
+            Carriage        = '\r'
+        },
+        [System.Collections.IDictionary] $NewLineFormatProperty = @{
+            NewLineCarriage = '<br>'
+            NewLine         = '\n'
+            Carriage        = '\r'
+        }
     )
 
     $Writer = $null
@@ -40,7 +53,7 @@ function Export-ADComputerReportData {
             $Count++
 
             if ($Chunk.Count -ge $ChunkSize) {
-                [Array] $PrettyRows = @(ConvertTo-PrettyObject -Object $Chunk.ToArray() -PropertyName $PropertyNames -Force -BoolAsString -ArrayJoin -ArrayJoinString ', ')
+                [Array] $PrettyRows = @(ConvertTo-PrettyObject -Object $Chunk.ToArray() -PropertyName $PropertyNames -Force -BoolAsString -ArrayJoin -ArrayJoinString ', ' -DateTimeFormat $DateTimeFormat -NewLineFormat $NewLineFormat -NewLineFormatProperty $NewLineFormatProperty)
                 [string] $Json = ConvertTo-Json -InputObject $PrettyRows -Depth 4 -Compress
                 if ($Json.Length -gt 2) {
                     if ($WroteData) {
@@ -56,7 +69,7 @@ function Export-ADComputerReportData {
         }
 
         if ($Chunk.Count -gt 0) {
-            [Array] $PrettyRows = @(ConvertTo-PrettyObject -Object $Chunk.ToArray() -PropertyName $PropertyNames -Force -BoolAsString -ArrayJoin -ArrayJoinString ', ')
+            [Array] $PrettyRows = @(ConvertTo-PrettyObject -Object $Chunk.ToArray() -PropertyName $PropertyNames -Force -BoolAsString -ArrayJoin -ArrayJoinString ', ' -DateTimeFormat $DateTimeFormat -NewLineFormat $NewLineFormat -NewLineFormatProperty $NewLineFormatProperty)
             [string] $Json = ConvertTo-Json -InputObject $PrettyRows -Depth 4 -Compress
             if ($Json.Length -gt 2) {
                 if ($WroteData) {

--- a/Private/Export-ADComputerReportData.ps1
+++ b/Private/Export-ADComputerReportData.ps1
@@ -1,0 +1,92 @@
+function Export-ADComputerReportData {
+    <#
+    .SYNOPSIS
+    Serializes the complete AD computer report table with bounded memory usage.
+
+    .DESCRIPTION
+    Writes report rows as a JSON array in configurable chunks. Only the current
+    chunk and one sample row remain in serialization memory. The returned sample
+    is used by PSWriteHTML to configure the DataTables columns.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [Array] $Computers,
+        [Parameter(Mandatory)]
+        [string] $FilePath,
+        [ValidateRange(1, 10000)]
+        [int] $ChunkSize = 2000,
+        [string[]] $ExcludeProperty = @('TimeOnPendingList', 'TimeToLeavePendingList', 'DistinguishedNameAfterMove')
+    )
+
+    $Writer = $null
+    try {
+        $Encoding = [System.Text.UTF8Encoding]::new($false)
+        $Writer = [System.IO.StreamWriter]::new($FilePath, $false, $Encoding)
+        $Writer.Write('[')
+
+        $Chunk = [System.Collections.Generic.List[object]]::new($ChunkSize)
+        $PropertyNames = $null
+        $Sample = $null
+        $Count = 0
+        $WroteData = $false
+
+        foreach ($Computer in $Computers) {
+            if ($null -eq $PropertyNames) {
+                $PropertyNames = @($Computer.PSObject.Properties.Name | Where-Object { $_ -notin $ExcludeProperty })
+                $Sample = $Computer | Select-Object -Property $PropertyNames
+            }
+            $Chunk.Add($Computer)
+            $Count++
+
+            if ($Chunk.Count -ge $ChunkSize) {
+                [Array] $PrettyRows = @(ConvertTo-PrettyObject -Object $Chunk.ToArray() -PropertyName $PropertyNames -Force -BoolAsString -ArrayJoin -ArrayJoinString ', ')
+                [string] $Json = ConvertTo-Json -InputObject $PrettyRows -Depth 4 -Compress
+                if ($Json.Length -gt 2) {
+                    if ($WroteData) {
+                        $Writer.Write(',')
+                    }
+                    $Writer.Write($Json.Substring(1, $Json.Length - 2).Replace('<', '&lt;').Replace('>', '&gt;'))
+                    $WroteData = $true
+                }
+                $Chunk.Clear()
+                $PrettyRows = $null
+                $Json = $null
+            }
+        }
+
+        if ($Chunk.Count -gt 0) {
+            [Array] $PrettyRows = @(ConvertTo-PrettyObject -Object $Chunk.ToArray() -PropertyName $PropertyNames -Force -BoolAsString -ArrayJoin -ArrayJoinString ', ')
+            [string] $Json = ConvertTo-Json -InputObject $PrettyRows -Depth 4 -Compress
+            if ($Json.Length -gt 2) {
+                if ($WroteData) {
+                    $Writer.Write(',')
+                }
+                $Writer.Write($Json.Substring(1, $Json.Length - 2).Replace('<', '&lt;').Replace('>', '&gt;'))
+            }
+        }
+        $Writer.Write(']')
+        $Writer.Flush()
+
+        [PSCustomObject] [ordered] @{
+            FilePath      = $FilePath
+            Count         = $Count
+            Sample        = $Sample
+            PropertyNames = $PropertyNames
+            DataStoreID   = 'CleanupMonsterADComputers'
+        }
+    } catch {
+        $ExportError = $_
+    } finally {
+        if ($null -ne $Writer) {
+            $Writer.Dispose()
+        }
+    }
+
+    if ($null -ne $ExportError) {
+        if (Test-Path -LiteralPath $FilePath) {
+            Remove-Item -LiteralPath $FilePath -Force -WhatIf:$false -ErrorAction SilentlyContinue
+        }
+        throw $ExportError
+    }
+}

--- a/Private/Export-ADComputerReportData.ps1
+++ b/Private/Export-ADComputerReportData.ps1
@@ -81,7 +81,7 @@ function Export-ADComputerReportData {
         $Writer.Write(']')
         $Writer.Flush()
 
-        [PSCustomObject] [ordered] @{
+        [PSCustomObject] @{
             FilePath      = $FilePath
             Count         = $Count
             Sample        = $Sample

--- a/Private/Find-JavaScriptArrayAssignment.ps1
+++ b/Private/Find-JavaScriptArrayAssignment.ps1
@@ -116,7 +116,7 @@ function Find-JavaScriptArrayAssignment {
                 continue
             }
 
-            return [PSCustomObject] [ordered] @{
+            return [PSCustomObject] @{
                 DataStartIndex = $ContentGroup.Index + $DataStartIndex
                 DataEndIndex   = $ContentGroup.Index + $DataEndIndex
             }

--- a/Private/Find-JavaScriptArrayAssignment.ps1
+++ b/Private/Find-JavaScriptArrayAssignment.ps1
@@ -1,0 +1,127 @@
+function Find-JavaScriptArrayAssignment {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $Html,
+        [Parameter(Mandatory)]
+        [ValidatePattern('^[A-Za-z_$][A-Za-z0-9_$]*$')]
+        [string] $VariableName
+    )
+
+    $AssignmentPattern = '\bvar\s+' + [regex]::Escape($VariableName) + '\s*=\s*'
+    $ScriptPattern = '(?is)<script\b[^>]*>(?<Content>.*?)</script\s*>'
+
+    foreach ($ScriptMatch in [regex]::Matches($Html, $ScriptPattern)) {
+        $ContentGroup = $ScriptMatch.Groups['Content']
+        $Content = $ContentGroup.Value
+
+        foreach ($AssignmentMatch in [regex]::Matches($Content, $AssignmentPattern)) {
+            $State = 'Code'
+            $Escaped = $false
+            for ($Index = 0; $Index -lt $AssignmentMatch.Index; $Index++) {
+                $Character = $Content[$Index]
+                $NextCharacter = if ($Index + 1 -lt $Content.Length) { $Content[$Index + 1] } else { [char] 0 }
+
+                if ($State -eq 'LineComment') {
+                    if ($Character -eq "`r" -or $Character -eq "`n") {
+                        $State = 'Code'
+                    }
+                    continue
+                }
+                if ($State -eq 'BlockComment') {
+                    if ($Character -eq '*' -and $NextCharacter -eq '/') {
+                        $State = 'Code'
+                        $Index++
+                    }
+                    continue
+                }
+                if ($State -ne 'Code') {
+                    if ($Escaped) {
+                        $Escaped = $false
+                    } elseif ($Character -eq '\') {
+                        $Escaped = $true
+                    } elseif (($State -eq 'SingleQuote' -and $Character -eq "'") -or
+                        ($State -eq 'DoubleQuote' -and $Character -eq '"') -or
+                        ($State -eq 'Template' -and $Character -eq [char] 96)) {
+                        $State = 'Code'
+                    }
+                    continue
+                }
+
+                if ($Character -eq "'") {
+                    $State = 'SingleQuote'
+                } elseif ($Character -eq '"') {
+                    $State = 'DoubleQuote'
+                } elseif ($Character -eq [char] 96) {
+                    $State = 'Template'
+                } elseif ($Character -eq '/' -and $NextCharacter -eq '/') {
+                    $State = 'LineComment'
+                    $Index++
+                } elseif ($Character -eq '/' -and $NextCharacter -eq '*') {
+                    $State = 'BlockComment'
+                    $Index++
+                }
+            }
+
+            if ($State -ne 'Code') {
+                continue
+            }
+
+            $DataStartIndex = $AssignmentMatch.Index + $AssignmentMatch.Length
+            while ($DataStartIndex -lt $Content.Length -and [char]::IsWhiteSpace($Content[$DataStartIndex])) {
+                $DataStartIndex++
+            }
+            if ($DataStartIndex -ge $Content.Length -or $Content[$DataStartIndex] -ne '[') {
+                continue
+            }
+
+            $ArrayDepth = 0
+            $InString = $false
+            $Escaped = $false
+            $DataEndIndex = -1
+            for ($Index = $DataStartIndex; $Index -lt $Content.Length; $Index++) {
+                $Character = $Content[$Index]
+                if ($InString) {
+                    if ($Escaped) {
+                        $Escaped = $false
+                    } elseif ($Character -eq '\') {
+                        $Escaped = $true
+                    } elseif ($Character -eq '"') {
+                        $InString = $false
+                    }
+                    continue
+                }
+
+                if ($Character -eq '"') {
+                    $InString = $true
+                } elseif ($Character -eq '[') {
+                    $ArrayDepth++
+                } elseif ($Character -eq ']') {
+                    $ArrayDepth--
+                    if ($ArrayDepth -eq 0) {
+                        $DataEndIndex = $Index
+                        break
+                    }
+                }
+            }
+            if ($DataEndIndex -lt 0) {
+                continue
+            }
+
+            $TerminatorIndex = $DataEndIndex + 1
+            while ($TerminatorIndex -lt $Content.Length -and [char]::IsWhiteSpace($Content[$TerminatorIndex])) {
+                $TerminatorIndex++
+            }
+            if ($TerminatorIndex -ge $Content.Length -or $Content[$TerminatorIndex] -ne ';') {
+                continue
+            }
+
+            return [PSCustomObject] [ordered] @{
+                DataStartIndex = $ContentGroup.Index + $DataStartIndex
+                DataEndIndex   = $ContentGroup.Index + $DataEndIndex
+            }
+        }
+    }
+
+    throw "The JavaScript array assignment for '$VariableName' was not found."
+}

--- a/Private/Get-ADComputersToProcess.ps1
+++ b/Private/Get-ADComputersToProcess.ps1
@@ -7,6 +7,7 @@
         [Array] $Exclusions,
         [System.Collections.IDictionary] $DomainInformation,
         [System.Collections.IDictionary] $ProcessedComputers,
+        [System.Collections.IDictionary] $PendingStateRollback,
         [System.Collections.IDictionary] $AzureInformationCache,
         [System.Collections.IDictionary] $JamfInformationCache,
         [switch] $IncludeAzureAD,
@@ -70,6 +71,9 @@
                         if ($FoundComputer.ActionDate -is [DateTime]) {
                             $TimeSpan = New-TimeSpan -Start $FoundComputer.ActionDate -End $Today
                             # Lets calculate how many days it's been on the list
+                            if ($null -ne $PendingStateRollback) {
+                                Save-ADComputerPendingStateEntry -Rollback $PendingStateRollback -Key $FullComputerName -Value $FoundComputer
+                            }
                             $ProcessedComputers[$FullComputerName].TimeToLeavePendingList = $ActionIf.ListProcessedMoreThan - $TimeSpan.Days
                             if ($TimeSpan.Days -gt $ActionIf.ListProcessedMoreThan) {
 
@@ -97,12 +101,18 @@
                     if ($Computer.Enabled -eq $true) {
                         # We checked and it seems the computer has been enabled since it was added to list, we remove it from the list and reprocess
                         Write-Color -Text "[*] Removing computer from pending list (computer is enabled) ", $FoundComputer.SamAccountName, " ($($FoundComputer.DistinguishedName))" -Color DarkYellow, Green, DarkYellow
+                        if ($null -ne $PendingStateRollback) {
+                            Save-ADComputerPendingStateEntry -Rollback $PendingStateRollback -Key $FullComputerName -Value $FoundComputer
+                        }
                         $ProcessedComputers.Remove($FullComputerName)
                     } elseif ($ActionIf.DisableAndMove -and $Computer.Enabled -eq $false) {
                         if ($ConfiguredMoveTarget) {
                             if (-not $CachedDestinationMove[$Computer.OrganizationalUnit]) {
                                 # We checked and it seems the computer has been moved since it was added to list, we remove it from the list and reprocess
                                 Write-Color -Text "[*] Removing computer from pending list (computer is moved out of pending deletion OU) ", $FoundComputer.SamAccountName, " ($($FoundComputer.DistinguishedName))" -Color DarkYellow, Green, DarkYellow
+                                if ($null -ne $PendingStateRollback) {
+                                    Save-ADComputerPendingStateEntry -Rollback $PendingStateRollback -Key $FullComputerName -Value $FoundComputer
+                                }
                                 $ProcessedComputers.Remove($FullComputerName)
                             } else {
                                 # We checked and it seems the computer is in place where it's supposed to, we skip to next computer

--- a/Private/Get-ADQueryServerCandidates.ps1
+++ b/Private/Get-ADQueryServerCandidates.ps1
@@ -1,0 +1,47 @@
+function Get-ADQueryServerCandidates {
+    <#
+    .SYNOPSIS
+    Resolves the ordered domain controller candidates for an AD inventory query.
+
+    .DESCRIPTION
+    Returns manually configured domain controllers first and appends auto-detected
+    controllers as fallbacks. Duplicate names are removed case-insensitively while
+    preserving the configured order.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $Domain,
+        [object] $TargetServers,
+        [object[]] $DetectedServers
+    )
+
+    $Candidates = [System.Collections.Generic.List[string]]::new()
+    $Seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    $ConfiguredServers = @()
+    if ($TargetServers -is [string]) {
+        $ConfiguredServers = @($TargetServers)
+    } elseif ($TargetServers -is [System.Collections.IDictionary]) {
+        $MatchedKey = foreach ($Key in $TargetServers.Keys) {
+            if ([string] $Key -ieq $Domain) {
+                $Key
+                break
+            }
+        }
+        if ($null -ne $MatchedKey) {
+            $ConfiguredServers = @($TargetServers[$MatchedKey])
+        }
+    } elseif ($TargetServers -is [System.Collections.IEnumerable]) {
+        $ConfiguredServers = @($TargetServers)
+    }
+
+    foreach ($Server in @($ConfiguredServers) + @($DetectedServers)) {
+        $ServerName = [string] $Server
+        if (-not [string]::IsNullOrWhiteSpace($ServerName) -and $Seen.Add($ServerName.Trim())) {
+            $Candidates.Add($ServerName.Trim())
+        }
+    }
+
+    $Candidates.ToArray()
+}

--- a/Private/Get-InitialADComputers.ps1
+++ b/Private/Get-InitialADComputers.ps1
@@ -1,4 +1,4 @@
-﻿function Get-InitialADComputers {
+function Get-InitialADComputers {
     [CmdletBinding()]
     param(
         [System.Collections.IDictionary] $Report,
@@ -22,119 +22,75 @@
         [int] $ADQueryRetryDelay = 5,
         [int] $ADQueryPageSize = 1000
     )
-    $AllComputers = [ordered] @{}
+
+    $AllComputerKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $SuccessfulDomains = [System.Collections.Generic.List[string]]::new()
+    $FailedDomains = [System.Collections.Generic.List[string]]::new()
 
     $AzureRequired = $false
     $IntuneRequired = $false
     $JamfRequired = $false
 
-    if ($DisableOnlyIf) {
-        if ($null -ne $DisableOnlyIf.LastSyncAzureMoreThan -or $null -ne $DisableOnlyIf.LastSeenAzureMoreThan) {
+    foreach ($ActionIf in @($DisableOnlyIf, $MoveOnlyIf, $DeleteOnlyIf)) {
+        if ($null -eq $ActionIf) {
+            continue
+        }
+        if ($null -ne $ActionIf.LastSyncAzureMoreThan -or $null -ne $ActionIf.LastSeenAzureMoreThan) {
             $AzureRequired = $true
         }
-        if ($null -ne $DisableOnlyIf.LastContactJamfMoreThan) {
-            $JamfRequired = $true
-        }
-        if ($null -ne $DisableOnlyIf.LastSeenIntuneMoreThan) {
+        if ($null -ne $ActionIf.LastSeenIntuneMoreThan) {
             $IntuneRequired = $true
         }
-    }
-    if ($MoveOnlyIf) {
-        if ($null -ne $MoveOnlyIf.LastSyncAzureMoreThan -or $null -ne $MoveOnlyIf.LastSeenAzureMoreThan) {
-            $AzureRequired = $true
-        }
-        if ($null -ne $MoveOnlyIf.LastContactJamfMoreThan) {
+        if ($null -ne $ActionIf.LastContactJamfMoreThan) {
             $JamfRequired = $true
-        }
-        if ($null -ne $MoveOnlyIf.LastSeenIntuneMoreThan) {
-            $IntuneRequired = $true
-        }
-    }
-    if ($DeleteOnlyIf) {
-        if ($null -ne $DeleteOnlyIf.LastSyncAzureMoreThan -or $null -ne $DeleteOnlyIf.LastSeenAzureMoreThan) {
-            $AzureRequired = $true
-        }
-        if ($null -ne $DeleteOnlyIf.LastContactJamfMoreThan) {
-            $JamfRequired = $true
-        }
-        if ($null -ne $DeleteOnlyIf.LastSeenIntuneMoreThan) {
-            $IntuneRequired = $true
-        }
-    }
-
-    if ($TargetServers) {
-        # User provided target servers/server. If there is only one we assume user wants to use it for all domains (hopefully just one domain)
-        # If there are multiple we assume user wants to use different servers for different domains using hashtable/dictionary
-        # If there is no server for a domain we will use the default server, as detected
-        #
-        # Examples that work:
-        # String: -TargetServers "DC01.domain.com"
-        # Hashtable: -TargetServers @{ "domain1.com" = "DC01.domain1.com"; "domain2.com" = "DC02.domain2.com" }
-        # OrderedDictionary: -TargetServers ([ordered] @{ "domain1.com" = "DC01.domain1.com"; "domain2.com" = "DC02.domain2.com" })
-        #
-        if ($TargetServers -is [string]) {
-            $TargetServer = $TargetServers
-            Write-Color -Text "[i] Target server configured for all domains: ", $TargetServer -Color Yellow, Cyan
-        } elseif ($TargetServers -is [System.Collections.IDictionary]) {
-            $TargetServerDictionary = $TargetServers
-            if ($TargetServerDictionary.Count -eq 0) {
-                Write-Color -Text "[w] Target servers dictionary is empty. Using auto-detected servers." -Color Yellow, DarkYellow
-            } else {
-                Write-Color -Text "[i] Target servers configured per domain:" -Color Yellow, Cyan
-                foreach ($Entry in $TargetServerDictionary.GetEnumerator()) {
-                    $DomainKey = if ($Entry.Key) { $Entry.Key } else { "<null>" }
-                    $ServerValue = if ($Entry.Value) { $Entry.Value } else { "<null>" }
-                    Write-Color -Text "    ", $DomainKey, " -> ", $ServerValue -Color Yellow, Cyan, Yellow, Green
-                }
-            }
-        } else {
-            Write-Color -Text "[w] TargetServers parameter is not a string or hashtable/dictionary. Ignoring and using auto-detected servers." -Color Yellow, DarkYellow
         }
     }
 
     $CountDomains = 0
     foreach ($Domain in $ForestInformation.Domains) {
         $CountDomains++
-        $Report["$Domain"] = [ordered] @{ }
-        $Server = $ForestInformation['QueryServers'][$Domain].HostName[0]
-        if (-not $Server) {
-            Write-Color "[e] ", "No server found for domain $Domain" -Color Yellow, Red
+        $DetectedServers = @($ForestInformation['QueryServers'][$Domain].HostName)
+        $ServerCandidates = @(Get-ADQueryServerCandidates -Domain $Domain -TargetServers $TargetServers -DetectedServers $DetectedServers)
+        $DomainInformation = $ForestInformation.DomainsExtended[$Domain]
+
+        $Report["$Domain"] = [ordered] @{
+            QueryStatus          = 'Pending'
+            QueryError           = $null
+            Server               = $null
+            ServerCandidates     = $ServerCandidates
+            AttemptedServers     = @()
+            QueryAttempts        = 0
+            ComputerCount        = 0
+            Computers            = @()
+            ComputersToBeDisabled = 0
+            ComputersToBeMoved   = 0
+            ComputersToBeDeleted = 0
+        }
+
+        if ($ServerCandidates.Count -eq 0) {
+            $Report["$Domain"].QueryStatus = 'Failed'
+            $Report["$Domain"].QueryError = "No domain controller was found for $Domain."
+            $FailedDomains.Add($Domain)
+            Write-Color -Text '[e] ', $Report["$Domain"].QueryError -Color Yellow, Red
             continue
         }
-        if ($TargetServer) {
-            Write-Color -Text "[i] Overwriting target server for domain ", $Domain, ": ", $TargetServer -Color Yellow, Magenta
-            $Server = $TargetServer
-        } elseif ($TargetServerDictionary) {
-            # Try exact match first
-            if ($TargetServerDictionary[$Domain]) {
-                Write-Color -Text "[i] Overwriting target server for domain ", $Domain, ": ", $TargetServerDictionary[$Domain] -Color Yellow, Magenta
-                $Server = $TargetServerDictionary[$Domain]
-            } else {
-                # Try case-insensitive match
-                $MatchedKey = $TargetServerDictionary.Keys | Where-Object { $_ -ieq $Domain }
-                if ($MatchedKey) {
-                    Write-Color -Text "[i] Overwriting target server for domain ", $Domain, " (case-insensitive match): ", $TargetServerDictionary[$MatchedKey] -Color Yellow, Magenta
-                    $Server = $TargetServerDictionary[$MatchedKey]
-                } else {
-                    Write-Color -Text "[i] No target server specified for domain ", $Domain, ", using auto-detected server: ", $Server -Color Yellow, Cyan
-                }
-            }
-        }
-        $DomainInformation = $ForestInformation.DomainsExtended[$Domain]
-        $Report["$Domain"]['Server'] = $Server
-        Write-Color "[i] Getting all computers for domain ", $Domain, " [", $CountDomains, "/", $ForestInformation.Domains.Count, "]", " from ", $Server -Color Yellow, Magenta, Yellow, Magenta, Yellow, Magenta, Yellow, Yellow, Magenta
+
+        Write-Color -Text '[i] ', "Getting all computers for domain $Domain [$CountDomains/$($ForestInformation.Domains.Count)]. Candidate servers: $($ServerCandidates -join ', ')" -Color Yellow, Magenta
 
         if ($Filter) {
             if ($Filter -is [string]) {
                 $FilterToUse = $Filter
             } elseif ($Filter -is [System.Collections.IDictionary]) {
                 $FilterToUse = $Filter[$Domain]
+                if ([string]::IsNullOrWhiteSpace([string] $FilterToUse)) {
+                    $FilterToUse = '*'
+                }
             } else {
-                Write-Color "[e] ", "Filter must be a string or a hashtable/ordereddictionary" -Color Yellow, Red
+                Write-Color -Text '[e] ', 'Filter must be a string or a hashtable/ordereddictionary.' -Color Yellow, Red
                 return $false
             }
         } else {
-            $FilterToUse = "*"
+            $FilterToUse = '*'
         }
 
         if ($SearchBase) {
@@ -143,159 +99,116 @@
             } elseif ($SearchBase -is [System.Collections.IDictionary]) {
                 $SearchBaseToUse = $SearchBase[$Domain]
             } else {
-                Write-Color "[e] ", "SearchBase must be a string or a hashtable/ordereddictionary" -Color Yellow, Red
+                Write-Color -Text '[e] ', 'SearchBase must be a string or a hashtable/ordereddictionary.' -Color Yellow, Red
                 return $false
             }
         } else {
             $SearchBaseToUse = $DomainInformation.DistinguishedName
         }
 
-        $getADComputerSplat = @{
-            Filter         = $FilterToUse
-            Server         = $Server
-            Properties     = $Properties
-            ErrorAction    = 'Stop'
-            # Use ADQueryPageSize for consistent paging behavior
-            ResultPageSize = $ADQueryPageSize
-            ResultSetSize  = $null
+        $QueryParameters = @{
+            Filter     = $FilterToUse
+            Properties = $Properties
         }
         if ($SearchBaseToUse) {
-            $getADComputerSplat.SearchBase = $SearchBaseToUse
+            $QueryParameters.SearchBase = $SearchBaseToUse
         }
 
-        # Implement retry logic for handling enumeration context errors
-        $MaxRetries = $ADQueryMaxRetries
-        $RetryDelay = $ADQueryRetryDelay
-        $Computers = @()
-        $Success = $false
+        $QueryResult = Invoke-ADComputerInventoryQuery `
+            -Domain $Domain `
+            -Servers $ServerCandidates `
+            -QueryParameters $QueryParameters `
+            -AzureInformationCache $AzureInformationCache `
+            -JamfInformationCache $JamfInformationCache `
+            -IncludeAzureAD:$AzureRequired `
+            -IncludeIntune:$IntuneRequired `
+            -IncludeJamf:$JamfRequired `
+            -MaxAttemptsPerServer $ADQueryMaxRetries `
+            -RetryDelaySeconds $ADQueryRetryDelay `
+            -PageSize $ADQueryPageSize
 
-        for ($RetryCount = 1; $RetryCount -le $MaxRetries; $RetryCount++) {
-            try {
-                Write-Color -Text "[i] ", "Attempting to get computers (attempt $RetryCount of $MaxRetries)..." -Color Yellow, Cyan
-                [Array] $Computers = Get-ADComputer @getADComputerSplat
-                $Success = $true
-                break
-            } catch {
-                $ErrorMessage = $_.Exception.Message
-                if ($ErrorMessage -like "*invalid enumeration context*" -or $ErrorMessage -like "*timeout*" -or $ErrorMessage -like "*server is not operational*") {
-                    Write-Color "[w] ", "Enumeration error on attempt $RetryCount`: $ErrorMessage" -Color Yellow, DarkYellow
-                    if ($RetryCount -lt $MaxRetries) {
-                        Write-Color "[i] ", "Waiting $RetryDelay seconds before retry..." -Color Yellow, Cyan
-                        Start-Sleep -Seconds $RetryDelay
-                        # Increase delay for next retry
-                        $RetryDelay = $RetryDelay * 2
-                    }
-                } elseif ($ErrorMessage -like "*distinguishedName must belong to one of the following partition*") {
-                    Write-Color "[e] ", "Error getting computers for domain $($Domain): ", $ErrorMessage -Color Yellow, Red
-                    Write-Color "[e] ", "Please check if the distinguishedName for SearchBase is correct for the domain. If you have multiple domains please use Hashtable/Dictionary to provide relevant data or using IncludeDomains/ExcludeDomains functionality" -Color Yellow, Red
-                    return $false
-                } else {
-                    Write-Color "[e] ", "Error getting computers for domain $($Domain): ", $ErrorMessage -Color Yellow, Red
-                    # For non-retry-able errors, break the loop
-                    break
-                }
-            }
+        $Report["$Domain"].Server = $QueryResult.Server
+        $Report["$Domain"].AttemptedServers = @($QueryResult.Attempts | Select-Object -ExpandProperty Server -Unique)
+        $Report["$Domain"].QueryAttempts = $QueryResult.Attempts.Count
+
+        if (-not $QueryResult.Succeeded) {
+            $Report["$Domain"].QueryStatus = 'Failed'
+            $Report["$Domain"].QueryError = $QueryResult.Error
+            $FailedDomains.Add($Domain)
+            Write-Color -Text '[e] ', "Unable to inventory domain $Domain after trying $($Report["$Domain"].AttemptedServers -join ', '): $($QueryResult.Error)" -Color Yellow, Red
+            continue
         }
 
-        # If all retries failed, try alternative approach with smaller page size
-        if (-not $Success) {
-            Write-Color "[w] ", "Standard query failed after $MaxRetries attempts. Trying alternative approach with smaller page size..." -Color Yellow, DarkYellow
-            try {
-                # Use a smaller page size to handle large result sets
-                $getADComputerSplat.ResultPageSize = [math]::Min($ADQueryPageSize, 500)
-                $getADComputerSplat.ResultSetSize = $null
-                [Array] $Computers = Get-ADComputer @getADComputerSplat
-                $Success = $true
-                Write-Color "[+] ", "Alternative query with smaller page size succeeded!" -Color Yellow, Green
-            } catch {
-                Write-Color "[e] ", "All query attempts failed for domain $($Domain): ", $_.Exception.Message -Color Yellow, Red
-                return $false
-            }
-        }
-
-        if (-not $Success) {
-            Write-Color "[e] ", "Failed to retrieve computers for domain $($Domain) after all attempts." -Color Yellow, Red
-            return $false
-        }
+        [Array] $Computers = $QueryResult.Computers
+        $Report["$Domain"].QueryStatus = 'Succeeded'
+        $Report["$Domain"].ComputerCount = $Computers.Count
+        $Report["$Domain"].Computers = $Computers
+        $SuccessfulDomains.Add($Domain)
 
         foreach ($Computer in $Computers) {
-            # we will be using it later to just check if computer exists in AD
-            $DomainName = ConvertFrom-DistinguishedName -DistinguishedName $Computer.DistinguishedName -ToDomainCN
-            $ComputerFullName = -join ($Computer.SamAccountName, "@", $DomainName)
-            # initially we used DN, but DN changes when moving so it wouldn't work
-            $AllComputers[$ComputerFullName] = $Computer
+            $ComputerFullName = -join ($Computer.SamAccountName, '@', $Computer.DomainName)
+            $null = $AllComputerKeys.Add($ComputerFullName)
         }
-        $Report["$Domain"]['Computers'] = @(
-            $convertToPreparedComputerSplat = @{
-                Computers             = $Computers
-                AzureInformationCache = $AzureInformationCache
-                JamfInformationCache  = $JamfInformationCache
-                IncludeAzureAD        = $AzureRequired
-                IncludeJamf           = $JamfRequired
-                IncludeIntune         = $IntuneRequired
-            }
 
-            ConvertTo-PreparedComputer @convertToPreparedComputerSplat
-        )
-        Write-Color "[i] ", "Computers found for domain $Domain`: ", $($Computers.Count) -Color Yellow, Cyan, Green
+        Write-Color -Text '[i] ', "Computers found for domain $Domain through $($QueryResult.Server): ", $Computers.Count -Color Yellow, Cyan, Green
+
         if ($Disable) {
-            Write-Color "[i] ", "Processing computers to disable for domain $Domain" -Color Yellow, Cyan, Green
-            $getADComputersToDisableSplat = @{
-                Computers             = $Report["$Domain"]['Computers']
-                DisableOnlyIf         = $DisableOnlyIf
-                Exclusions            = $Exclusions
-                DomainInformation     = $DomainInformation
-                ProcessedComputers    = $ProcessedComputers
-                AzureInformationCache = $AzureInformationCache
-                JamfInformationCache  = $JamfInformationCache
-                IncludeAzureAD        = $AzureRequired
-                IncludeJamf           = $JamfRequired
-                IncludeIntune         = $IntuneRequired
-                Type                  = 'Disable'
-            }
-            $Report["$Domain"]['ComputersToBeDisabled'] = Get-ADComputersToProcess @getADComputersToDisableSplat
-            #Write-Color "[i] ", "Computers to be disabled for domain $Domain`: ", $($Report["$Domain"]['ComputersToBeDisabled'].Count) -Color Yellow, Cyan, Green
+            Write-Color -Text '[i] ', "Processing computers to disable for domain $Domain" -Color Yellow, Cyan
+            $Report["$Domain"].ComputersToBeDisabled = Get-ADComputersToProcess `
+                -Computers $Computers `
+                -DisableOnlyIf $DisableOnlyIf `
+                -Exclusions $Exclusions `
+                -DomainInformation $DomainInformation `
+                -ProcessedComputers $ProcessedComputers `
+                -AzureInformationCache $AzureInformationCache `
+                -JamfInformationCache $JamfInformationCache `
+                -IncludeAzureAD:$AzureRequired `
+                -IncludeIntune:$IntuneRequired `
+                -IncludeJamf:$JamfRequired `
+                -Type Disable
         }
         if ($Move) {
-            Write-Color "[i] ", "Processing computers to move for domain $Domain" -Color Yellow, Cyan, Green
-            $getADComputersToDeleteSplat = @{
-                Computers             = $Report["$Domain"]['Computers']
-                MoveOnlyIf            = $MoveOnlyIf
-                Exclusions            = $Exclusions
-                DomainInformation     = $DomainInformation
-                ProcessedComputers    = $ProcessedComputers
-                AzureInformationCache = $AzureInformationCache
-                JamfInformationCache  = $JamfInformationCache
-                IncludeAzureAD        = $AzureRequired
-                IncludeJamf           = $JamfRequired
-                IncludeIntune         = $IntuneRequired
-                Type                  = 'Move'
-            }
-            $Report["$Domain"]['ComputersToBeMoved'] = Get-ADComputersToProcess @getADComputersToDeleteSplat
-            #Write-Color "[i] ", "Computers to be moved for domain $Domain`: ", $($Report["$Domain"]['ComputersToBeMoved'].Count) -Color Yellow, Cyan, Green
+            Write-Color -Text '[i] ', "Processing computers to move for domain $Domain" -Color Yellow, Cyan
+            $Report["$Domain"].ComputersToBeMoved = Get-ADComputersToProcess `
+                -Computers $Computers `
+                -MoveOnlyIf $MoveOnlyIf `
+                -Exclusions $Exclusions `
+                -DomainInformation $DomainInformation `
+                -ProcessedComputers $ProcessedComputers `
+                -AzureInformationCache $AzureInformationCache `
+                -JamfInformationCache $JamfInformationCache `
+                -IncludeAzureAD:$AzureRequired `
+                -IncludeIntune:$IntuneRequired `
+                -IncludeJamf:$JamfRequired `
+                -Type Move
         }
         if ($Delete) {
-            Write-Color "[i] ", "Processing computers to delete for domain $Domain" -Color Yellow, Cyan, Green
-            $getADComputersToDeleteSplat = @{
-                Computers             = $Report["$Domain"]['Computers']
-                DeleteOnlyIf          = $DeleteOnlyIf
-                Exclusions            = $Exclusions
-                DomainInformation     = $DomainInformation
-                ProcessedComputers    = $ProcessedComputers
-                AzureInformationCache = $AzureInformationCache
-                JamfInformationCache  = $JamfInformationCache
-                IncludeAzureAD        = $AzureRequired
-                IncludeJamf           = $JamfRequired
-                IncludeIntune         = $IntuneRequired
-                Type                  = 'Delete'
-            }
-            $Report["$Domain"]['ComputersToBeDeleted'] = Get-ADComputersToProcess @getADComputersToDeleteSplat
-            #Write-Color "[i] ", "Computers to be deleted for domain $Domain`: ", $($Report["$Domain"]['ComputersToBeDeleted'].Count) -Color Yellow, Cyan, Green
+            Write-Color -Text '[i] ', "Processing computers to delete for domain $Domain" -Color Yellow, Cyan
+            $Report["$Domain"].ComputersToBeDeleted = Get-ADComputersToProcess `
+                -Computers $Computers `
+                -DeleteOnlyIf $DeleteOnlyIf `
+                -Exclusions $Exclusions `
+                -DomainInformation $DomainInformation `
+                -ProcessedComputers $ProcessedComputers `
+                -AzureInformationCache $AzureInformationCache `
+                -JamfInformationCache $JamfInformationCache `
+                -IncludeAzureAD:$AzureRequired `
+                -IncludeIntune:$IntuneRequired `
+                -IncludeJamf:$JamfRequired `
+                -Type Delete
         }
     }
-    if ($null -ne $SafetyADLimit -and $AllComputers.Count -lt $SafetyADLimit) {
-        Write-Color "[e] ", "Only ", $($AllComputers.Count), " computers found in AD, this is less than the safety limit of ", $SafetyADLimit, ". Terminating!" -Color Yellow, Cyan, Red, Cyan
-        return $false
+
+    $SafetyLimitSatisfied = $null -eq $SafetyADLimit -or $AllComputerKeys.Count -ge $SafetyADLimit
+    if (-not $SafetyLimitSatisfied) {
+        Write-Color -Text '[e] ', 'Only ', $AllComputerKeys.Count, ' computers were found in AD, which is below the safety limit of ', $SafetyADLimit, '. All mutations will be suppressed.' -Color Yellow, Cyan, Red, Cyan
     }
-    $AllComputers
+
+    [PSCustomObject] [ordered] @{
+        Succeeded            = $FailedDomains.Count -eq 0
+        SafetyLimitSatisfied = $SafetyLimitSatisfied
+        ComputerKeys         = $AllComputerKeys
+        SuccessfulDomains    = $SuccessfulDomains.ToArray()
+        FailedDomains        = $FailedDomains.ToArray()
+    }
 }

--- a/Private/Get-InitialADComputers.ps1
+++ b/Private/Get-InitialADComputers.ps1
@@ -82,46 +82,47 @@ function Get-InitialADComputers {
 
         Write-Color -Text '[i] ', "Getting all computers for domain $Domain [$CountDomains/$($ForestInformation.Domains.Count)]. Candidate servers: $($ServerCandidates -join ', ')" -Color Yellow, Magenta
 
-        if ($Filter) {
-            if ($Filter -is [string]) {
-                $FilterToUse = $Filter
-            } elseif ($Filter -is [System.Collections.IDictionary]) {
-                $FilterToUse = $Filter[$Domain]
-                if ([string]::IsNullOrWhiteSpace([string] $FilterToUse)) {
-                    $Report["$Domain"].QueryStatus = 'Failed'
-                    $Report["$Domain"].QueryError = "No AD filter was configured for domain $Domain."
-                    $FailedDomains.Add($Domain)
-                    Write-Color -Text '[e] ', $Report["$Domain"].QueryError -Color Yellow, Red
-                    continue
-                }
-            } else {
-                Write-Color -Text '[e] ', 'Filter must be a string or a hashtable/ordereddictionary.' -Color Yellow, Red
-                return $false
-            }
-        } else {
+        if ($null -eq $Filter) {
             $FilterToUse = '*'
+        } elseif ($Filter -is [string]) {
+            $FilterToUse = $Filter
+        } elseif ($Filter -is [System.Collections.IDictionary]) {
+            $FilterToUse = $Filter[$Domain]
+        } else {
+            Write-Color -Text '[e] ', 'Filter must be a string or a hashtable/ordereddictionary.' -Color Yellow, Red
+            return $false
+        }
+        if ([string]::IsNullOrWhiteSpace([string] $FilterToUse)) {
+            $Report["$Domain"].QueryStatus = 'Failed'
+            $Report["$Domain"].QueryError = "No AD filter was configured for domain $Domain."
+            $FailedDomains.Add($Domain)
+            Write-Color -Text '[e] ', $Report["$Domain"].QueryError -Color Yellow, Red
+            continue
         }
 
-        if ($SearchBase) {
-            if ($SearchBase -is [string]) {
-                $SearchBaseToUse = $SearchBase
-            } elseif ($SearchBase -is [System.Collections.IDictionary]) {
-                $SearchBaseToUse = $SearchBase[$Domain]
-            } else {
-                Write-Color -Text '[e] ', 'SearchBase must be a string or a hashtable/ordereddictionary.' -Color Yellow, Red
-                return $false
-            }
-        } else {
+        if ($null -eq $SearchBase) {
             $SearchBaseToUse = $DomainInformation.DistinguishedName
+        } elseif ($SearchBase -is [string]) {
+            $SearchBaseToUse = $SearchBase
+        } elseif ($SearchBase -is [System.Collections.IDictionary]) {
+            $SearchBaseToUse = $SearchBase[$Domain]
+        } else {
+            Write-Color -Text '[e] ', 'SearchBase must be a string or a hashtable/ordereddictionary.' -Color Yellow, Red
+            return $false
+        }
+        if ([string]::IsNullOrWhiteSpace([string] $SearchBaseToUse)) {
+            $Report["$Domain"].QueryStatus = 'Failed'
+            $Report["$Domain"].QueryError = "No AD search base was configured for domain $Domain."
+            $FailedDomains.Add($Domain)
+            Write-Color -Text '[e] ', $Report["$Domain"].QueryError -Color Yellow, Red
+            continue
         }
 
         $QueryParameters = @{
             Filter     = $FilterToUse
             Properties = $Properties
         }
-        if ($SearchBaseToUse) {
-            $QueryParameters.SearchBase = $SearchBaseToUse
-        }
+        $QueryParameters.SearchBase = $SearchBaseToUse
 
         $QueryResult = Invoke-ADComputerInventoryQuery `
             -Domain $Domain `

--- a/Private/Get-InitialADComputers.ps1
+++ b/Private/Get-InitialADComputers.ps1
@@ -219,7 +219,7 @@ function Get-InitialADComputers {
         Write-Color -Text '[e] ', 'Only ', $AllComputerKeys.Count, ' computers were found in AD, which is below the safety limit of ', $SafetyADLimit, '. All mutations will be suppressed.' -Color Yellow, Cyan, Red, Cyan
     }
 
-    [PSCustomObject] [ordered] @{
+    [PSCustomObject] @{
         Succeeded            = $FailedDomains.Count -eq 0
         SafetyLimitSatisfied = $SafetyLimitSatisfied
         ComputerKeys         = $AllComputerKeys

--- a/Private/Get-InitialADComputers.ps1
+++ b/Private/Get-InitialADComputers.ps1
@@ -26,6 +26,7 @@ function Get-InitialADComputers {
     $AllComputerKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
     $SuccessfulDomains = [System.Collections.Generic.List[string]]::new()
     $FailedDomains = [System.Collections.Generic.List[string]]::new()
+    $PendingStateRollback = [ordered] @{}
 
     $AzureRequired = $false
     $IntuneRequired = $false
@@ -83,7 +84,11 @@ function Get-InitialADComputers {
             } elseif ($Filter -is [System.Collections.IDictionary]) {
                 $FilterToUse = $Filter[$Domain]
                 if ([string]::IsNullOrWhiteSpace([string] $FilterToUse)) {
-                    $FilterToUse = '*'
+                    $Report["$Domain"].QueryStatus = 'Failed'
+                    $Report["$Domain"].QueryError = "No AD filter was configured for domain $Domain."
+                    $FailedDomains.Add($Domain)
+                    Write-Color -Text '[e] ', $Report["$Domain"].QueryError -Color Yellow, Red
+                    continue
                 }
             } else {
                 Write-Color -Text '[e] ', 'Filter must be a string or a hashtable/ordereddictionary.' -Color Yellow, Red
@@ -160,6 +165,7 @@ function Get-InitialADComputers {
                 -Exclusions $Exclusions `
                 -DomainInformation $DomainInformation `
                 -ProcessedComputers $ProcessedComputers `
+                -PendingStateRollback $PendingStateRollback `
                 -AzureInformationCache $AzureInformationCache `
                 -JamfInformationCache $JamfInformationCache `
                 -IncludeAzureAD:$AzureRequired `
@@ -175,6 +181,7 @@ function Get-InitialADComputers {
                 -Exclusions $Exclusions `
                 -DomainInformation $DomainInformation `
                 -ProcessedComputers $ProcessedComputers `
+                -PendingStateRollback $PendingStateRollback `
                 -AzureInformationCache $AzureInformationCache `
                 -JamfInformationCache $JamfInformationCache `
                 -IncludeAzureAD:$AzureRequired `
@@ -190,6 +197,7 @@ function Get-InitialADComputers {
                 -Exclusions $Exclusions `
                 -DomainInformation $DomainInformation `
                 -ProcessedComputers $ProcessedComputers `
+                -PendingStateRollback $PendingStateRollback `
                 -AzureInformationCache $AzureInformationCache `
                 -JamfInformationCache $JamfInformationCache `
                 -IncludeAzureAD:$AzureRequired `
@@ -210,5 +218,6 @@ function Get-InitialADComputers {
         ComputerKeys         = $AllComputerKeys
         SuccessfulDomains    = $SuccessfulDomains.ToArray()
         FailedDomains        = $FailedDomains.ToArray()
+        PendingStateRollback = $PendingStateRollback
     }
 }

--- a/Private/Get-InitialADComputers.ps1
+++ b/Private/Get-InitialADComputers.ps1
@@ -20,6 +20,10 @@ function Get-InitialADComputers {
         [object] $TargetServers,
         [int] $ADQueryMaxRetries = 3,
         [int] $ADQueryRetryDelay = 5,
+        [ValidateRange(1, 300)]
+        [int] $ADQueryConnectionTimeout = 15,
+        [ValidateRange(1, 3600)]
+        [int] $ADQueryIdleTimeout = 120,
         [int] $ADQueryPageSize = 1000
     )
 
@@ -130,6 +134,8 @@ function Get-InitialADComputers {
             -IncludeJamf:$JamfRequired `
             -MaxAttemptsPerServer $ADQueryMaxRetries `
             -RetryDelaySeconds $ADQueryRetryDelay `
+            -ConnectionTimeoutSeconds $ADQueryConnectionTimeout `
+            -IdleTimeoutSeconds $ADQueryIdleTimeout `
             -PageSize $ADQueryPageSize
 
         $Report["$Domain"].Server = $QueryResult.Server

--- a/Private/Get-InitialCloudDevices.ps1
+++ b/Private/Get-InitialCloudDevices.ps1
@@ -228,7 +228,7 @@ function Get-InitialCloudDevices {
             'NotClaimed'
         }
 
-        $outputDevices.Add([PSCustomObject] [ordered] @{
+        $outputDevices.Add([PSCustomObject] @{
             Name                    = $entraDevice.Name
             EntraDeviceObjectId     = $entraDevice.EntraDeviceObjectId
             DeviceId                = $entraDevice.DeviceId
@@ -304,7 +304,7 @@ function Get-InitialCloudDevices {
             $autopilotLastContactedDays = & $getAgeDays $autopilotLastContacted
         }
 
-        $outputDevices.Add([PSCustomObject] [ordered] @{
+        $outputDevices.Add([PSCustomObject] @{
             Name                    = $intuneDevice.Name
             EntraDeviceObjectId     = $intuneDevice.EntraDeviceObjectId
             DeviceId                = $intuneDevice.AzureAdDeviceId

--- a/Private/Invoke-ADComputerInventoryAttempt.ps1
+++ b/Private/Invoke-ADComputerInventoryAttempt.ps1
@@ -18,6 +18,8 @@ function Invoke-ADComputerInventoryAttempt {
         [int] $PageSize = 1000,
         [ValidateRange(1, 300)]
         [int] $ConnectionTimeoutSeconds = 15,
+        [ValidateRange(1, 300)]
+        [int] $InitializationTimeoutSeconds = 60,
         [ValidateRange(1, 3600)]
         [int] $IdleTimeoutSeconds = 120,
         [DateTime] $Today = (Get-Date),
@@ -29,6 +31,7 @@ function Invoke-ADComputerInventoryAttempt {
     $TemporaryDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "CleanupMonster.ADQuery.$([Guid]::NewGuid().ToString('N'))"
     $null = [System.IO.Directory]::CreateDirectory($TemporaryDirectory)
     $ConfigurationPath = Join-Path $TemporaryDirectory 'query.clixml'
+    $InitializationPath = Join-Path $TemporaryDirectory 'initialized'
     $ReadyPath = Join-Path $TemporaryDirectory 'ready'
     $ProgressPath = Join-Path $TemporaryDirectory 'progress'
     $SuccessPath = Join-Path $TemporaryDirectory 'success'
@@ -45,6 +48,7 @@ function Invoke-ADComputerInventoryAttempt {
             Properties   = @($QueryParameters.Properties)
             SearchBase   = $QueryParameters.SearchBase
             PageSize     = $PageSize
+            InitializationPath = $InitializationPath
             ReadyPath    = $ReadyPath
             ProgressPath = $ProgressPath
             SuccessPath  = $SuccessPath
@@ -64,15 +68,26 @@ function Invoke-ADComputerInventoryAttempt {
             -RedirectStandardError $StandardErrorPath `
             -PassThru
 
+        $InitializationObserved = $false
         $ReadyObserved = $false
-        $ConnectionDeadline = [DateTime]::UtcNow.AddSeconds($ConnectionTimeoutSeconds)
+        $InitializationDeadline = [DateTime]::UtcNow.AddSeconds($InitializationTimeoutSeconds)
+        $ConnectionDeadline = $null
         $LastProgress = [DateTime]::UtcNow
         $TimedOut = $false
         $TimeoutPhase = $null
 
         while (-not $Process.WaitForExit(250)) {
             $Now = [DateTime]::UtcNow
-            if (-not $ReadyObserved) {
+            if (-not $InitializationObserved) {
+                if (Test-Path -LiteralPath $InitializationPath) {
+                    $InitializationObserved = $true
+                    $ConnectionDeadline = $Now.AddSeconds($ConnectionTimeoutSeconds)
+                } elseif ($Now -ge $InitializationDeadline) {
+                    $TimedOut = $true
+                    $TimeoutPhase = 'Initialization'
+                    break
+                }
+            } elseif (-not $ReadyObserved) {
                 if (Test-Path -LiteralPath $ReadyPath) {
                     $ReadyObserved = $true
                     $LastProgress = $Now
@@ -101,9 +116,13 @@ function Invoke-ADComputerInventoryAttempt {
                 $Process.Kill()
                 $null = $Process.WaitForExit(5000)
             } catch {
-                # The process may have exited between the timeout decision and Kill.
+                Write-Verbose "The isolated AD query process exited before it could be stopped: $($_.Exception.Message)"
             }
-            $TimeoutSeconds = if ($TimeoutPhase -eq 'Connection') { $ConnectionTimeoutSeconds } else { $IdleTimeoutSeconds }
+            $TimeoutSeconds = switch ($TimeoutPhase) {
+                'Initialization' { $InitializationTimeoutSeconds }
+                'Connection' { $ConnectionTimeoutSeconds }
+                default { $IdleTimeoutSeconds }
+            }
             return [PSCustomObject] [ordered] @{
                 Succeeded    = $false
                 Computers    = @()

--- a/Private/Invoke-ADComputerInventoryAttempt.ps1
+++ b/Private/Invoke-ADComputerInventoryAttempt.ps1
@@ -44,7 +44,7 @@ function Invoke-ADComputerInventoryAttempt {
     $EffectiveIdleTimeoutMilliseconds = ($IdleTimeoutSeconds * 1000) + $ProgressIntervalMilliseconds
 
     try {
-        $Configuration = [PSCustomObject] [ordered] @{
+        $Configuration = [PSCustomObject] @{
             Server       = $Server
             Filter       = $QueryParameters.Filter
             Properties   = @($QueryParameters.Properties)
@@ -144,7 +144,7 @@ function Invoke-ADComputerInventoryAttempt {
             } else {
                 "AD $($TimeoutPhase.ToLowerInvariant()) timeout after $TimeoutSeconds seconds through $Server. The isolated query process was stopped."
             }
-            return [PSCustomObject] [ordered] @{
+            return [PSCustomObject] @{
                 Succeeded    = $false
                 Computers    = @()
                 TimedOut     = $true
@@ -169,7 +169,7 @@ function Invoke-ADComputerInventoryAttempt {
             } else {
                 "The isolated AD query process exited with code $($Process.ExitCode)."
             }
-            return [PSCustomObject] [ordered] @{
+            return [PSCustomObject] @{
                 Succeeded    = $false
                 Computers    = @()
                 TimedOut     = $false
@@ -193,7 +193,7 @@ function Invoke-ADComputerInventoryAttempt {
             @()
         }
 
-        [PSCustomObject] [ordered] @{
+        [PSCustomObject] @{
             Succeeded    = $true
             Computers    = $PreparedComputers
             TimedOut     = $false
@@ -202,7 +202,7 @@ function Invoke-ADComputerInventoryAttempt {
             ErrorMessage = $null
         }
     } catch {
-        [PSCustomObject] [ordered] @{
+        [PSCustomObject] @{
             Succeeded    = $false
             Computers    = @()
             TimedOut     = $false

--- a/Private/Invoke-ADComputerInventoryAttempt.ps1
+++ b/Private/Invoke-ADComputerInventoryAttempt.ps1
@@ -23,7 +23,7 @@ function Invoke-ADComputerInventoryAttempt {
         [ValidateRange(1, 3600)]
         [int] $IdleTimeoutSeconds = 120,
         [DateTime] $Today = (Get-Date),
-        [string] $ChildProcessFunctionPath = (Join-Path $PSScriptRoot 'Invoke-ADComputerInventoryChildProcess.ps1')
+        [string] $ChildProcessFunctionPath
     )
 
     $Started = Get-Date
@@ -58,18 +58,31 @@ function Invoke-ADComputerInventoryAttempt {
             ErrorPath    = $ErrorPath
             DataPath     = $DataPath
         }
-        $Configuration | Export-Clixml -LiteralPath $ConfigurationPath -Depth 4
+        $PreviousWhatIfPreference = $WhatIfPreference
+        try {
+            # Inventory setup is non-destructive infrastructure required even
+            # when the caller previews later cleanup actions with -WhatIf.
+            $WhatIfPreference = $false
+            $Configuration | Export-Clixml -LiteralPath $ConfigurationPath -Depth 4
 
-        $EscapedFunctionPath = $ChildProcessFunctionPath.Replace("'", "''")
-        $EscapedConfigurationPath = $ConfigurationPath.Replace("'", "''")
-        $Command = "& { . '$EscapedFunctionPath'; Invoke-ADComputerInventoryChildProcess -ConfigurationPath '$EscapedConfigurationPath'; exit 0 }"
-        $EncodedCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($Command))
-        $Process = Start-Process -FilePath $PowerShellPath `
-            -ArgumentList '-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', $EncodedCommand `
-            -WindowStyle Hidden `
-            -RedirectStandardOutput $StandardOutputPath `
-            -RedirectStandardError $StandardErrorPath `
-            -PassThru
+            $EscapedConfigurationPath = $ConfigurationPath.Replace("'", "''")
+            if ($ChildProcessFunctionPath) {
+                $EscapedFunctionPath = $ChildProcessFunctionPath.Replace("'", "''")
+                $Command = "& { . '$EscapedFunctionPath'; Invoke-ADComputerInventoryChildProcess -ConfigurationPath '$EscapedConfigurationPath'; exit 0 }"
+            } else {
+                $ChildProcessFunction = Get-Command -Name Invoke-ADComputerInventoryChildProcess -CommandType Function -ErrorAction Stop
+                $Command = "& { function Invoke-ADComputerInventoryChildProcess {`n$($ChildProcessFunction.Definition)`n}; Invoke-ADComputerInventoryChildProcess -ConfigurationPath '$EscapedConfigurationPath'; exit 0 }"
+            }
+            $EncodedCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($Command))
+            $Process = Start-Process -FilePath $PowerShellPath `
+                -ArgumentList '-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', $EncodedCommand `
+                -WindowStyle Hidden `
+                -RedirectStandardOutput $StandardOutputPath `
+                -RedirectStandardError $StandardErrorPath `
+                -PassThru
+        } finally {
+            $WhatIfPreference = $PreviousWhatIfPreference
+        }
 
         $InitializationObserved = $false
         $ReadyObserved = $false

--- a/Private/Invoke-ADComputerInventoryAttempt.ps1
+++ b/Private/Invoke-ADComputerInventoryAttempt.ps1
@@ -1,0 +1,193 @@
+function Invoke-ADComputerInventoryAttempt {
+    <#
+    .SYNOPSIS
+    Runs one killable, bounded-idle AD computer inventory attempt.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $Server,
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $QueryParameters,
+        [System.Collections.IDictionary] $AzureInformationCache,
+        [System.Collections.IDictionary] $JamfInformationCache,
+        [switch] $IncludeAzureAD,
+        [switch] $IncludeIntune,
+        [switch] $IncludeJamf,
+        [ValidateRange(1, 10000)]
+        [int] $PageSize = 1000,
+        [ValidateRange(1, 300)]
+        [int] $ConnectionTimeoutSeconds = 15,
+        [ValidateRange(1, 3600)]
+        [int] $IdleTimeoutSeconds = 120,
+        [DateTime] $Today = (Get-Date),
+        [string] $ChildProcessFunctionPath = (Join-Path $PSScriptRoot 'Invoke-ADComputerInventoryChildProcess.ps1')
+    )
+
+    $Started = Get-Date
+    $PowerShellPath = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+    $TemporaryDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "CleanupMonster.ADQuery.$([Guid]::NewGuid().ToString('N'))"
+    $null = [System.IO.Directory]::CreateDirectory($TemporaryDirectory)
+    $ConfigurationPath = Join-Path $TemporaryDirectory 'query.clixml'
+    $ReadyPath = Join-Path $TemporaryDirectory 'ready'
+    $ProgressPath = Join-Path $TemporaryDirectory 'progress'
+    $SuccessPath = Join-Path $TemporaryDirectory 'success'
+    $ErrorPath = Join-Path $TemporaryDirectory 'error.txt'
+    $DataPath = Join-Path $TemporaryDirectory 'computers.csv'
+    $StandardOutputPath = Join-Path $TemporaryDirectory 'stdout.txt'
+    $StandardErrorPath = Join-Path $TemporaryDirectory 'stderr.txt'
+    $Process = $null
+
+    try {
+        $Configuration = [PSCustomObject] [ordered] @{
+            Server       = $Server
+            Filter       = $QueryParameters.Filter
+            Properties   = @($QueryParameters.Properties)
+            SearchBase   = $QueryParameters.SearchBase
+            PageSize     = $PageSize
+            ReadyPath    = $ReadyPath
+            ProgressPath = $ProgressPath
+            SuccessPath  = $SuccessPath
+            ErrorPath    = $ErrorPath
+            DataPath     = $DataPath
+        }
+        $Configuration | Export-Clixml -LiteralPath $ConfigurationPath -Depth 4
+
+        $EscapedFunctionPath = $ChildProcessFunctionPath.Replace("'", "''")
+        $EscapedConfigurationPath = $ConfigurationPath.Replace("'", "''")
+        $Command = "& { . '$EscapedFunctionPath'; Invoke-ADComputerInventoryChildProcess -ConfigurationPath '$EscapedConfigurationPath'; exit 0 }"
+        $EncodedCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($Command))
+        $Process = Start-Process -FilePath $PowerShellPath `
+            -ArgumentList '-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', $EncodedCommand `
+            -WindowStyle Hidden `
+            -RedirectStandardOutput $StandardOutputPath `
+            -RedirectStandardError $StandardErrorPath `
+            -PassThru
+
+        $ReadyObserved = $false
+        $ConnectionDeadline = [DateTime]::UtcNow.AddSeconds($ConnectionTimeoutSeconds)
+        $LastProgress = [DateTime]::UtcNow
+        $TimedOut = $false
+        $TimeoutPhase = $null
+
+        while (-not $Process.WaitForExit(250)) {
+            $Now = [DateTime]::UtcNow
+            if (-not $ReadyObserved) {
+                if (Test-Path -LiteralPath $ReadyPath) {
+                    $ReadyObserved = $true
+                    $LastProgress = $Now
+                } elseif ($Now -ge $ConnectionDeadline) {
+                    $TimedOut = $true
+                    $TimeoutPhase = 'Connection'
+                    break
+                }
+            } else {
+                if (Test-Path -LiteralPath $ProgressPath) {
+                    $ProgressWriteTime = [System.IO.File]::GetLastWriteTimeUtc($ProgressPath)
+                    if ($ProgressWriteTime -gt $LastProgress) {
+                        $LastProgress = $ProgressWriteTime
+                    }
+                }
+                if (($Now - $LastProgress).TotalSeconds -ge $IdleTimeoutSeconds) {
+                    $TimedOut = $true
+                    $TimeoutPhase = 'Query'
+                    break
+                }
+            }
+        }
+
+        if ($TimedOut) {
+            try {
+                $Process.Kill()
+                $null = $Process.WaitForExit(5000)
+            } catch {
+                # The process may have exited between the timeout decision and Kill.
+            }
+            $TimeoutSeconds = if ($TimeoutPhase -eq 'Connection') { $ConnectionTimeoutSeconds } else { $IdleTimeoutSeconds }
+            return [PSCustomObject] [ordered] @{
+                Succeeded    = $false
+                Computers    = @()
+                TimedOut     = $true
+                TimeoutPhase = $TimeoutPhase
+                Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
+                ErrorMessage = "AD $($TimeoutPhase.ToLowerInvariant()) timeout after $TimeoutSeconds seconds through $Server. The isolated query process was stopped."
+            }
+        }
+
+        $Process.WaitForExit()
+        # The success marker is written only after the complete CSV is closed. It
+        # is more reliable than the host exit code on Windows PowerShell 5.1,
+        # which can be non-zero after emitting first-use progress CLIXML.
+        if (-not (Test-Path -LiteralPath $SuccessPath)) {
+            $StandardErrorText = if (Test-Path -LiteralPath $StandardErrorPath) {
+                [System.IO.File]::ReadAllText($StandardErrorPath)
+            }
+            $ErrorMessage = if (Test-Path -LiteralPath $ErrorPath) {
+                [System.IO.File]::ReadAllText($ErrorPath)
+            } elseif (-not [string]::IsNullOrWhiteSpace($StandardErrorText)) {
+                $StandardErrorText
+            } else {
+                "The isolated AD query process exited with code $($Process.ExitCode)."
+            }
+            return [PSCustomObject] [ordered] @{
+                Succeeded    = $false
+                Computers    = @()
+                TimedOut     = $false
+                TimeoutPhase = $null
+                Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
+                ErrorMessage = $ErrorMessage.Trim()
+            }
+        }
+
+        [Array] $PreparedComputers = if (Test-Path -LiteralPath $DataPath) {
+            @(
+                Import-Csv -LiteralPath $DataPath | ConvertFrom-ADComputerInventoryRow | ConvertTo-PreparedComputer `
+                    -AzureInformationCache $AzureInformationCache `
+                    -JamfInformationCache $JamfInformationCache `
+                    -IncludeAzureAD:$IncludeAzureAD.IsPresent `
+                    -IncludeIntune:$IncludeIntune.IsPresent `
+                    -IncludeJamf:$IncludeJamf.IsPresent `
+                    -Today $Today
+            )
+        } else {
+            @()
+        }
+
+        [PSCustomObject] [ordered] @{
+            Succeeded    = $true
+            Computers    = $PreparedComputers
+            TimedOut     = $false
+            TimeoutPhase = $null
+            Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
+            ErrorMessage = $null
+        }
+    } catch {
+        [PSCustomObject] [ordered] @{
+            Succeeded    = $false
+            Computers    = @()
+            TimedOut     = $false
+            TimeoutPhase = $null
+            Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
+            ErrorMessage = $_.Exception.Message
+        }
+    } finally {
+        if ($null -ne $Process) {
+            try {
+                # Cover caller cancellation, Ctrl+C, and unexpected terminating
+                # errors as well as the explicit timeout branch above.
+                if (-not $Process.HasExited) {
+                    $Process.Kill()
+                    $null = $Process.WaitForExit(5000)
+                }
+            } catch {
+                Write-Warning "Unable to stop isolated AD query process $($Process.Id): $($_.Exception.Message)"
+            }
+            $Process.Dispose()
+        }
+        try {
+            [System.IO.Directory]::Delete($TemporaryDirectory, $true)
+        } catch {
+            Write-Verbose "Unable to remove temporary AD query directory $TemporaryDirectory`: $($_.Exception.Message)"
+        }
+    }
+}

--- a/Private/Invoke-ADComputerInventoryAttempt.ps1
+++ b/Private/Invoke-ADComputerInventoryAttempt.ps1
@@ -40,6 +40,8 @@ function Invoke-ADComputerInventoryAttempt {
     $StandardOutputPath = Join-Path $TemporaryDirectory 'stdout.txt'
     $StandardErrorPath = Join-Path $TemporaryDirectory 'stderr.txt'
     $Process = $null
+    $ProgressIntervalMilliseconds = [Math]::Max(100, [Math]::Min(1000, [int] ($IdleTimeoutSeconds * 250)))
+    $EffectiveIdleTimeoutMilliseconds = ($IdleTimeoutSeconds * 1000) + $ProgressIntervalMilliseconds
 
     try {
         $Configuration = [PSCustomObject] [ordered] @{
@@ -48,6 +50,7 @@ function Invoke-ADComputerInventoryAttempt {
             Properties   = @($QueryParameters.Properties)
             SearchBase   = $QueryParameters.SearchBase
             PageSize     = $PageSize
+            ProgressIntervalMilliseconds = $ProgressIntervalMilliseconds
             InitializationPath = $InitializationPath
             ReadyPath    = $ReadyPath
             ProgressPath = $ProgressPath
@@ -103,7 +106,7 @@ function Invoke-ADComputerInventoryAttempt {
                         $LastProgress = $ProgressWriteTime
                     }
                 }
-                if (($Now - $LastProgress).TotalSeconds -ge $IdleTimeoutSeconds) {
+                if (($Now - $LastProgress).TotalMilliseconds -ge $EffectiveIdleTimeoutMilliseconds) {
                     $TimedOut = $true
                     $TimeoutPhase = 'Query'
                     break
@@ -123,13 +126,18 @@ function Invoke-ADComputerInventoryAttempt {
                 'Connection' { $ConnectionTimeoutSeconds }
                 default { $IdleTimeoutSeconds }
             }
+            $TimeoutMessage = if ($TimeoutPhase -eq 'Query') {
+                "AD query timeout after $TimeoutSeconds seconds without result progress through $Server, plus up to $ProgressIntervalMilliseconds milliseconds for progress signaling. The isolated query process was stopped."
+            } else {
+                "AD $($TimeoutPhase.ToLowerInvariant()) timeout after $TimeoutSeconds seconds through $Server. The isolated query process was stopped."
+            }
             return [PSCustomObject] [ordered] @{
                 Succeeded    = $false
                 Computers    = @()
                 TimedOut     = $true
                 TimeoutPhase = $TimeoutPhase
                 Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
-                ErrorMessage = "AD $($TimeoutPhase.ToLowerInvariant()) timeout after $TimeoutSeconds seconds through $Server. The isolated query process was stopped."
+                ErrorMessage = $TimeoutMessage
             }
         }
 

--- a/Private/Invoke-ADComputerInventoryChildProcess.ps1
+++ b/Private/Invoke-ADComputerInventoryChildProcess.ps1
@@ -12,6 +12,7 @@ function Invoke-ADComputerInventoryChildProcess {
     try {
         $Configuration = Import-Clixml -LiteralPath $ConfigurationPath -ErrorAction Stop
         Import-Module ActiveDirectory -ErrorAction Stop
+        [System.IO.File]::WriteAllText($Configuration.InitializationPath, 'Initialized', [System.Text.Encoding]::UTF8)
 
         # Use the AD cmdlet itself for readiness so every supported -Server form,
         # including domain locator and host:port values, retains its native meaning.

--- a/Private/Invoke-ADComputerInventoryChildProcess.ps1
+++ b/Private/Invoke-ADComputerInventoryChildProcess.ps1
@@ -1,0 +1,71 @@
+function Invoke-ADComputerInventoryChildProcess {
+    <#
+    .SYNOPSIS
+    Executes one AD computer query inside an isolated Windows PowerShell process.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $ConfigurationPath
+    )
+
+    try {
+        $Configuration = Import-Clixml -LiteralPath $ConfigurationPath -ErrorAction Stop
+        Import-Module ActiveDirectory -ErrorAction Stop
+
+        # Use the AD cmdlet itself for readiness so every supported -Server form,
+        # including domain locator and host:port values, retains its native meaning.
+        Get-ADRootDSE -Server $Configuration.Server -ErrorAction Stop | Out-Null
+        [System.IO.File]::WriteAllText($Configuration.ReadyPath, 'Ready', [System.Text.Encoding]::UTF8)
+        [System.IO.File]::WriteAllText($Configuration.ProgressPath, '0', [System.Text.Encoding]::UTF8)
+
+        $Query = @{
+            Filter         = $Configuration.Filter
+            Properties     = @($Configuration.Properties)
+            Server         = $Configuration.Server
+            ResultPageSize = $Configuration.PageSize
+            ResultSetSize  = $null
+            ErrorAction    = 'Stop'
+        }
+        if ($Configuration.SearchBase) {
+            $Query.SearchBase = $Configuration.SearchBase
+        }
+
+        $Count = 0
+        Get-ADComputer @Query | ForEach-Object {
+            $Count++
+            if ($Count -eq 1 -or $Count % 100 -eq 0) {
+                [System.IO.File]::WriteAllText($Configuration.ProgressPath, [string] $Count, [System.Text.Encoding]::UTF8)
+            }
+
+            [PSCustomObject] [ordered] @{
+                Name                            = $_.Name
+                DNSHostName                     = $_.DNSHostName
+                SamAccountName                  = $_.SamAccountName
+                DistinguishedName               = $_.DistinguishedName
+                Enabled                         = $_.Enabled
+                OperatingSystem                 = $_.OperatingSystem
+                OperatingSystemVersion          = $_.OperatingSystemVersion
+                LastLogonDateBinary              = if ($null -ne $_.LastLogonDate) { $_.LastLogonDate.ToBinary() } else { $null }
+                PasswordLastSetBinary            = if ($null -ne $_.PasswordLastSet) { $_.PasswordLastSet.ToBinary() } else { $null }
+                PasswordExpired                 = $_.PasswordExpired
+                ServicePrincipalNameJson        = ConvertTo-Json -InputObject @($_.servicePrincipalName) -Compress
+                LogonCount                      = $_.logonCount
+                ManagedBy                       = $_.ManagedBy
+                Description                     = $_.Description
+                WhenCreatedBinary               = if ($null -ne $_.WhenCreated) { $_.WhenCreated.ToBinary() } else { $null }
+                WhenChangedBinary               = if ($null -ne $_.WhenChanged) { $_.WhenChanged.ToBinary() } else { $null }
+                ProtectedFromAccidentalDeletion = $_.ProtectedFromAccidentalDeletion
+            }
+        } | Export-Csv -LiteralPath $Configuration.DataPath -NoTypeInformation -Encoding UTF8
+
+        [System.IO.File]::WriteAllText($Configuration.SuccessPath, [string] $Count, [System.Text.Encoding]::UTF8)
+    } catch {
+        if ($null -ne $Configuration -and $Configuration.ErrorPath) {
+            [System.IO.File]::WriteAllText($Configuration.ErrorPath, $_.Exception.Message, [System.Text.Encoding]::UTF8)
+        } else {
+            Write-Error -ErrorRecord $_
+        }
+        exit 1
+    }
+}

--- a/Private/Invoke-ADComputerInventoryChildProcess.ps1
+++ b/Private/Invoke-ADComputerInventoryChildProcess.ps1
@@ -43,7 +43,7 @@ function Invoke-ADComputerInventoryChildProcess {
                 $LastProgressWriteUtc = $Now
             }
 
-            [PSCustomObject] [ordered] @{
+            [PSCustomObject] @{
                 Name                            = $_.Name
                 DNSHostName                     = $_.DNSHostName
                 SamAccountName                  = $_.SamAccountName

--- a/Private/Invoke-ADComputerInventoryChildProcess.ps1
+++ b/Private/Invoke-ADComputerInventoryChildProcess.ps1
@@ -33,10 +33,14 @@ function Invoke-ADComputerInventoryChildProcess {
         }
 
         $Count = 0
+        $ProgressIntervalMilliseconds = [int] $Configuration.ProgressIntervalMilliseconds
+        $LastProgressWriteUtc = [DateTime]::UtcNow
         Get-ADComputer @Query | ForEach-Object {
             $Count++
-            if ($Count -eq 1 -or $Count % 100 -eq 0) {
+            $Now = [DateTime]::UtcNow
+            if ($Count -eq 1 -or ($Now - $LastProgressWriteUtc).TotalMilliseconds -ge $ProgressIntervalMilliseconds) {
                 [System.IO.File]::WriteAllText($Configuration.ProgressPath, [string] $Count, [System.Text.Encoding]::UTF8)
+                $LastProgressWriteUtc = $Now
             }
 
             [PSCustomObject] [ordered] @{

--- a/Private/Invoke-ADComputerInventoryQuery.ps1
+++ b/Private/Invoke-ADComputerInventoryQuery.ps1
@@ -60,7 +60,7 @@ function Invoke-ADComputerInventoryQuery {
                 -Today $Today
 
             $QueryReachedServer = $QueryReachedServer -or $AttemptResult.TimeoutPhase -notin @('Initialization', 'Connection')
-            $Attempts.Add([PSCustomObject] [ordered] @{
+            $Attempts.Add([PSCustomObject] @{
                     Server       = $Server
                     Attempt      = $Attempt
                     PageSize     = $PageSize
@@ -70,7 +70,7 @@ function Invoke-ADComputerInventoryQuery {
                 })
 
             if ($AttemptResult.Succeeded) {
-                return [PSCustomObject] [ordered] @{
+                return [PSCustomObject] @{
                     Succeeded = $true
                     Server    = $Server
                     Computers = $AttemptResult.Computers
@@ -88,7 +88,7 @@ function Invoke-ADComputerInventoryQuery {
             Write-Color -Text '[w] ', "AD query failed for $Domain through $Server`: $($AttemptResult.ErrorMessage)" -Color Yellow, DarkYellow
 
             if (Test-ADQueryConfigurationError -ErrorRecord $LastError) {
-                return [PSCustomObject] [ordered] @{
+                return [PSCustomObject] @{
                     Succeeded = $false
                     Server    = $null
                     Computers = @()
@@ -118,7 +118,7 @@ function Invoke-ADComputerInventoryQuery {
                 -IdleTimeoutSeconds $IdleTimeoutSeconds `
                 -Today $Today
 
-            $Attempts.Add([PSCustomObject] [ordered] @{
+            $Attempts.Add([PSCustomObject] @{
                     Server       = $Server
                     Attempt      = 'SmallPageFallback'
                     PageSize     = $FallbackPageSize
@@ -128,7 +128,7 @@ function Invoke-ADComputerInventoryQuery {
                 })
 
             if ($AttemptResult.Succeeded) {
-                return [PSCustomObject] [ordered] @{
+                return [PSCustomObject] @{
                     Succeeded = $true
                     Server    = $Server
                     Computers = $AttemptResult.Computers
@@ -147,7 +147,7 @@ function Invoke-ADComputerInventoryQuery {
         }
     }
 
-    [PSCustomObject] [ordered] @{
+    [PSCustomObject] @{
         Succeeded = $false
         Server    = $null
         Computers = @()

--- a/Private/Invoke-ADComputerInventoryQuery.ps1
+++ b/Private/Invoke-ADComputerInventoryQuery.ps1
@@ -1,0 +1,168 @@
+function Invoke-ADComputerInventoryQuery {
+    <#
+    .SYNOPSIS
+    Queries one AD domain with retry and domain-controller failover.
+
+    .DESCRIPTION
+    Attempts each configured domain controller in order. Each controller receives
+    the configured number of attempts, followed by one smaller-page attempt when
+    the configured page size is greater than 500. Raw ADComputer objects are
+    converted as they arrive and are not retained after normalization.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $Domain,
+        [Parameter(Mandatory)]
+        [string[]] $Servers,
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $QueryParameters,
+        [System.Collections.IDictionary] $AzureInformationCache,
+        [System.Collections.IDictionary] $JamfInformationCache,
+        [switch] $IncludeAzureAD,
+        [switch] $IncludeIntune,
+        [switch] $IncludeJamf,
+        [ValidateRange(1, [int]::MaxValue)]
+        [int] $MaxAttemptsPerServer = 3,
+        [ValidateRange(0, [int]::MaxValue)]
+        [int] $RetryDelaySeconds = 5,
+        [ValidateRange(1, 10000)]
+        [int] $PageSize = 1000,
+        [DateTime] $Today = (Get-Date)
+    )
+
+    $Attempts = [System.Collections.Generic.List[object]]::new()
+    $LastError = $null
+
+    foreach ($Server in $Servers) {
+        $Delay = $RetryDelaySeconds
+        for ($Attempt = 1; $Attempt -le $MaxAttemptsPerServer; $Attempt++) {
+            $Query = @{}
+            foreach ($Key in $QueryParameters.Keys) {
+                $Query[$Key] = $QueryParameters[$Key]
+            }
+            $Query.Server = $Server
+            $Query.ResultPageSize = $PageSize
+            $Query.ResultSetSize = $null
+            $Query.ErrorAction = 'Stop'
+
+            $Started = Get-Date
+            try {
+                Write-Color -Text '[i] ', "Querying $Domain through $Server (attempt $Attempt of $MaxAttemptsPerServer, page size $PageSize)..." -Color Yellow, Cyan
+                [Array] $PreparedComputers = @(
+                    Get-ADComputer @Query | ConvertTo-PreparedComputer `
+                        -AzureInformationCache $AzureInformationCache `
+                        -JamfInformationCache $JamfInformationCache `
+                        -IncludeAzureAD:$IncludeAzureAD.IsPresent `
+                        -IncludeIntune:$IncludeIntune.IsPresent `
+                        -IncludeJamf:$IncludeJamf.IsPresent `
+                        -Today $Today
+                )
+                $Attempts.Add([PSCustomObject] [ordered] @{
+                        Server       = $Server
+                        Attempt      = $Attempt
+                        PageSize     = $PageSize
+                        Succeeded    = $true
+                        Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
+                        ErrorMessage = $null
+                    })
+                return [PSCustomObject] [ordered] @{
+                    Succeeded = $true
+                    Server    = $Server
+                    Computers = $PreparedComputers
+                    Attempts  = $Attempts.ToArray()
+                    Error     = $null
+                }
+            } catch {
+                $LastError = $_
+                $PreparedComputers = $null
+                $Attempts.Add([PSCustomObject] [ordered] @{
+                        Server       = $Server
+                        Attempt      = $Attempt
+                        PageSize     = $PageSize
+                        Succeeded    = $false
+                        Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
+                        ErrorMessage = $_.Exception.Message
+                    })
+                Write-Color -Text '[w] ', "AD query failed for $Domain through $Server`: $($_.Exception.Message)" -Color Yellow, DarkYellow
+
+                if (Test-ADQueryConfigurationError -ErrorRecord $_) {
+                    return [PSCustomObject] [ordered] @{
+                        Succeeded = $false
+                        Server    = $null
+                        Computers = @()
+                        Attempts  = $Attempts.ToArray()
+                        Error     = $_.Exception.Message
+                    }
+                }
+                if ($Attempt -lt $MaxAttemptsPerServer -and $Delay -gt 0) {
+                    Start-Sleep -Seconds $Delay
+                    $Delay = [math]::Min($Delay * 2, 300)
+                }
+            }
+        }
+
+        if ($PageSize -gt 500) {
+            $FallbackPageSize = 500
+            $Query = @{}
+            foreach ($Key in $QueryParameters.Keys) {
+                $Query[$Key] = $QueryParameters[$Key]
+            }
+            $Query.Server = $Server
+            $Query.ResultPageSize = $FallbackPageSize
+            $Query.ResultSetSize = $null
+            $Query.ErrorAction = 'Stop'
+            $Started = Get-Date
+            try {
+                Write-Color -Text '[i] ', "Retrying $Domain through $Server with page size $FallbackPageSize..." -Color Yellow, Cyan
+                [Array] $PreparedComputers = @(
+                    Get-ADComputer @Query | ConvertTo-PreparedComputer `
+                        -AzureInformationCache $AzureInformationCache `
+                        -JamfInformationCache $JamfInformationCache `
+                        -IncludeAzureAD:$IncludeAzureAD.IsPresent `
+                        -IncludeIntune:$IncludeIntune.IsPresent `
+                        -IncludeJamf:$IncludeJamf.IsPresent `
+                        -Today $Today
+                )
+                $Attempts.Add([PSCustomObject] [ordered] @{
+                        Server       = $Server
+                        Attempt      = 'SmallPageFallback'
+                        PageSize     = $FallbackPageSize
+                        Succeeded    = $true
+                        Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
+                        ErrorMessage = $null
+                    })
+                return [PSCustomObject] [ordered] @{
+                    Succeeded = $true
+                    Server    = $Server
+                    Computers = $PreparedComputers
+                    Attempts  = $Attempts.ToArray()
+                    Error     = $null
+                }
+            } catch {
+                $LastError = $_
+                $PreparedComputers = $null
+                $Attempts.Add([PSCustomObject] [ordered] @{
+                        Server       = $Server
+                        Attempt      = 'SmallPageFallback'
+                        PageSize     = $FallbackPageSize
+                        Succeeded    = $false
+                        Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
+                        ErrorMessage = $_.Exception.Message
+                    })
+                Write-Color -Text '[w] ', "Small-page AD query failed for $Domain through $Server`: $($_.Exception.Message)" -Color Yellow, DarkYellow
+                if (Test-ADQueryConfigurationError -ErrorRecord $_) {
+                    break
+                }
+            }
+        }
+    }
+
+    [PSCustomObject] [ordered] @{
+        Succeeded = $false
+        Server    = $null
+        Computers = @()
+        Attempts  = $Attempts.ToArray()
+        Error     = if ($LastError) { $LastError.Exception.Message } else { "No domain controller was available for $Domain." }
+    }
+}

--- a/Private/Invoke-ADComputerInventoryQuery.ps1
+++ b/Private/Invoke-ADComputerInventoryQuery.ps1
@@ -4,10 +4,13 @@ function Invoke-ADComputerInventoryQuery {
     Queries one AD domain with retry and domain-controller failover.
 
     .DESCRIPTION
-    Attempts each configured domain controller in order. Each controller receives
-    the configured number of attempts, followed by one smaller-page attempt when
-    the configured page size is greater than 500. Raw ADComputer objects are
-    converted as they arrive and are not retained after normalization.
+    Attempts each configured domain controller in order. Every Get-ADComputer call
+    runs in an isolated Windows PowerShell process so a connection or idle-query
+    timeout can stop the real AD operation. Each controller receives the configured
+    number of attempts, followed by one smaller-page attempt when the configured
+    page size is greater than 500. The child process transports only the properties
+    required by CleanupMonster and raw ADComputer objects are never retained beside
+    the normalized inventory.
     #>
     [CmdletBinding()]
     param(
@@ -26,6 +29,10 @@ function Invoke-ADComputerInventoryQuery {
         [int] $MaxAttemptsPerServer = 3,
         [ValidateRange(0, [int]::MaxValue)]
         [int] $RetryDelaySeconds = 5,
+        [ValidateRange(1, 300)]
+        [int] $ConnectionTimeoutSeconds = 15,
+        [ValidateRange(1, 3600)]
+        [int] $IdleTimeoutSeconds = 120,
         [ValidateRange(1, 10000)]
         [int] $PageSize = 1000,
         [DateTime] $Today = (Get-Date)
@@ -36,125 +43,107 @@ function Invoke-ADComputerInventoryQuery {
 
     foreach ($Server in $Servers) {
         $Delay = $RetryDelaySeconds
+        $QueryReachedServer = $false
         for ($Attempt = 1; $Attempt -le $MaxAttemptsPerServer; $Attempt++) {
-            $Query = @{}
-            foreach ($Key in $QueryParameters.Keys) {
-                $Query[$Key] = $QueryParameters[$Key]
-            }
-            $Query.Server = $Server
-            $Query.ResultPageSize = $PageSize
-            $Query.ResultSetSize = $null
-            $Query.ErrorAction = 'Stop'
+            Write-Color -Text '[i] ', "Querying $Domain through $Server (attempt $Attempt of $MaxAttemptsPerServer, page size $PageSize)..." -Color Yellow, Cyan
+            $AttemptResult = Invoke-ADComputerInventoryAttempt `
+                -Server $Server `
+                -QueryParameters $QueryParameters `
+                -AzureInformationCache $AzureInformationCache `
+                -JamfInformationCache $JamfInformationCache `
+                -IncludeAzureAD:$IncludeAzureAD.IsPresent `
+                -IncludeIntune:$IncludeIntune.IsPresent `
+                -IncludeJamf:$IncludeJamf.IsPresent `
+                -PageSize $PageSize `
+                -ConnectionTimeoutSeconds $ConnectionTimeoutSeconds `
+                -IdleTimeoutSeconds $IdleTimeoutSeconds `
+                -Today $Today
 
-            $Started = Get-Date
-            try {
-                Write-Color -Text '[i] ', "Querying $Domain through $Server (attempt $Attempt of $MaxAttemptsPerServer, page size $PageSize)..." -Color Yellow, Cyan
-                [Array] $PreparedComputers = @(
-                    Get-ADComputer @Query | ConvertTo-PreparedComputer `
-                        -AzureInformationCache $AzureInformationCache `
-                        -JamfInformationCache $JamfInformationCache `
-                        -IncludeAzureAD:$IncludeAzureAD.IsPresent `
-                        -IncludeIntune:$IncludeIntune.IsPresent `
-                        -IncludeJamf:$IncludeJamf.IsPresent `
-                        -Today $Today
-                )
-                $Attempts.Add([PSCustomObject] [ordered] @{
-                        Server       = $Server
-                        Attempt      = $Attempt
-                        PageSize     = $PageSize
-                        Succeeded    = $true
-                        Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
-                        ErrorMessage = $null
-                    })
+            $QueryReachedServer = $QueryReachedServer -or $AttemptResult.TimeoutPhase -ne 'Connection'
+            $Attempts.Add([PSCustomObject] [ordered] @{
+                    Server       = $Server
+                    Attempt      = $Attempt
+                    PageSize     = $PageSize
+                    Succeeded    = $AttemptResult.Succeeded
+                    Duration     = $AttemptResult.Duration
+                    ErrorMessage = $AttemptResult.ErrorMessage
+                })
+
+            if ($AttemptResult.Succeeded) {
                 return [PSCustomObject] [ordered] @{
                     Succeeded = $true
                     Server    = $Server
-                    Computers = $PreparedComputers
+                    Computers = $AttemptResult.Computers
                     Attempts  = $Attempts.ToArray()
                     Error     = $null
                 }
-            } catch {
-                $LastError = $_
-                $PreparedComputers = $null
-                $Attempts.Add([PSCustomObject] [ordered] @{
-                        Server       = $Server
-                        Attempt      = $Attempt
-                        PageSize     = $PageSize
-                        Succeeded    = $false
-                        Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
-                        ErrorMessage = $_.Exception.Message
-                    })
-                Write-Color -Text '[w] ', "AD query failed for $Domain through $Server`: $($_.Exception.Message)" -Color Yellow, DarkYellow
+            }
 
-                if (Test-ADQueryConfigurationError -ErrorRecord $_) {
-                    return [PSCustomObject] [ordered] @{
-                        Succeeded = $false
-                        Server    = $null
-                        Computers = @()
-                        Attempts  = $Attempts.ToArray()
-                        Error     = $_.Exception.Message
-                    }
+            $LastError = [System.Management.Automation.ErrorRecord]::new(
+                [System.InvalidOperationException]::new($AttemptResult.ErrorMessage),
+                'ADComputerInventoryQueryFailed',
+                [System.Management.Automation.ErrorCategory]::ConnectionError,
+                $Server
+            )
+            Write-Color -Text '[w] ', "AD query failed for $Domain through $Server`: $($AttemptResult.ErrorMessage)" -Color Yellow, DarkYellow
+
+            if (Test-ADQueryConfigurationError -ErrorRecord $LastError) {
+                return [PSCustomObject] [ordered] @{
+                    Succeeded = $false
+                    Server    = $null
+                    Computers = @()
+                    Attempts  = $Attempts.ToArray()
+                    Error     = $AttemptResult.ErrorMessage
                 }
-                if ($Attempt -lt $MaxAttemptsPerServer -and $Delay -gt 0) {
-                    Start-Sleep -Seconds $Delay
-                    $Delay = [math]::Min($Delay * 2, 300)
-                }
+            }
+            if ($Attempt -lt $MaxAttemptsPerServer -and $Delay -gt 0) {
+                Start-Sleep -Seconds $Delay
+                $Delay = [math]::Min($Delay * 2, 300)
             }
         }
 
-        if ($PageSize -gt 500) {
+        if ($QueryReachedServer -and $PageSize -gt 500) {
             $FallbackPageSize = 500
-            $Query = @{}
-            foreach ($Key in $QueryParameters.Keys) {
-                $Query[$Key] = $QueryParameters[$Key]
-            }
-            $Query.Server = $Server
-            $Query.ResultPageSize = $FallbackPageSize
-            $Query.ResultSetSize = $null
-            $Query.ErrorAction = 'Stop'
-            $Started = Get-Date
-            try {
-                Write-Color -Text '[i] ', "Retrying $Domain through $Server with page size $FallbackPageSize..." -Color Yellow, Cyan
-                [Array] $PreparedComputers = @(
-                    Get-ADComputer @Query | ConvertTo-PreparedComputer `
-                        -AzureInformationCache $AzureInformationCache `
-                        -JamfInformationCache $JamfInformationCache `
-                        -IncludeAzureAD:$IncludeAzureAD.IsPresent `
-                        -IncludeIntune:$IncludeIntune.IsPresent `
-                        -IncludeJamf:$IncludeJamf.IsPresent `
-                        -Today $Today
-                )
-                $Attempts.Add([PSCustomObject] [ordered] @{
-                        Server       = $Server
-                        Attempt      = 'SmallPageFallback'
-                        PageSize     = $FallbackPageSize
-                        Succeeded    = $true
-                        Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
-                        ErrorMessage = $null
-                    })
+            Write-Color -Text '[i] ', "Retrying $Domain through $Server with page size $FallbackPageSize..." -Color Yellow, Cyan
+            $AttemptResult = Invoke-ADComputerInventoryAttempt `
+                -Server $Server `
+                -QueryParameters $QueryParameters `
+                -AzureInformationCache $AzureInformationCache `
+                -JamfInformationCache $JamfInformationCache `
+                -IncludeAzureAD:$IncludeAzureAD.IsPresent `
+                -IncludeIntune:$IncludeIntune.IsPresent `
+                -IncludeJamf:$IncludeJamf.IsPresent `
+                -PageSize $FallbackPageSize `
+                -ConnectionTimeoutSeconds $ConnectionTimeoutSeconds `
+                -IdleTimeoutSeconds $IdleTimeoutSeconds `
+                -Today $Today
+
+            $Attempts.Add([PSCustomObject] [ordered] @{
+                    Server       = $Server
+                    Attempt      = 'SmallPageFallback'
+                    PageSize     = $FallbackPageSize
+                    Succeeded    = $AttemptResult.Succeeded
+                    Duration     = $AttemptResult.Duration
+                    ErrorMessage = $AttemptResult.ErrorMessage
+                })
+
+            if ($AttemptResult.Succeeded) {
                 return [PSCustomObject] [ordered] @{
                     Succeeded = $true
                     Server    = $Server
-                    Computers = $PreparedComputers
+                    Computers = $AttemptResult.Computers
                     Attempts  = $Attempts.ToArray()
                     Error     = $null
                 }
-            } catch {
-                $LastError = $_
-                $PreparedComputers = $null
-                $Attempts.Add([PSCustomObject] [ordered] @{
-                        Server       = $Server
-                        Attempt      = 'SmallPageFallback'
-                        PageSize     = $FallbackPageSize
-                        Succeeded    = $false
-                        Duration     = (New-TimeSpan -Start $Started -End (Get-Date))
-                        ErrorMessage = $_.Exception.Message
-                    })
-                Write-Color -Text '[w] ', "Small-page AD query failed for $Domain through $Server`: $($_.Exception.Message)" -Color Yellow, DarkYellow
-                if (Test-ADQueryConfigurationError -ErrorRecord $_) {
-                    break
-                }
             }
+
+            $LastError = [System.Management.Automation.ErrorRecord]::new(
+                [System.InvalidOperationException]::new($AttemptResult.ErrorMessage),
+                'ADComputerInventoryQueryFailed',
+                [System.Management.Automation.ErrorCategory]::ConnectionError,
+                $Server
+            )
+            Write-Color -Text '[w] ', "Small-page AD query failed for $Domain through $Server`: $($AttemptResult.ErrorMessage)" -Color Yellow, DarkYellow
         }
     }
 

--- a/Private/Invoke-ADComputerInventoryQuery.ps1
+++ b/Private/Invoke-ADComputerInventoryQuery.ps1
@@ -59,7 +59,7 @@ function Invoke-ADComputerInventoryQuery {
                 -IdleTimeoutSeconds $IdleTimeoutSeconds `
                 -Today $Today
 
-            $QueryReachedServer = $QueryReachedServer -or $AttemptResult.TimeoutPhase -ne 'Connection'
+            $QueryReachedServer = $QueryReachedServer -or $AttemptResult.TimeoutPhase -notin @('Initialization', 'Connection')
             $Attempts.Add([PSCustomObject] [ordered] @{
                     Server       = $Server
                     Attempt      = $Attempt

--- a/Private/Merge-ADComputerHTMLReportData.ps1
+++ b/Private/Merge-ADComputerHTMLReportData.ps1
@@ -21,62 +21,9 @@ function Merge-ADComputerHTMLReportData {
     )
 
     $StagingHtml = Get-Content -LiteralPath $StagingHtmlPath -Raw -ErrorAction Stop
-    $AssignmentPattern = '\bvar\s+' + [regex]::Escape($DataStoreID) + '\s*=\s*'
-    $AssignmentMatch = [regex]::Match($StagingHtml, $AssignmentPattern)
-    if (-not $AssignmentMatch.Success) {
-        throw "The PSWriteHTML data assignment for '$DataStoreID' was not found."
-    }
-
-    # The real assignment precedes its JSON payload. Assignment-like text inside
-    # a row value therefore cannot displace this first match.
-    $DataStartIndex = $AssignmentMatch.Index + $AssignmentMatch.Length
-    while ($DataStartIndex -lt $StagingHtml.Length -and [char]::IsWhiteSpace($StagingHtml[$DataStartIndex])) {
-        $DataStartIndex++
-    }
-    if ($DataStartIndex -ge $StagingHtml.Length -or $StagingHtml[$DataStartIndex] -ne '[') {
-        throw "The PSWriteHTML data assignment for '$DataStoreID' is not a JavaScript array."
-    }
-
-    $ArrayDepth = 0
-    $InString = $false
-    $Escaped = $false
-    $DataEndIndex = -1
-    for ($Index = $DataStartIndex; $Index -lt $StagingHtml.Length; $Index++) {
-        $Character = $StagingHtml[$Index]
-        if ($InString) {
-            if ($Escaped) {
-                $Escaped = $false
-            } elseif ($Character -eq '\') {
-                $Escaped = $true
-            } elseif ($Character -eq '"') {
-                $InString = $false
-            }
-            continue
-        }
-
-        if ($Character -eq '"') {
-            $InString = $true
-        } elseif ($Character -eq '[') {
-            $ArrayDepth++
-        } elseif ($Character -eq ']') {
-            $ArrayDepth--
-            if ($ArrayDepth -eq 0) {
-                $DataEndIndex = $Index
-                break
-            }
-        }
-    }
-    if ($DataEndIndex -lt 0) {
-        throw "The PSWriteHTML data array for '$DataStoreID' is not terminated."
-    }
-
-    $TerminatorIndex = $DataEndIndex + 1
-    while ($TerminatorIndex -lt $StagingHtml.Length -and [char]::IsWhiteSpace($StagingHtml[$TerminatorIndex])) {
-        $TerminatorIndex++
-    }
-    if ($TerminatorIndex -ge $StagingHtml.Length -or $StagingHtml[$TerminatorIndex] -ne ';') {
-        throw "The PSWriteHTML data assignment for '$DataStoreID' has no statement terminator."
-    }
+    $Assignment = Find-JavaScriptArrayAssignment -Html $StagingHtml -VariableName $DataStoreID
+    $DataStartIndex = $Assignment.DataStartIndex
+    $DataEndIndex = $Assignment.DataEndIndex
 
     $Marker = '__CLEANUPMONSTER_AD_REPORT_DATA_' + [guid]::NewGuid().ToString('N') + '__'
     $HtmlWithMarker = $StagingHtml.Substring(0, $DataStartIndex) + $Marker + $StagingHtml.Substring($DataEndIndex + 1)

--- a/Private/Merge-ADComputerHTMLReportData.ps1
+++ b/Private/Merge-ADComputerHTMLReportData.ps1
@@ -22,12 +22,14 @@ function Merge-ADComputerHTMLReportData {
 
     $StagingHtml = Get-Content -LiteralPath $StagingHtmlPath -Raw -ErrorAction Stop
     $AssignmentPattern = '\bvar\s+' + [regex]::Escape($DataStoreID) + '\s*=\s*'
-    $AssignmentMatches = [regex]::Matches($StagingHtml, $AssignmentPattern)
-    if ($AssignmentMatches.Count -ne 1) {
-        throw "Expected one PSWriteHTML data assignment for '$DataStoreID', found $($AssignmentMatches.Count)."
+    $AssignmentMatch = [regex]::Match($StagingHtml, $AssignmentPattern)
+    if (-not $AssignmentMatch.Success) {
+        throw "The PSWriteHTML data assignment for '$DataStoreID' was not found."
     }
 
-    $DataStartIndex = $AssignmentMatches[0].Index + $AssignmentMatches[0].Length
+    # The real assignment precedes its JSON payload. Assignment-like text inside
+    # a row value therefore cannot displace this first match.
+    $DataStartIndex = $AssignmentMatch.Index + $AssignmentMatch.Length
     while ($DataStartIndex -lt $StagingHtml.Length -and [char]::IsWhiteSpace($StagingHtml[$DataStartIndex])) {
         $DataStartIndex++
     }

--- a/Private/Merge-ADComputerHTMLReportData.ps1
+++ b/Private/Merge-ADComputerHTMLReportData.ps1
@@ -21,19 +21,64 @@ function Merge-ADComputerHTMLReportData {
     )
 
     $StagingHtml = Get-Content -LiteralPath $StagingHtmlPath -Raw -ErrorAction Stop
-    $Pattern = 'var\s+' + [regex]::Escape($DataStoreID) + '\s*=\s*\[[\s\S]*?\];'
-    $Matches = [regex]::Matches($StagingHtml, $Pattern)
-    if ($Matches.Count -ne 1) {
-        throw "Expected one PSWriteHTML data assignment for '$DataStoreID', found $($Matches.Count)."
+    $AssignmentPattern = '\bvar\s+' + [regex]::Escape($DataStoreID) + '\s*=\s*'
+    $AssignmentMatches = [regex]::Matches($StagingHtml, $AssignmentPattern)
+    if ($AssignmentMatches.Count -ne 1) {
+        throw "Expected one PSWriteHTML data assignment for '$DataStoreID', found $($AssignmentMatches.Count)."
+    }
+
+    $DataStartIndex = $AssignmentMatches[0].Index + $AssignmentMatches[0].Length
+    while ($DataStartIndex -lt $StagingHtml.Length -and [char]::IsWhiteSpace($StagingHtml[$DataStartIndex])) {
+        $DataStartIndex++
+    }
+    if ($DataStartIndex -ge $StagingHtml.Length -or $StagingHtml[$DataStartIndex] -ne '[') {
+        throw "The PSWriteHTML data assignment for '$DataStoreID' is not a JavaScript array."
+    }
+
+    $ArrayDepth = 0
+    $InString = $false
+    $Escaped = $false
+    $DataEndIndex = -1
+    for ($Index = $DataStartIndex; $Index -lt $StagingHtml.Length; $Index++) {
+        $Character = $StagingHtml[$Index]
+        if ($InString) {
+            if ($Escaped) {
+                $Escaped = $false
+            } elseif ($Character -eq '\') {
+                $Escaped = $true
+            } elseif ($Character -eq '"') {
+                $InString = $false
+            }
+            continue
+        }
+
+        if ($Character -eq '"') {
+            $InString = $true
+        } elseif ($Character -eq '[') {
+            $ArrayDepth++
+        } elseif ($Character -eq ']') {
+            $ArrayDepth--
+            if ($ArrayDepth -eq 0) {
+                $DataEndIndex = $Index
+                break
+            }
+        }
+    }
+    if ($DataEndIndex -lt 0) {
+        throw "The PSWriteHTML data array for '$DataStoreID' is not terminated."
+    }
+
+    $TerminatorIndex = $DataEndIndex + 1
+    while ($TerminatorIndex -lt $StagingHtml.Length -and [char]::IsWhiteSpace($StagingHtml[$TerminatorIndex])) {
+        $TerminatorIndex++
+    }
+    if ($TerminatorIndex -ge $StagingHtml.Length -or $StagingHtml[$TerminatorIndex] -ne ';') {
+        throw "The PSWriteHTML data assignment for '$DataStoreID' has no statement terminator."
     }
 
     $Marker = '__CLEANUPMONSTER_AD_REPORT_DATA_' + [guid]::NewGuid().ToString('N') + '__'
-    $Replacement = "var $DataStoreID = $Marker;"
-    $HtmlWithMarker = [regex]::Replace($StagingHtml, $Pattern, $Replacement, 1)
-    $MarkerIndex = $HtmlWithMarker.IndexOf($Marker, [System.StringComparison]::Ordinal)
-    if ($MarkerIndex -lt 0) {
-        throw 'The report data marker could not be created.'
-    }
+    $HtmlWithMarker = $StagingHtml.Substring(0, $DataStartIndex) + $Marker + $StagingHtml.Substring($DataEndIndex + 1)
+    $MarkerIndex = $DataStartIndex
 
     $OutputDirectory = [System.IO.Path]::GetDirectoryName($OutputPath)
     if (-not [string]::IsNullOrWhiteSpace($OutputDirectory)) {

--- a/Private/Merge-ADComputerHTMLReportData.ps1
+++ b/Private/Merge-ADComputerHTMLReportData.ps1
@@ -1,0 +1,77 @@
+function Merge-ADComputerHTMLReportData {
+    <#
+    .SYNOPSIS
+    Streams a JSON report-data file into a PSWriteHTML DataStoreID placeholder.
+
+    .DESCRIPTION
+    Keeps the final report self-contained without loading the full serialized
+    computer inventory into the PowerShell process as one string.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $StagingHtmlPath,
+        [Parameter(Mandatory)]
+        [string] $DataFilePath,
+        [Parameter(Mandatory)]
+        [string] $OutputPath,
+        [Parameter(Mandatory)]
+        [ValidatePattern('^[A-Za-z_$][A-Za-z0-9_$]*$')]
+        [string] $DataStoreID
+    )
+
+    $StagingHtml = Get-Content -LiteralPath $StagingHtmlPath -Raw -ErrorAction Stop
+    $Pattern = 'var\s+' + [regex]::Escape($DataStoreID) + '\s*=\s*\[[\s\S]*?\];'
+    $Matches = [regex]::Matches($StagingHtml, $Pattern)
+    if ($Matches.Count -ne 1) {
+        throw "Expected one PSWriteHTML data assignment for '$DataStoreID', found $($Matches.Count)."
+    }
+
+    $Marker = '__CLEANUPMONSTER_AD_REPORT_DATA_' + [guid]::NewGuid().ToString('N') + '__'
+    $Replacement = "var $DataStoreID = $Marker;"
+    $HtmlWithMarker = [regex]::Replace($StagingHtml, $Pattern, $Replacement, 1)
+    $MarkerIndex = $HtmlWithMarker.IndexOf($Marker, [System.StringComparison]::Ordinal)
+    if ($MarkerIndex -lt 0) {
+        throw 'The report data marker could not be created.'
+    }
+
+    $OutputDirectory = [System.IO.Path]::GetDirectoryName($OutputPath)
+    if (-not [string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        $null = New-Item -ItemType Directory -Path $OutputDirectory -Force -WhatIf:$false
+    }
+    $TemporaryOutputPath = "$OutputPath.$([guid]::NewGuid().ToString('N')).tmp"
+    $Encoding = [System.Text.UTF8Encoding]::new($false)
+    $Writer = $null
+    $Reader = $null
+    try {
+        $Writer = [System.IO.StreamWriter]::new($TemporaryOutputPath, $false, $Encoding)
+        $Writer.Write($HtmlWithMarker.Substring(0, $MarkerIndex))
+
+        $Reader = [System.IO.StreamReader]::new($DataFilePath, $Encoding, $true)
+        $Buffer = [char[]]::new(65536)
+        while (($Read = $Reader.Read($Buffer, 0, $Buffer.Length)) -gt 0) {
+            $Writer.Write($Buffer, 0, $Read)
+        }
+        $Reader.Dispose()
+        $Reader = $null
+
+        $Writer.Write($HtmlWithMarker.Substring($MarkerIndex + $Marker.Length))
+        $Writer.Flush()
+        $Writer.Dispose()
+        $Writer = $null
+
+        Move-Item -LiteralPath $TemporaryOutputPath -Destination $OutputPath -Force -WhatIf:$false -ErrorAction Stop
+    } catch {
+        if (Test-Path -LiteralPath $TemporaryOutputPath) {
+            Remove-Item -LiteralPath $TemporaryOutputPath -Force -WhatIf:$false -ErrorAction SilentlyContinue
+        }
+        throw
+    } finally {
+        if ($null -ne $Reader) {
+            $Reader.Dispose()
+        }
+        if ($null -ne $Writer) {
+            $Writer.Dispose()
+        }
+    }
+}

--- a/Private/New-HTMLProcessedComputers.ps1
+++ b/Private/New-HTMLProcessedComputers.ps1
@@ -5,7 +5,7 @@
         [System.Collections.IDictionary] $DisableOnlyIf,
         [System.Collections.IDictionary] $DeleteOnlyIf,
         [System.Collections.IDictionary] $MoveOnlyIf,
-        [Array] $ComputersToProcess,
+        [PSCustomObject] $ComputerReportData,
         [string] $FilePath,
         [switch] $Online,
         [switch] $ShowHTML,
@@ -16,7 +16,11 @@
         [switch] $ReportOnly
     )
 
-    New-HTML {
+    $ReportDirectory = [System.IO.Path]::GetDirectoryName([System.IO.Path]::GetFullPath($FilePath))
+    $StagingFilePath = Join-Path -Path $ReportDirectory -ChildPath ".cleanupmonster-$([Guid]::NewGuid().ToString('N')).html"
+
+    try {
+        New-HTML {
         New-HTMLTabStyle -BorderRadius 0px -TextTransform capitalize -BackgroundColorActive SlateGrey -BackgroundColor BlizzardBlue
         New-HTMLSectionStyle -BorderRadius 0px -HeaderBackGroundColor Grey -RemoveShadow
         New-HTMLPanelStyle -BorderRadius 0px
@@ -31,6 +35,21 @@
                     New-HTMLText -Text "Cleanup Monster - $($Export['Version'])" -Color Blue
                 } -JustifyContent flex-end -Invisible
             }
+        }
+        New-HTMLTab -Name 'Domain Inventory' {
+            New-HTMLSection {
+                New-HTMLPanel {
+                    if ($Export.InventoryComplete) {
+                        New-HTMLToast -TextHeader 'Inventory complete' -Text 'Every configured domain was inventoried successfully.' -BarColorLeft MintGreen -IconSolid check-circle -IconColor MintGreen
+                    } else {
+                        New-HTMLToast -TextHeader 'Inventory unsafe' -Text 'At least one domain failed or the AD safety limit was not met. Review domain status before relying on totals or findings.' -BarColorLeft OrangeRed -IconSolid exclamation-triangle -IconColor OrangeRed
+                    }
+                } -Invisible
+            } -Invisible
+            New-HTMLTable -DataTable @($Export.DomainInventory) -Filtering -ScrollX {
+                New-HTMLTableCondition -Name 'Status' -ComparisonType string -Value 'Succeeded' -BackgroundColor LightGreen
+                New-HTMLTableCondition -Name 'Status' -ComparisonType string -Value 'Failed' -BackgroundColor Salmon
+            } -WarningAction SilentlyContinue -AllProperties
         }
         if (-not $ReportOnly) {
             New-HTMLTab -Name 'Devices Current Run' {
@@ -112,7 +131,7 @@
         New-HTMLTab -Name 'Devices' {
             New-HTMLSection {
                 New-HTMLPanel {
-                    New-HTMLToast -TextHeader 'Total' -Text "Computers Total: $($ComputersToProcess.Count)" -BarColorLeft MintGreen -IconSolid info-circle -IconColor MintGreen
+                    New-HTMLToast -TextHeader 'Total' -Text "Computers Total: $($ComputerReportData.Count)" -BarColorLeft MintGreen -IconSolid info-circle -IconColor MintGreen
                 } -Invisible
                 New-HTMLPanel {
                     New-HTMLToast -TextHeader 'To disable' -Text "Computers to be disabled: $($Export.Statistics.ToDisable)" -BarColorLeft OrangePeel -IconSolid info-circle -IconColor OrangePeel
@@ -286,17 +305,21 @@
                 }
             }
 
-            New-HTMLTable -DataTable $ComputersToProcess -Filtering -ScrollX {
-                New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Delete' -BackgroundColor PinkLace
-                New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Move' -BackgroundColor Yellow
-                New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Disable' -BackgroundColor EnergyYellow
-                New-HTMLTableCondition -Name 'ActionStatus' -ComparisonType string -Value 'True' -BackgroundColor LightGreen
-                New-HTMLTableCondition -Name 'ActionStatus' -ComparisonType string -Value 'False' -BackgroundColor Salmon
-                New-HTMLTableCondition -Name 'ActionStatus' -ComparisonType string -Value 'Whatif' -BackgroundColor LightBlue
-                New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'ExcludedByFilter' -BackgroundColor LightBlue
-                New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'ExcludedBySetting' -BackgroundColor LightPink
-                New-HTMLTableCondition -Name 'ProtectedFromAccidentalDeletion' -ComparisonType string -Value $false -BackgroundColor LightBlue -FailBackgroundColor Salmon
-            } -WarningAction SilentlyContinue -ExcludeProperty 'TimeOnPendingList', 'TimeToLeavePendingList', 'DistinguishedNameAfterMove'
+            if ($ComputerReportData.Count -gt 0) {
+                New-HTMLTable -DataTable @($ComputerReportData.Sample) -DataStoreID $ComputerReportData.DataStoreID -Filtering -ScrollX {
+                    New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Delete' -BackgroundColor PinkLace
+                    New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Move' -BackgroundColor Yellow
+                    New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'Disable' -BackgroundColor EnergyYellow
+                    New-HTMLTableCondition -Name 'ActionStatus' -ComparisonType string -Value 'True' -BackgroundColor LightGreen
+                    New-HTMLTableCondition -Name 'ActionStatus' -ComparisonType string -Value 'False' -BackgroundColor Salmon
+                    New-HTMLTableCondition -Name 'ActionStatus' -ComparisonType string -Value 'Whatif' -BackgroundColor LightBlue
+                    New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'ExcludedByFilter' -BackgroundColor LightBlue
+                    New-HTMLTableCondition -Name 'Action' -ComparisonType string -Value 'ExcludedBySetting' -BackgroundColor LightPink
+                    New-HTMLTableCondition -Name 'ProtectedFromAccidentalDeletion' -ComparisonType string -Value $false -BackgroundColor LightBlue -FailBackgroundColor Salmon
+                } -WarningAction SilentlyContinue
+            } else {
+                New-HTMLText -Text 'No computers were returned by the successful domain inventories.' -FontWeight bold
+            }
         }
         try {
             if ($LogFile -and (Test-Path -LiteralPath $LogFile -ErrorAction Stop)) {
@@ -308,5 +331,20 @@
         } catch {
             Write-Color -Text "[e] ", "Couldn't read the log file. Skipping adding log to HTML. Error: $($_.Exception.Message)" -Color Yellow, Red
         }
-    } -FilePath $FilePath -Online:$Online.IsPresent -ShowHTML:$ShowHTML.IsPresent
+        } -FilePath $StagingFilePath -Online:$Online.IsPresent
+
+        if ($ComputerReportData.Count -gt 0) {
+            Merge-ADComputerHTMLReportData -StagingHtmlPath $StagingFilePath -DataFilePath $ComputerReportData.FilePath -OutputPath $FilePath -DataStoreID $ComputerReportData.DataStoreID
+        } else {
+            Move-Item -LiteralPath $StagingFilePath -Destination $FilePath -Force -WhatIf:$false
+        }
+
+        if ($ShowHTML) {
+            Invoke-Item -LiteralPath $FilePath -WhatIf:$false
+        }
+    } finally {
+        if (Test-Path -LiteralPath $StagingFilePath) {
+            Remove-Item -LiteralPath $StagingFilePath -Force -WhatIf:$false -ErrorAction SilentlyContinue
+        }
+    }
 }

--- a/Private/Save-ADComputerPendingStateEntry.ps1
+++ b/Private/Save-ADComputerPendingStateEntry.ps1
@@ -1,0 +1,15 @@
+function Save-ADComputerPendingStateEntry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary] $Rollback,
+        [Parameter(Mandatory)]
+        [string] $Key,
+        [Parameter(Mandatory)]
+        [PSObject] $Value
+    )
+
+    if (-not $Rollback.Contains($Key)) {
+        $Rollback[$Key] = $Value.PSObject.Copy()
+    }
+}

--- a/Private/Test-ADQueryConfigurationError.ps1
+++ b/Private/Test-ADQueryConfigurationError.ps1
@@ -1,0 +1,16 @@
+function Test-ADQueryConfigurationError {
+    <#
+    .SYNOPSIS
+    Determines whether an AD query error is independent of the selected server.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.Management.Automation.ErrorRecord] $ErrorRecord
+    )
+
+    $Message = [string] $ErrorRecord.Exception.Message
+    $Message -like '*distinguishedName must belong to one of the following partition*' -or
+        $Message -like '*The search filter cannot be recognized*' -or
+        $Message -like '*The supplied distinguishedName must belong*'
+}

--- a/Private/Test-ADQueryConfigurationError.ps1
+++ b/Private/Test-ADQueryConfigurationError.ps1
@@ -10,7 +10,5 @@ function Test-ADQueryConfigurationError {
     )
 
     $Message = [string] $ErrorRecord.Exception.Message
-    $Message -like '*distinguishedName must belong to one of the following partition*' -or
-        $Message -like '*The search filter cannot be recognized*' -or
-        $Message -like '*The supplied distinguishedName must belong*'
+    $Message -like '*The search filter cannot be recognized*'
 }

--- a/Public/Invoke-ADComputersCleanup.ps1
+++ b/Public/Invoke-ADComputersCleanup.ps1
@@ -1041,11 +1041,13 @@
     }
 
     if ($Export -and $ReportPath) {
-        [Array] $ComputersToProcess = foreach ($Domain in $Report.Keys) {
-            if ($Report["$Domain"]['Computers'].Count -gt 0) {
-                $Report["$Domain"]['Computers']
+        [Array] $ComputersToProcess = @(
+            foreach ($Domain in $Report.Keys) {
+                if ($Report["$Domain"]['Computers'].Count -gt 0) {
+                    $Report["$Domain"]['Computers']
+                }
             }
-        }
+        )
         Write-Color -Text "[i] ", "Computers to be processed for HTML report`: ", $ComputersToProcess.Count -Color Yellow, Cyan, Green
         $Export.Statistics = New-ADComputersStatistics -ComputersToProcess $ComputersToProcess
 
@@ -1070,7 +1072,7 @@
                 Delete             = $Delete
                 Disable            = $Disable
                 Move               = $Move
-                ReportOnly         = $EffectiveReportOnly
+                ReportOnly         = $ReportOnly.IsPresent
             }
             Write-Color "[i] ", "Generating HTML report ($ReportPath)" -Color Yellow, Magenta
             New-HTMLProcessedComputers @newHTMLProcessedComputersSplat

--- a/Public/Invoke-ADComputersCleanup.ps1
+++ b/Public/Invoke-ADComputersCleanup.ps1
@@ -356,9 +356,9 @@
     Path to the HTML report file. Default is $PSScriptRoot\ProcessedComputers.html
 
     .PARAMETER SafetyADLimit
-    Minimum number of computers that must be returned by AD cmdlets to proceed with the process.
+    Minimum number of computers that must be returned by AD cmdlets before mutations are allowed.
     Default is not to check.
-    This is there to prevent accidental deletion of all computers if there is a problem with AD.
+    If the limit is not met, mutations are suppressed and the HTML report is still generated.
 
     .PARAMETER SafetyAzureADLimit
     Minimum number of computers that must be returned by AzureAD cmdlets to proceed with the process.
@@ -384,10 +384,8 @@
 
     .PARAMETER TargetServers
     Target servers to use when connecting to Active Directory.
-    It can take a string with server name, or hashtable with key being the domain, and value being the server name.
-    If you have a forest with multiple domains and want to use different servers for different domains, you can use hashtable.
-    It will use the default server if no server is provided for a domain, which is default approach.
-    This feature is only nessecary if you have specific requirments per domain/forest rather than using the automatic detection.
+    It can take one server name, an array of server names, or a hashtable whose keys are domains and whose values are one or more server names.
+    Manually configured servers are tried in order before auto-detected writable domain controllers.
 
     .PARAMETER RemoveProtectedFromAccidentalDeletionFlag
     Remove the ProtectedFromAccidentalDeletion flag from the computer object before moving or deleting it.
@@ -395,13 +393,18 @@
     By default it will not remove the flag, and require it to be removed manually.
 
     .PARAMETER ADQueryMaxRetries
-    Maximum number of retries for AD query operations. Default is 3.
+    Maximum number of query attempts per domain controller before failing over to the next server. Default is 3.
 
     .PARAMETER ADQueryRetryDelay
     Delay in seconds between retries for AD query operations. Default is 5.
 
     .PARAMETER ADQueryPageSize
     Page size for AD query operations. Default is 1000.
+
+    .PARAMETER DomainFailureAction
+    Controls write behavior when one or more domains cannot be inventoried.
+    Stop is the safe default and suppresses all mutations while still producing an incomplete report.
+    ContinueSuccessfulDomains explicitly allows actions for successfully inventoried domains only.
 
     .EXAMPLE
     $Output = Invoke-ADComputersCleanup -DeleteIsEnabled $false -Delete -WhatIfDelete -ShowHTML -ReportOnly -LogPath $PSScriptRoot\Logs\DeleteComputers_$((Get-Date).ToString('yyyy-MM-dd_HH_mm_ss')).log -ReportPath $PSScriptRoot\Reports\DeleteComputers_$((Get-Date).ToString('yyyy-MM-dd_HH_mm_ss')).html
@@ -449,6 +452,15 @@
     }
     $Output = Invoke-ADComputersCleanup @Configuration
     $Output
+
+    .EXAMPLE
+    # Prefer two manually selected DCs per domain, retain detected DCs as fallbacks,
+    # and suppress every write if any domain still cannot be inventoried.
+    $TargetServers = @{
+        'contoso.com'       = @('dc1.contoso.com', 'dc2.contoso.com')
+        'child.contoso.com' = @('dc1.child.contoso.com', 'dc2.child.contoso.com')
+    }
+    Invoke-ADComputersCleanup -Disable -TargetServers $TargetServers -DomainFailureAction Stop -ShowHTML
 
     .EXAMPLE
     # Run the script
@@ -608,7 +620,9 @@
         [ValidateRange(0, [int]::MaxValue)]
         [int] $ADQueryRetryDelay = 5,
         [ValidateRange(1, 10000)]
-        [int] $ADQueryPageSize = 1000
+        [int] $ADQueryPageSize = 1000,
+        [ValidateSet('Stop', 'ContinueSuccessfulDomains')]
+        [string] $DomainFailureAction = 'Stop'
     )
     # we will use it to check for intune/azuread/jamf functionality
     $Script:CleanupOptions = [ordered] @{}
@@ -730,6 +744,8 @@
         CurrentRun      = $null
         History         = $null
         PendingDeletion = $null
+        InventoryComplete = $true
+        DomainInventory = @()
     }
 
     Write-Color '[i] ', "[CleanupMonster] ", 'Version', ' [Informative] ', $Export['Version'] -Color Yellow, DarkGray, Yellow, DarkGray, Magenta
@@ -812,9 +828,44 @@
         ADQueryPageSize       = $ADQueryPageSize
     }
 
-    $AllComputers = Get-InitialADComputers @SplatADComputers
-    if ($AllComputers -eq $false) {
+    $InventoryResult = Get-InitialADComputers @SplatADComputers
+    if ($InventoryResult -eq $false) {
         return
+    }
+    $SafetyLimitSatisfied = if ($null -ne $InventoryResult.PSObject.Properties['SafetyLimitSatisfied']) {
+        [bool] $InventoryResult.SafetyLimitSatisfied
+    } else {
+        $true
+    }
+    $AllComputerKeys = $InventoryResult.ComputerKeys
+    $Export.InventoryComplete = $InventoryResult.Succeeded -and $SafetyLimitSatisfied
+    $Export.DomainInventory = @(
+        foreach ($Domain in $Report.Keys) {
+            [PSCustomObject] [ordered] @{
+                Domain           = $Domain
+                Status           = $Report["$Domain"].QueryStatus
+                Server           = $Report["$Domain"].Server
+                ComputerCount    = $Report["$Domain"].ComputerCount
+                QueryAttempts    = $Report["$Domain"].QueryAttempts
+                AttemptedServers = $Report["$Domain"].AttemptedServers -join ', '
+                Error            = $Report["$Domain"].QueryError
+            }
+        }
+    )
+
+    $EffectiveReportOnly = $ReportOnly.IsPresent
+    if (-not $InventoryResult.Succeeded) {
+        $FailedDomainText = $InventoryResult.FailedDomains -join ', '
+        if ($DomainFailureAction -eq 'Stop') {
+            $EffectiveReportOnly = $true
+            Write-Color -Text '[e] ', "AD inventory is incomplete. Failed domains: $FailedDomainText. All mutations are suppressed; an incomplete report will still be generated." -Color Yellow, Red
+        } else {
+            Write-Color -Text '[w] ', "AD inventory is incomplete. Failed domains: $FailedDomainText. Continuing only for successfully inventoried domains because DomainFailureAction is ContinueSuccessfulDomains." -Color Yellow, DarkYellow
+        }
+    }
+    if (-not $SafetyLimitSatisfied) {
+        $EffectiveReportOnly = $true
+        Write-Color -Text '[e] ', "AD inventory returned $($AllComputerKeys.Count) computers, below SafetyADLimit $SafetyADLimit. All mutations are suppressed; the report will still be generated." -Color Yellow, Red
     }
 
     foreach ($Domain in $Report.Keys) {
@@ -863,7 +914,7 @@
             DisableModifyDescription                  = $DisableModifyDescription.IsPresent
             DisableModifyAdminDescription             = $DisableModifyAdminDescription.IsPresent
             DisableLimit                              = $DisableLimit
-            ReportOnly                                = $ReportOnly
+            ReportOnly                                = $EffectiveReportOnly
             Today                                     = $Today
             DontWriteToEventLog                       = $DontWriteToEventLog
             DisableMoveTargetOrganizationalUnit       = $DisableMoveTargetOrganizationalUnit
@@ -880,7 +931,7 @@
             WhatIfMove                                = $WhatIfMove
             WhatIf                                    = $WhatIfPreference
             MoveLimit                                 = $MoveLimit
-            ReportOnly                                = $ReportOnly
+            ReportOnly                                = $EffectiveReportOnly
             Today                                     = $Today
             ProcessedComputers                        = $ProcessedComputers
             TargetOrganizationalUnit                  = $MoveTargetOrganizationalUnit
@@ -898,7 +949,7 @@
             WhatIfDelete                              = $WhatIfDelete
             WhatIf                                    = $WhatIfPreference
             DeleteLimit                               = $DeleteLimit
-            ReportOnly                                = $ReportOnly
+            ReportOnly                                = $EffectiveReportOnly
             Today                                     = $Today
             ProcessedComputers                        = $ProcessedComputers
             DontWriteToEventLog                       = $DontWriteToEventLog
@@ -907,11 +958,24 @@
         [Array] $ReportDeleted = Request-ADComputersDelete @requestADComputersDeleteSplat
     }
 
-    Write-Color "[i] ", "Cleanup process for processed computers that no longer exists in AD" -Color Yellow, Green
-    foreach ($FullName in [string[]] $ProcessedComputers.Keys) {
-        if (-not $AllComputers["$($FullName)"]) {
-            Write-Color -Text "[*] Removing computer from pending list ", $ProcessedComputers[$FullName].SamAccountName, " ($($ProcessedComputers[$FullName].DistinguishedName))" -Color Yellow, Green, Yellow
-            $ProcessedComputers.Remove("$($FullName)")
+    if (-not $EffectiveReportOnly) {
+        Write-Color '[i] ', 'Cleaning pending entries that no longer exist in successfully inventoried AD domains' -Color Yellow, Green
+        $SuccessfulDomainSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($SuccessfulDomain in $InventoryResult.SuccessfulDomains) {
+            $null = $SuccessfulDomainSet.Add($SuccessfulDomain)
+        }
+        foreach ($FullName in [string[]] $ProcessedComputers.Keys) {
+            $PendingDomain = [string] $ProcessedComputers[$FullName].DomainName
+            if ([string]::IsNullOrWhiteSpace($PendingDomain)) {
+                $SeparatorIndex = $FullName.LastIndexOf('@')
+                if ($SeparatorIndex -ge 0 -and $SeparatorIndex -lt $FullName.Length - 1) {
+                    $PendingDomain = $FullName.Substring($SeparatorIndex + 1)
+                }
+            }
+            if ($SuccessfulDomainSet.Contains($PendingDomain) -and -not $AllComputerKeys.Contains($FullName)) {
+                Write-Color -Text '[*] Removing computer from pending list ', $ProcessedComputers[$FullName].SamAccountName, " ($($ProcessedComputers[$FullName].DistinguishedName))" -Color Yellow, Green, Yellow
+                $ProcessedComputers.Remove($FullName)
+            }
         }
     }
 
@@ -944,7 +1008,7 @@
     )
 
     Write-Color "[i] ", "Exporting Processed List" -Color Yellow, Magenta
-    if (-not $ReportOnly) {
+    if (-not $EffectiveReportOnly) {
         try {
             $Export | Export-Clixml -LiteralPath $DataStorePath -Encoding Unicode -WhatIf:$false -ErrorAction Stop
         } catch {
@@ -963,16 +1027,16 @@
             Write-Color -Text "[i] ", "Computers to be deleted for domain $Domain`: ", $Report["$Domain"]['ComputersToBeDeleted'] -Color Yellow, Cyan, Green
         }
     }
-    if (-not $ReportOnly) {
+    if (-not $EffectiveReportOnly) {
         Write-Color -Text "[i] ", "Computers on pending list`: ", $Export['PendingDeletion'].Count -Color Yellow, Cyan, Green
     }
-    if (($Disable -or $DisableAndMove) -and -not $ReportOnly) {
+    if (($Disable -or $DisableAndMove) -and -not $EffectiveReportOnly) {
         Write-Color -Text "[i] ", "Computers disabled in this run`: ", $ReportDisabled.Count -Color Yellow, Cyan, Green
     }
-    if ($Move -and -not $ReportOnly) {
+    if ($Move -and -not $EffectiveReportOnly) {
         Write-Color -Text "[i] ", "Computers moved in this run`: ", $ReportMoved.Count -Color Yellow, Cyan, Green
     }
-    if ($Delete -and -not $ReportOnly) {
+    if ($Delete -and -not $EffectiveReportOnly) {
         Write-Color -Text "[i] ", "Computers deleted in this run`: ", $ReportDeleted.Count -Color Yellow, Cyan, Green
     }
 
@@ -985,23 +1049,36 @@
         Write-Color -Text "[i] ", "Computers to be processed for HTML report`: ", $ComputersToProcess.Count -Color Yellow, Cyan, Green
         $Export.Statistics = New-ADComputersStatistics -ComputersToProcess $ComputersToProcess
 
-        $newHTMLProcessedComputersSplat = @{
-            Export             = $Export
-            FilePath           = $ReportPath
-            Online             = $Online.IsPresent
-            ShowHTML           = $ShowHTML.IsPresent
-            LogFile            = $LogPath
-            ComputersToProcess = $ComputersToProcess
-            DisableOnlyIf      = $DisableOnlyIf
-            DeleteOnlyIf       = $DeleteOnlyIf
-            MoveOnlyIf         = $MoveOnlyIf
-            Delete             = $Delete
-            Disable            = $Disable
-            Move               = $Move
-            ReportOnly         = $ReportOnly
+        $ReportDataPath = [System.IO.Path]::GetTempFileName()
+        try {
+            $ComputerReportData = Export-ADComputerReportData -Computers $ComputersToProcess -FilePath $ReportDataPath
+            foreach ($Domain in $Report.Keys) {
+                $Report["$Domain"]['Computers'] = @()
+            }
+            $ComputersToProcess = $null
+
+            $newHTMLProcessedComputersSplat = @{
+                Export             = $Export
+                FilePath           = $ReportPath
+                Online             = $Online.IsPresent
+                ShowHTML           = $ShowHTML.IsPresent
+                LogFile            = $LogPath
+                ComputerReportData = $ComputerReportData
+                DisableOnlyIf      = $DisableOnlyIf
+                DeleteOnlyIf       = $DeleteOnlyIf
+                MoveOnlyIf         = $MoveOnlyIf
+                Delete             = $Delete
+                Disable            = $Disable
+                Move               = $Move
+                ReportOnly         = $EffectiveReportOnly
+            }
+            Write-Color "[i] ", "Generating HTML report ($ReportPath)" -Color Yellow, Magenta
+            New-HTMLProcessedComputers @newHTMLProcessedComputersSplat
+        } finally {
+            if (Test-Path -LiteralPath $ReportDataPath) {
+                Remove-Item -LiteralPath $ReportDataPath -Force -WhatIf:$false -ErrorAction SilentlyContinue
+            }
         }
-        Write-Color "[i] ", "Generating HTML report ($ReportPath)" -Color Yellow, Magenta
-        New-HTMLProcessedComputers @newHTMLProcessedComputersSplat
     }
 
     Write-Color -Text "[i] Finished process of cleaning up stale computers" -Color Green

--- a/Public/Invoke-ADComputersCleanup.ps1
+++ b/Public/Invoke-ADComputersCleanup.ps1
@@ -786,7 +786,7 @@
 
     $Report = [ordered] @{}
 
-    $getInitialGraphComputersSplat = [ordered] @{
+    $getInitialGraphComputersSplat = @{
         SafetyAzureADLimit            = $SafetyAzureADLimit
         SafetyIntuneLimit             = $SafetyIntuneLimit
         DeleteLastSeenAzureMoreThan   = $DeleteLastSeenAzureMoreThan
@@ -817,7 +817,7 @@
         return
     }
 
-    $SplatADComputers = [ordered] @{
+    $SplatADComputers = @{
         Report                = $Report
         ForestInformation     = $ForestInformation
         Filter                = $Filter
@@ -855,7 +855,7 @@
     $Export.InventoryComplete = $InventoryResult.Succeeded -and $SafetyLimitSatisfied
     $Export.DomainInventory = @(
         foreach ($Domain in $Report.Keys) {
-            [PSCustomObject] [ordered] @{
+            [PSCustomObject] @{
                 Domain           = $Domain
                 Status           = $Report["$Domain"].QueryStatus
                 Server           = $Report["$Domain"].Server

--- a/Public/Invoke-ADComputersCleanup.ps1
+++ b/Public/Invoke-ADComputersCleanup.ps1
@@ -854,10 +854,12 @@
     )
 
     $EffectiveReportOnly = $ReportOnly.IsPresent
+    $InventoryWritesSuppressed = $false
     if (-not $InventoryResult.Succeeded) {
         $FailedDomainText = $InventoryResult.FailedDomains -join ', '
         if ($DomainFailureAction -eq 'Stop') {
             $EffectiveReportOnly = $true
+            $InventoryWritesSuppressed = $true
             Write-Color -Text '[e] ', "AD inventory is incomplete. Failed domains: $FailedDomainText. All mutations are suppressed; an incomplete report will still be generated." -Color Yellow, Red
         } else {
             Write-Color -Text '[w] ', "AD inventory is incomplete. Failed domains: $FailedDomainText. Continuing only for successfully inventoried domains because DomainFailureAction is ContinueSuccessfulDomains." -Color Yellow, DarkYellow
@@ -865,7 +867,21 @@
     }
     if (-not $SafetyLimitSatisfied) {
         $EffectiveReportOnly = $true
+        $InventoryWritesSuppressed = $true
         Write-Color -Text '[e] ', "AD inventory returned $($AllComputerKeys.Count) computers, below SafetyADLimit $SafetyADLimit. All mutations are suppressed; the report will still be generated." -Color Yellow, Red
+    }
+    if ($InventoryWritesSuppressed) {
+        # Inventory discovery may remove or update a small subset of pending
+        # entries. Restore only those journaled entries so fail-closed reports
+        # match the unchanged datastore without cloning the full pending set.
+        $PendingStateRollback = if ($null -ne $InventoryResult.PSObject.Properties['PendingStateRollback']) {
+            $InventoryResult.PendingStateRollback
+        }
+        if ($null -ne $PendingStateRollback) {
+            foreach ($PendingKey in @($PendingStateRollback.Keys)) {
+                $ProcessedComputers[$PendingKey] = $PendingStateRollback[$PendingKey]
+            }
+        }
     }
 
     foreach ($Domain in $Report.Keys) {
@@ -956,6 +972,15 @@
             RemoveProtectedFromAccidentalDeletionFlag = $RemoveProtectedFromAccidentalDeletionFlag.IsPresent
         }
         [Array] $ReportDeleted = Request-ADComputersDelete @requestADComputersDeleteSplat
+    }
+
+    if ($InventoryWritesSuppressed) {
+        # Request functions intentionally return candidates in ReportOnly mode.
+        # Automatic fail-closed suppression is different: nothing was attempted,
+        # so those candidates must not become current-run or historical actions.
+        $ReportDisabled = @()
+        $ReportMoved = @()
+        $ReportDeleted = @()
     }
 
     if (-not $EffectiveReportOnly) {

--- a/Public/Invoke-ADComputersCleanup.ps1
+++ b/Public/Invoke-ADComputersCleanup.ps1
@@ -398,6 +398,12 @@
     .PARAMETER ADQueryRetryDelay
     Delay in seconds between retries for AD query operations. Default is 5.
 
+    .PARAMETER ADQueryConnectionTimeout
+    Maximum number of seconds allowed for the isolated AD query process to connect to a domain controller before retrying or failing over. Default is 15.
+
+    .PARAMETER ADQueryIdleTimeout
+    Maximum number of seconds an established AD inventory query may make no result progress before its isolated process is stopped and the query is retried or failed over. This is an idle timeout, not a limit on the total time required to return a large domain. Default is 120.
+
     .PARAMETER ADQueryPageSize
     Page size for AD query operations. Default is 1000.
 
@@ -444,6 +450,8 @@
         DeleteListProcessedMoreThan = 90
         ADQueryMaxRetries     = 5      # Increase retries for unreliable environments
         ADQueryRetryDelay     = 10     # Increase delay between retries
+        ADQueryConnectionTimeout = 15  # Bound unavailable-DC connection attempts
+        ADQueryIdleTimeout       = 120 # Stop a query that stops producing results
         ADQueryPageSize       = 500    # Smaller page size for large environments
         WhatIfDelete          = $true
         ShowHTML             = $true
@@ -619,6 +627,10 @@
         [int] $ADQueryMaxRetries = 3,
         [ValidateRange(0, [int]::MaxValue)]
         [int] $ADQueryRetryDelay = 5,
+        [ValidateRange(1, 300)]
+        [int] $ADQueryConnectionTimeout = 15,
+        [ValidateRange(1, 3600)]
+        [int] $ADQueryIdleTimeout = 120,
         [ValidateRange(1, 10000)]
         [int] $ADQueryPageSize = 1000,
         [ValidateSet('Stop', 'ContinueSuccessfulDomains')]
@@ -825,6 +837,8 @@
         TargetServers         = $TargetServers
         ADQueryMaxRetries     = $ADQueryMaxRetries
         ADQueryRetryDelay     = $ADQueryRetryDelay
+        ADQueryConnectionTimeout = $ADQueryConnectionTimeout
+        ADQueryIdleTimeout    = $ADQueryIdleTimeout
         ADQueryPageSize       = $ADQueryPageSize
     }
 

--- a/README.MD
+++ b/README.MD
@@ -399,10 +399,11 @@ These are good defaults almost everywhere:
 
 These help ensure your data sources are healthy before any action happens:
 
-- `SafetyADLimit` to stop if AD returns fewer objects than expected
+- `SafetyADLimit` to suppress mutations if AD returns fewer objects than expected while still writing the report
 - `SafetyAzureADLimit`, `SafetyIntuneLimit`, and `SafetyJamfLimit` when cloud/device-source validation matters
 - `SafetyEntraLimit` and `SafetyIntuneLimit` for cloud-device cleanup to stop on partial Microsoft Graph inventory
-- `TargetServers` when you want deterministic domain-controller selection
+- `TargetServers` when you want deterministic domain-controller selection and failover
+- `DomainFailureAction Stop` (the default) to suppress all AD mutations when any included domain cannot be inventoried
 
 ### Workflow guards
 
@@ -423,6 +424,24 @@ These reduce risk in destructive cleanup patterns:
 | First lab / pilot | `-ReportOnly`, top-level `-WhatIf`, low limits, HTML report, log file |
 | Early production rollout | Explicit exclusions, low limits, AD safety limit, pending-list staging, action-specific `WhatIf` for risky steps |
 | Mature production automation | AD and cloud safety limits, staged disable/delete windows, OU quarantine, durable datastores, reports/logs, explicit target servers where needed |
+
+For multi-domain AD cleanup, provide an ordered list of preferred DCs for each domain. CleanupMonster tries those servers first, then any writable DCs found during forest discovery:
+
+```powershell
+$TargetServers = @{
+    'contoso.com'       = @('dc1.contoso.com', 'dc2.contoso.com')
+    'child.contoso.com' = @('dc1.child.contoso.com', 'dc2.child.contoso.com')
+}
+
+Invoke-ADComputersCleanup `
+    -Disable `
+    -TargetServers $TargetServers `
+    -ADQueryMaxRetries 3 `
+    -DomainFailureAction Stop `
+    -ShowHTML
+```
+
+`Stop` still writes an HTML report, but marks it incomplete and prevents disable, move, delete, datastore updates, and pending-list pruning. `ContinueSuccessfulDomains` is an explicit opt-in for independent domains: actions and pending-list maintenance are limited to domains whose inventory completed successfully, while failed-domain state is left untouched.
 
 ## Rollout Pattern 🪜
 

--- a/Tests/ADComputerInventoryQuery.Tests.ps1
+++ b/Tests/ADComputerInventoryQuery.Tests.ps1
@@ -3,6 +3,7 @@ BeforeAll {
     . (Get-CleanupMonsterPath 'Private/Get-ADQueryServerCandidates.ps1')
     . (Get-CleanupMonsterPath 'Private/Test-ADQueryConfigurationError.ps1')
     . (Get-CleanupMonsterPath 'Private/Invoke-ADComputerInventoryQuery.ps1')
+    . (Get-CleanupMonsterPath 'Private/Get-InitialADComputers.ps1')
 
     function Write-Color { param([Parameter(ValueFromRemainingArguments = $true)] $Text, [object[]] $Color) }
     function Get-ADComputer {
@@ -21,6 +22,41 @@ BeforeAll {
             [DateTime] $Today
         )
         process { $InputObject }
+    }
+}
+
+Describe 'AD computer inventory safety' {
+    It 'marks a domain failed instead of broadening a missing per-domain filter' {
+        $Report = [ordered] @{}
+        $ForestInformation = [ordered] @{
+            Domains         = @('contoso.com', 'child.contoso.com')
+            QueryServers    = @{
+                'contoso.com'       = @{ HostName = @('dc1.contoso.com') }
+                'child.contoso.com' = @{ HostName = @('dc1.child.contoso.com') }
+            }
+            DomainsExtended = @{
+                'contoso.com'       = @{ DistinguishedName = 'DC=contoso,DC=com' }
+                'child.contoso.com' = @{ DistinguishedName = 'DC=child,DC=contoso,DC=com' }
+            }
+        }
+        Mock Invoke-ADComputerInventoryQuery {
+            [PSCustomObject] @{
+                Succeeded = $true
+                Server    = $Servers[0]
+                Computers = @()
+                Attempts  = @([PSCustomObject] @{ Server = $Servers[0] })
+                Error     = $null
+            }
+        }
+
+        $Result = Get-InitialADComputers -Report $Report -ForestInformation $ForestInformation -Filter @{ 'contoso.com' = '*' } -Properties @('SamAccountName') -Disable:$false -Move:$false -Delete:$false
+
+        $Result.Succeeded | Should -BeFalse
+        $Result.SuccessfulDomains | Should -Be @('contoso.com')
+        $Result.FailedDomains | Should -Be @('child.contoso.com')
+        $Report['child.contoso.com'].QueryStatus | Should -Be 'Failed'
+        $Report['child.contoso.com'].QueryError | Should -Match 'No AD filter was configured'
+        Assert-MockCalled Invoke-ADComputerInventoryQuery -Times 1 -Exactly
     }
 }
 

--- a/Tests/ADComputerInventoryQuery.Tests.ps1
+++ b/Tests/ADComputerInventoryQuery.Tests.ps1
@@ -148,6 +148,25 @@ Describe 'AD computer inventory server selection and failover' {
         Assert-MockCalled Invoke-ADComputerInventoryAttempt -Times 1 -Exactly -ParameterFilter { $Server -eq 'dc2.contoso.com' }
     }
 
+    It 'skips the smaller-page retry when the child cannot initialize' {
+        Mock Invoke-ADComputerInventoryAttempt {
+            [PSCustomObject] @{
+                Succeeded    = $false
+                Computers    = @()
+                TimedOut     = $true
+                TimeoutPhase = 'Initialization'
+                Duration     = [TimeSpan]::FromSeconds(60)
+                ErrorMessage = 'AD initialization timeout after 60 seconds. The isolated query process was stopped.'
+            }
+        }
+
+        $Result = Invoke-ADComputerInventoryQuery -Domain 'contoso.com' -Servers @('dc1.contoso.com') -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -MaxAttemptsPerServer 1 -RetryDelaySeconds 0 -PageSize 1000
+
+        $Result.Succeeded | Should -BeFalse
+        $Result.Attempts | Should -HaveCount 1
+        Assert-MockCalled Invoke-ADComputerInventoryAttempt -Times 1 -Exactly
+    }
+
     It 'records an explicit failed result after every domain controller fails' {
         Mock Invoke-ADComputerInventoryAttempt {
             [PSCustomObject] @{
@@ -255,6 +274,8 @@ Describe 'AD computer inventory process isolation' {
         @'
 function Invoke-ADComputerInventoryChildProcess {
     param([string] $ConfigurationPath)
+    $Configuration = Import-Clixml -LiteralPath $ConfigurationPath
+    [System.IO.File]::WriteAllText($Configuration.InitializationPath, 'Initialized')
     Start-Sleep -Seconds 10
 }
 '@ | Set-Content -LiteralPath $ChildPath -Encoding UTF8
@@ -269,12 +290,50 @@ function Invoke-ADComputerInventoryChildProcess {
         ((Get-Date) - $Started).TotalSeconds | Should -BeLessThan 5
     }
 
+    It 'does not charge child initialization time against the connection timeout' {
+        $ChildPath = Join-Path $TestDrive 'SlowInitializationChild.ps1'
+        @'
+function Invoke-ADComputerInventoryChildProcess {
+    param([string] $ConfigurationPath)
+    $Configuration = Import-Clixml -LiteralPath $ConfigurationPath
+    Start-Sleep -Seconds 2
+    [System.IO.File]::WriteAllText($Configuration.InitializationPath, 'Initialized')
+    [System.IO.File]::WriteAllText($Configuration.ReadyPath, 'Ready')
+    [System.IO.File]::WriteAllText($Configuration.ProgressPath, '0')
+    [System.IO.File]::WriteAllText($Configuration.SuccessPath, '0')
+}
+'@ | Set-Content -LiteralPath $ChildPath -Encoding UTF8
+
+        $Result = Invoke-ADComputerInventoryAttempt -Server 'dc1.contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -ConnectionTimeoutSeconds 1 -InitializationTimeoutSeconds 5 -IdleTimeoutSeconds 5 -ChildProcessFunctionPath $ChildPath
+
+        $Result.Succeeded | Should -BeTrue -Because $Result.ErrorMessage
+    }
+
+    It 'kills a child that never completes initialization' {
+        $ChildPath = Join-Path $TestDrive 'StalledInitializationChild.ps1'
+        @'
+function Invoke-ADComputerInventoryChildProcess {
+    param([string] $ConfigurationPath)
+    Start-Sleep -Seconds 10
+}
+'@ | Set-Content -LiteralPath $ChildPath -Encoding UTF8
+
+        $Started = Get-Date
+        $Result = Invoke-ADComputerInventoryAttempt -Server 'dc1.contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -ConnectionTimeoutSeconds 5 -InitializationTimeoutSeconds 1 -IdleTimeoutSeconds 5 -ChildProcessFunctionPath $ChildPath
+
+        $Result.Succeeded | Should -BeFalse
+        $Result.TimedOut | Should -BeTrue
+        $Result.TimeoutPhase | Should -Be 'Initialization'
+        ((Get-Date) - $Started).TotalSeconds | Should -BeLessThan 5
+    }
+
     It 'kills an established child query after the configured idle timeout' {
         $ChildPath = Join-Path $TestDrive 'StalledChild.ps1'
         @'
 function Invoke-ADComputerInventoryChildProcess {
     param([string] $ConfigurationPath)
     $Configuration = Import-Clixml -LiteralPath $ConfigurationPath
+    [System.IO.File]::WriteAllText($Configuration.InitializationPath, 'Initialized')
     [System.IO.File]::WriteAllText($Configuration.ReadyPath, 'Ready')
     [System.IO.File]::WriteAllText($Configuration.ProgressPath, '0')
     Start-Sleep -Seconds 10
@@ -297,6 +356,7 @@ function Invoke-ADComputerInventoryChildProcess {
 function Invoke-ADComputerInventoryChildProcess {
     param([string] $ConfigurationPath)
     $Configuration = Import-Clixml -LiteralPath $ConfigurationPath
+    [System.IO.File]::WriteAllText($Configuration.InitializationPath, 'Initialized')
     [System.IO.File]::WriteAllText($Configuration.ReadyPath, 'Ready')
     [System.IO.File]::WriteAllText($Configuration.ProgressPath, '1')
     [PSCustomObject] [ordered] @{

--- a/Tests/ADComputerInventoryQuery.Tests.ps1
+++ b/Tests/ADComputerInventoryQuery.Tests.ps1
@@ -80,4 +80,19 @@ Describe 'AD computer inventory server selection and failover' {
         $Result.Attempts | Should -HaveCount 2
         $Result.Attempts[1].PageSize | Should -Be 500
     }
+
+    It 'continues to the next domain controller after a partition error on a manual server' {
+        Mock Get-ADComputer {
+            if ($Server -eq 'manual.contoso.com') {
+                throw 'The supplied distinguishedName must belong to one of the following partition(s)'
+            }
+            [PSCustomObject] @{ SamAccountName = 'PC01$' }
+        }
+
+        $Result = Invoke-ADComputerInventoryQuery -Domain 'contoso.com' -Servers @('manual.contoso.com', 'detected.contoso.com') -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -MaxAttemptsPerServer 1 -RetryDelaySeconds 0 -PageSize 500
+
+        $Result.Succeeded | Should -BeTrue
+        $Result.Server | Should -Be 'detected.contoso.com'
+        $Result.Attempts | Should -HaveCount 2
+    }
 }

--- a/Tests/ADComputerInventoryQuery.Tests.ps1
+++ b/Tests/ADComputerInventoryQuery.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     . (Get-CleanupMonsterPath 'Private/Test-ADQueryConfigurationError.ps1')
     . (Get-CleanupMonsterPath 'Private/ConvertFrom-ADComputerInventoryRow.ps1')
     . (Get-CleanupMonsterPath 'Private/Invoke-ADComputerInventoryAttempt.ps1')
+    . (Get-CleanupMonsterPath 'Private/Invoke-ADComputerInventoryChildProcess.ps1')
     . (Get-CleanupMonsterPath 'Private/Invoke-ADComputerInventoryQuery.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-InitialADComputers.ps1')
 
@@ -54,6 +55,51 @@ Describe 'AD computer inventory safety' {
         $Result.FailedDomains | Should -Be @('child.contoso.com')
         $Report['child.contoso.com'].QueryStatus | Should -Be 'Failed'
         $Report['child.contoso.com'].QueryError | Should -Match 'No AD filter was configured'
+        Assert-MockCalled Invoke-ADComputerInventoryQuery -Times 1 -Exactly
+    }
+
+    It 'marks a domain failed instead of broadening an empty filter dictionary' {
+        $Report = [ordered] @{}
+        $ForestInformation = [ordered] @{
+            Domains = @('contoso.com')
+            QueryServers = @{ 'contoso.com' = @{ HostName = @('dc1.contoso.com') } }
+            DomainsExtended = @{ 'contoso.com' = @{ DistinguishedName = 'DC=contoso,DC=com' } }
+        }
+        Mock Invoke-ADComputerInventoryQuery {}
+
+        $Result = Get-InitialADComputers -Report $Report -ForestInformation $ForestInformation -Filter @{} -Properties @('SamAccountName') -Disable:$false -Move:$false -Delete:$false
+
+        $Result.Succeeded | Should -BeFalse
+        $Result.FailedDomains | Should -Be @('contoso.com')
+        $Report['contoso.com'].QueryError | Should -Match 'No AD filter was configured'
+        Assert-MockCalled Invoke-ADComputerInventoryQuery -Times 0 -Exactly
+    }
+
+    It 'marks a domain failed instead of broadening a missing per-domain search base' {
+        $Report = [ordered] @{}
+        $ForestInformation = [ordered] @{
+            Domains = @('contoso.com', 'child.contoso.com')
+            QueryServers = @{
+                'contoso.com' = @{ HostName = @('dc1.contoso.com') }
+                'child.contoso.com' = @{ HostName = @('dc1.child.contoso.com') }
+            }
+            DomainsExtended = @{
+                'contoso.com' = @{ DistinguishedName = 'DC=contoso,DC=com' }
+                'child.contoso.com' = @{ DistinguishedName = 'DC=child,DC=contoso,DC=com' }
+            }
+        }
+        Mock Invoke-ADComputerInventoryQuery {
+            [PSCustomObject] @{
+                Succeeded = $true; Server = $Servers[0]; Computers = @(); Attempts = @([PSCustomObject] @{ Server = $Servers[0] }); Error = $null
+            }
+        }
+
+        $Result = Get-InitialADComputers -Report $Report -ForestInformation $ForestInformation -Filter '*' -SearchBase @{ 'contoso.com' = 'OU=Computers,DC=contoso,DC=com' } -Properties @('SamAccountName') -Disable:$false -Move:$false -Delete:$false
+
+        $Result.Succeeded | Should -BeFalse
+        $Result.SuccessfulDomains | Should -Be @('contoso.com')
+        $Result.FailedDomains | Should -Be @('child.contoso.com')
+        $Report['child.contoso.com'].QueryError | Should -Match 'No AD search base was configured'
         Assert-MockCalled Invoke-ADComputerInventoryQuery -Times 1 -Exactly
     }
 }
@@ -247,6 +293,36 @@ Describe 'AD computer inventory server selection and failover' {
 }
 
 Describe 'AD computer inventory process isolation' {
+    It 'records time-throttled progress when fewer than 100 slow results arrive' {
+        function Get-ADRootDSE {}
+        function Get-ADComputer {}
+        Mock Import-Module {}
+        Mock Get-ADRootDSE { [PSCustomObject] @{} }
+        Mock Get-ADComputer {
+            1..3 | ForEach-Object {
+                Start-Sleep -Milliseconds 350
+                [PSCustomObject] @{
+                    Name = "PC$_"
+                    SamAccountName = "PC$_`$"
+                    DistinguishedName = "CN=PC$_,DC=contoso,DC=com"
+                }
+            }
+        }
+
+        $ConfigurationPath = Join-Path $TestDrive 'query.clixml'
+        $Configuration = [PSCustomObject] @{
+            Server = 'dc1.contoso.com'; Filter = '*'; Properties = @('SamAccountName'); SearchBase = $null; PageSize = 1000; ProgressIntervalMilliseconds = 250
+            InitializationPath = (Join-Path $TestDrive 'initialized'); ReadyPath = (Join-Path $TestDrive 'ready'); ProgressPath = (Join-Path $TestDrive 'progress')
+            SuccessPath = (Join-Path $TestDrive 'success'); ErrorPath = (Join-Path $TestDrive 'error.txt'); DataPath = (Join-Path $TestDrive 'computers.csv')
+        }
+        $Configuration | Export-Clixml -LiteralPath $ConfigurationPath
+
+        Invoke-ADComputerInventoryChildProcess -ConfigurationPath $ConfigurationPath
+
+        Get-Content -LiteralPath $Configuration.ProgressPath | Should -Be '3'
+        Get-Content -LiteralPath $Configuration.SuccessPath | Should -Be '3'
+    }
+
     It 'terminates a still-running child when polling exits unexpectedly' {
         $script:FakeChildKilled = $false
         $FakeProcess = [PSCustomObject] @{ HasExited = $false; Id = 4242; ExitCode = 0 }
@@ -348,6 +424,29 @@ function Invoke-ADComputerInventoryChildProcess {
         $Result.TimeoutPhase | Should -Be 'Query'
         $Result.ErrorMessage | Should -Match 'isolated query process was stopped'
         ((Get-Date) - $Started).TotalSeconds | Should -BeLessThan 5
+    }
+
+    It 'keeps a burst-shaped result stream alive across progress-marker throttle lag' {
+        $ChildPath = Join-Path $TestDrive 'SlowProgressChild.ps1'
+        @'
+function Invoke-ADComputerInventoryChildProcess {
+    param([string] $ConfigurationPath)
+    $Configuration = Import-Clixml -LiteralPath $ConfigurationPath
+    [System.IO.File]::WriteAllText($Configuration.InitializationPath, 'Initialized')
+    [System.IO.File]::WriteAllText($Configuration.ReadyPath, 'Ready')
+    [System.IO.File]::WriteAllText($Configuration.ProgressPath, '1')
+    Start-Sleep -Milliseconds 200
+    # A second result arrives inside the throttle window without a marker write.
+    Start-Sleep -Milliseconds 850
+    [System.IO.File]::WriteAllText($Configuration.ProgressPath, '3')
+    [System.IO.File]::WriteAllText($Configuration.SuccessPath, '3')
+}
+'@ | Set-Content -LiteralPath $ChildPath -Encoding UTF8
+
+        $Result = Invoke-ADComputerInventoryAttempt -Server 'dc1.contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -ConnectionTimeoutSeconds 5 -IdleTimeoutSeconds 1 -ChildProcessFunctionPath $ChildPath
+
+        $Result.Succeeded | Should -BeTrue -Because $Result.ErrorMessage
+        $Result.TimedOut | Should -BeFalse
     }
 
     It 'streams only the required row fields back from a successful isolated child' {

--- a/Tests/ADComputerInventoryQuery.Tests.ps1
+++ b/Tests/ADComputerInventoryQuery.Tests.ps1
@@ -2,14 +2,12 @@ BeforeAll {
     . "$PSScriptRoot\TestHelpers.ps1"
     . (Get-CleanupMonsterPath 'Private/Get-ADQueryServerCandidates.ps1')
     . (Get-CleanupMonsterPath 'Private/Test-ADQueryConfigurationError.ps1')
+    . (Get-CleanupMonsterPath 'Private/ConvertFrom-ADComputerInventoryRow.ps1')
+    . (Get-CleanupMonsterPath 'Private/Invoke-ADComputerInventoryAttempt.ps1')
     . (Get-CleanupMonsterPath 'Private/Invoke-ADComputerInventoryQuery.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-InitialADComputers.ps1')
 
     function Write-Color { param([Parameter(ValueFromRemainingArguments = $true)] $Text, [object[]] $Color) }
-    function Get-ADComputer {
-        [CmdletBinding()]
-        param($Filter, $Properties, $SearchBase, $Server, $ResultPageSize, $ResultSetSize)
-    }
     function ConvertTo-PreparedComputer {
         [CmdletBinding()]
         param(
@@ -61,6 +59,19 @@ Describe 'AD computer inventory safety' {
 }
 
 Describe 'AD computer inventory server selection and failover' {
+    BeforeEach {
+        Mock Invoke-ADComputerInventoryAttempt {
+            [PSCustomObject] @{
+                Succeeded    = $true
+                Computers    = @([PSCustomObject] @{ SamAccountName = 'PC01$' })
+                TimedOut     = $false
+                TimeoutPhase = $null
+                Duration     = [TimeSpan]::Zero
+                ErrorMessage = $null
+            }
+        }
+    }
+
     It 'uses every manual server for the domain before detected fallbacks and removes duplicates' {
         $Configured = @{
             'contoso.com' = @('manual-1.contoso.com', 'manual-2.contoso.com', 'MANUAL-1.contoso.com')
@@ -75,11 +86,25 @@ Describe 'AD computer inventory server selection and failover' {
     }
 
     It 'fails over to the next domain controller after exhausting the first one' {
-        Mock Get-ADComputer {
+        Mock Invoke-ADComputerInventoryAttempt {
             if ($Server -eq 'dc1.contoso.com') {
-                throw 'The server is not operational'
+                return [PSCustomObject] @{
+                    Succeeded    = $false
+                    Computers    = @()
+                    TimedOut     = $false
+                    TimeoutPhase = $null
+                    Duration     = [TimeSpan]::Zero
+                    ErrorMessage = 'The server is not operational'
+                }
             }
-            [PSCustomObject] @{ SamAccountName = 'PC01$' }
+            [PSCustomObject] @{
+                Succeeded    = $true
+                Computers    = @([PSCustomObject] @{ SamAccountName = 'PC01$' })
+                TimedOut     = $false
+                TimeoutPhase = $null
+                Duration     = [TimeSpan]::Zero
+                ErrorMessage = $null
+            }
         }
 
         $Result = Invoke-ADComputerInventoryQuery -Domain 'contoso.com' -Servers @('dc1.contoso.com', 'dc2.contoso.com') -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -MaxAttemptsPerServer 2 -RetryDelaySeconds 0 -PageSize 500
@@ -91,8 +116,49 @@ Describe 'AD computer inventory server selection and failover' {
         @($Result.Attempts | Where-Object Server -eq 'dc1.contoso.com') | Should -HaveCount 2
     }
 
+    It 'bounds the real isolated AD query and preserves port-qualified server values during failover' {
+        Mock Invoke-ADComputerInventoryAttempt {
+            if ($Server -eq 'dc1.contoso.com:60000') {
+                return [PSCustomObject] @{
+                    Succeeded    = $false
+                    Computers    = @()
+                    TimedOut     = $true
+                    TimeoutPhase = 'Connection'
+                    Duration     = [TimeSpan]::FromSeconds(10)
+                    ErrorMessage = 'AD connection timeout after 10 seconds through dc1.contoso.com:60000. The isolated query process was stopped.'
+                }
+            }
+            [PSCustomObject] @{
+                Succeeded    = $true
+                Computers    = @([PSCustomObject] @{ SamAccountName = 'PC01$' })
+                TimedOut     = $false
+                TimeoutPhase = $null
+                Duration     = [TimeSpan]::Zero
+                ErrorMessage = $null
+            }
+        }
+
+        $Result = Invoke-ADComputerInventoryQuery -Domain 'contoso.com' -Servers @('dc1.contoso.com:60000', 'dc2.contoso.com') -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -MaxAttemptsPerServer 2 -RetryDelaySeconds 0 -ConnectionTimeoutSeconds 10 -PageSize 1000
+
+        $Result.Succeeded | Should -BeTrue
+        $Result.Server | Should -Be 'dc2.contoso.com'
+        @($Result.Attempts | Where-Object Server -eq 'dc1.contoso.com:60000') | Should -HaveCount 2
+        @($Result.Attempts | Where-Object Server -eq 'dc1.contoso.com:60000').ErrorMessage | Should -Match 'isolated query process was stopped'
+        Assert-MockCalled Invoke-ADComputerInventoryAttempt -Times 2 -Exactly -ParameterFilter { $Server -eq 'dc1.contoso.com:60000' }
+        Assert-MockCalled Invoke-ADComputerInventoryAttempt -Times 1 -Exactly -ParameterFilter { $Server -eq 'dc2.contoso.com' }
+    }
+
     It 'records an explicit failed result after every domain controller fails' {
-        Mock Get-ADComputer { throw 'The server is not operational' }
+        Mock Invoke-ADComputerInventoryAttempt {
+            [PSCustomObject] @{
+                Succeeded    = $false
+                Computers    = @()
+                TimedOut     = $false
+                TimeoutPhase = $null
+                Duration     = [TimeSpan]::Zero
+                ErrorMessage = 'The server is not operational'
+            }
+        }
 
         $Result = Invoke-ADComputerInventoryQuery -Domain 'contoso.com' -Servers @('dc1.contoso.com', 'dc2.contoso.com') -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -MaxAttemptsPerServer 1 -RetryDelaySeconds 0 -PageSize 500
 
@@ -103,11 +169,25 @@ Describe 'AD computer inventory server selection and failover' {
     }
 
     It 'retries a failed large-page query once with the bounded fallback page size' {
-        Mock Get-ADComputer {
-            if ($ResultPageSize -eq 1000) {
-                throw 'invalid enumeration context'
+        Mock Invoke-ADComputerInventoryAttempt {
+            if ($PageSize -eq 1000) {
+                return [PSCustomObject] @{
+                    Succeeded    = $false
+                    Computers    = @()
+                    TimedOut     = $false
+                    TimeoutPhase = $null
+                    Duration     = [TimeSpan]::Zero
+                    ErrorMessage = 'invalid enumeration context'
+                }
             }
-            [PSCustomObject] @{ SamAccountName = 'PC01$' }
+            [PSCustomObject] @{
+                Succeeded    = $true
+                Computers    = @([PSCustomObject] @{ SamAccountName = 'PC01$' })
+                TimedOut     = $false
+                TimeoutPhase = $null
+                Duration     = [TimeSpan]::Zero
+                ErrorMessage = $null
+            }
         }
 
         $Result = Invoke-ADComputerInventoryQuery -Domain 'contoso.com' -Servers @('dc1.contoso.com') -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -MaxAttemptsPerServer 1 -RetryDelaySeconds 0 -PageSize 1000
@@ -118,11 +198,25 @@ Describe 'AD computer inventory server selection and failover' {
     }
 
     It 'continues to the next domain controller after a partition error on a manual server' {
-        Mock Get-ADComputer {
+        Mock Invoke-ADComputerInventoryAttempt {
             if ($Server -eq 'manual.contoso.com') {
-                throw 'The supplied distinguishedName must belong to one of the following partition(s)'
+                return [PSCustomObject] @{
+                    Succeeded    = $false
+                    Computers    = @()
+                    TimedOut     = $false
+                    TimeoutPhase = $null
+                    Duration     = [TimeSpan]::Zero
+                    ErrorMessage = 'The supplied distinguishedName must belong to one of the following partition(s)'
+                }
             }
-            [PSCustomObject] @{ SamAccountName = 'PC01$' }
+            [PSCustomObject] @{
+                Succeeded    = $true
+                Computers    = @([PSCustomObject] @{ SamAccountName = 'PC01$' })
+                TimedOut     = $false
+                TimeoutPhase = $null
+                Duration     = [TimeSpan]::Zero
+                ErrorMessage = $null
+            }
         }
 
         $Result = Invoke-ADComputerInventoryQuery -Domain 'contoso.com' -Servers @('manual.contoso.com', 'detected.contoso.com') -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -MaxAttemptsPerServer 1 -RetryDelaySeconds 0 -PageSize 500
@@ -130,5 +224,99 @@ Describe 'AD computer inventory server selection and failover' {
         $Result.Succeeded | Should -BeTrue
         $Result.Server | Should -Be 'detected.contoso.com'
         $Result.Attempts | Should -HaveCount 2
+    }
+}
+
+Describe 'AD computer inventory process isolation' {
+    It 'terminates a still-running child when polling exits unexpectedly' {
+        $script:FakeChildKilled = $false
+        $FakeProcess = [PSCustomObject] @{ HasExited = $false; Id = 4242; ExitCode = 0 }
+        $FakeProcess | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value {
+            param([int] $Milliseconds)
+            $this.HasExited
+        }
+        $FakeProcess | Add-Member -MemberType ScriptMethod -Name Kill -Value {
+            $script:FakeChildKilled = $true
+            $this.HasExited = $true
+        }
+        $FakeProcess | Add-Member -MemberType ScriptMethod -Name Dispose -Value {}
+        Mock Start-Process { $FakeProcess }
+        Mock Test-Path { throw 'Polling interrupted' }
+
+        $Result = Invoke-ADComputerInventoryAttempt -Server 'dc1.contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -ConnectionTimeoutSeconds 5 -IdleTimeoutSeconds 5
+
+        $Result.Succeeded | Should -BeFalse
+        $Result.ErrorMessage | Should -Be 'Polling interrupted'
+        $script:FakeChildKilled | Should -BeTrue
+    }
+
+    It 'kills a child that never completes native AD connection readiness' {
+        $ChildPath = Join-Path $TestDrive 'UnreadyChild.ps1'
+        @'
+function Invoke-ADComputerInventoryChildProcess {
+    param([string] $ConfigurationPath)
+    Start-Sleep -Seconds 10
+}
+'@ | Set-Content -LiteralPath $ChildPath -Encoding UTF8
+
+        $Started = Get-Date
+        $Result = Invoke-ADComputerInventoryAttempt -Server 'unavailable.contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -ConnectionTimeoutSeconds 1 -IdleTimeoutSeconds 5 -ChildProcessFunctionPath $ChildPath
+
+        $Result.Succeeded | Should -BeFalse
+        $Result.TimedOut | Should -BeTrue
+        $Result.TimeoutPhase | Should -Be 'Connection'
+        $Result.ErrorMessage | Should -Match 'isolated query process was stopped'
+        ((Get-Date) - $Started).TotalSeconds | Should -BeLessThan 5
+    }
+
+    It 'kills an established child query after the configured idle timeout' {
+        $ChildPath = Join-Path $TestDrive 'StalledChild.ps1'
+        @'
+function Invoke-ADComputerInventoryChildProcess {
+    param([string] $ConfigurationPath)
+    $Configuration = Import-Clixml -LiteralPath $ConfigurationPath
+    [System.IO.File]::WriteAllText($Configuration.ReadyPath, 'Ready')
+    [System.IO.File]::WriteAllText($Configuration.ProgressPath, '0')
+    Start-Sleep -Seconds 10
+}
+'@ | Set-Content -LiteralPath $ChildPath -Encoding UTF8
+
+        $Started = Get-Date
+        $Result = Invoke-ADComputerInventoryAttempt -Server 'dc1.contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -ConnectionTimeoutSeconds 5 -IdleTimeoutSeconds 1 -ChildProcessFunctionPath $ChildPath
+
+        $Result.Succeeded | Should -BeFalse
+        $Result.TimedOut | Should -BeTrue
+        $Result.TimeoutPhase | Should -Be 'Query'
+        $Result.ErrorMessage | Should -Match 'isolated query process was stopped'
+        ((Get-Date) - $Started).TotalSeconds | Should -BeLessThan 5
+    }
+
+    It 'streams only the required row fields back from a successful isolated child' {
+        $ChildPath = Join-Path $TestDrive 'SuccessfulChild.ps1'
+        @'
+function Invoke-ADComputerInventoryChildProcess {
+    param([string] $ConfigurationPath)
+    $Configuration = Import-Clixml -LiteralPath $ConfigurationPath
+    [System.IO.File]::WriteAllText($Configuration.ReadyPath, 'Ready')
+    [System.IO.File]::WriteAllText($Configuration.ProgressPath, '1')
+    [PSCustomObject] [ordered] @{
+        Name = 'PC01'; DNSHostName = 'pc01.contoso.com'; SamAccountName = 'PC01$'; DistinguishedName = 'CN=PC01,DC=contoso,DC=com'
+        Enabled = $true; OperatingSystem = 'Windows'; OperatingSystemVersion = '10.0'; LastLogonDateBinary = (Get-Date).ToBinary()
+        PasswordLastSetBinary = (Get-Date).ToBinary(); PasswordExpired = $false; ServicePrincipalNameJson = '["HOST/PC01"]'
+        LogonCount = 12; ManagedBy = ''; Description = 'Test'; WhenCreatedBinary = (Get-Date).ToBinary(); WhenChangedBinary = (Get-Date).ToBinary()
+        ProtectedFromAccidentalDeletion = $true
+    } | Export-Csv -LiteralPath $Configuration.DataPath -NoTypeInformation -Encoding UTF8
+    [System.IO.File]::WriteAllText($Configuration.SuccessPath, '1')
+}
+'@ | Set-Content -LiteralPath $ChildPath -Encoding UTF8
+
+        $Result = Invoke-ADComputerInventoryAttempt -Server 'contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -ConnectionTimeoutSeconds 5 -IdleTimeoutSeconds 5 -ChildProcessFunctionPath $ChildPath
+
+        $Result.Succeeded | Should -BeTrue -Because $Result.ErrorMessage
+        $Result.Computers | Should -HaveCount 1
+        $Result.Computers[0].SamAccountName | Should -Be 'PC01$'
+        $Result.Computers[0].servicePrincipalName | Should -Be @('HOST/PC01')
+        $Result.Computers[0].LastLogonDate | Should -BeOfType ([DateTime])
+        $Result.Computers[0].ProtectedFromAccidentalDeletion | Should -BeTrue
     }
 }

--- a/Tests/ADComputerInventoryQuery.Tests.ps1
+++ b/Tests/ADComputerInventoryQuery.Tests.ps1
@@ -1,0 +1,83 @@
+BeforeAll {
+    . "$PSScriptRoot\TestHelpers.ps1"
+    . (Get-CleanupMonsterPath 'Private/Get-ADQueryServerCandidates.ps1')
+    . (Get-CleanupMonsterPath 'Private/Test-ADQueryConfigurationError.ps1')
+    . (Get-CleanupMonsterPath 'Private/Invoke-ADComputerInventoryQuery.ps1')
+
+    function Write-Color { param([Parameter(ValueFromRemainingArguments = $true)] $Text, [object[]] $Color) }
+    function Get-ADComputer {
+        [CmdletBinding()]
+        param($Filter, $Properties, $SearchBase, $Server, $ResultPageSize, $ResultSetSize)
+    }
+    function ConvertTo-PreparedComputer {
+        [CmdletBinding()]
+        param(
+            [Parameter(ValueFromPipeline)] $InputObject,
+            $AzureInformationCache,
+            $JamfInformationCache,
+            [switch] $IncludeAzureAD,
+            [switch] $IncludeIntune,
+            [switch] $IncludeJamf,
+            [DateTime] $Today
+        )
+        process { $InputObject }
+    }
+}
+
+Describe 'AD computer inventory server selection and failover' {
+    It 'uses every manual server for the domain before detected fallbacks and removes duplicates' {
+        $Configured = @{
+            'contoso.com' = @('manual-1.contoso.com', 'manual-2.contoso.com', 'MANUAL-1.contoso.com')
+        }
+
+        $Actual = @(Get-ADQueryServerCandidates -Domain 'contoso.com' -TargetServers $Configured -DetectedServers @('auto-1.contoso.com', 'manual-2.contoso.com'))
+
+        $Actual | Should -HaveCount 3
+        $Actual[0] | Should -Be 'manual-1.contoso.com'
+        $Actual[1] | Should -Be 'manual-2.contoso.com'
+        $Actual[2] | Should -Be 'auto-1.contoso.com'
+    }
+
+    It 'fails over to the next domain controller after exhausting the first one' {
+        Mock Get-ADComputer {
+            if ($Server -eq 'dc1.contoso.com') {
+                throw 'The server is not operational'
+            }
+            [PSCustomObject] @{ SamAccountName = 'PC01$' }
+        }
+
+        $Result = Invoke-ADComputerInventoryQuery -Domain 'contoso.com' -Servers @('dc1.contoso.com', 'dc2.contoso.com') -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -MaxAttemptsPerServer 2 -RetryDelaySeconds 0 -PageSize 500
+
+        $Result.Succeeded | Should -BeTrue
+        $Result.Server | Should -Be 'dc2.contoso.com'
+        $Result.Computers | Should -HaveCount 1
+        $Result.Attempts | Should -HaveCount 3
+        @($Result.Attempts | Where-Object Server -eq 'dc1.contoso.com') | Should -HaveCount 2
+    }
+
+    It 'records an explicit failed result after every domain controller fails' {
+        Mock Get-ADComputer { throw 'The server is not operational' }
+
+        $Result = Invoke-ADComputerInventoryQuery -Domain 'contoso.com' -Servers @('dc1.contoso.com', 'dc2.contoso.com') -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -MaxAttemptsPerServer 1 -RetryDelaySeconds 0 -PageSize 500
+
+        $Result.Succeeded | Should -BeFalse
+        $Result.Computers | Should -HaveCount 0
+        $Result.Attempts | Should -HaveCount 2
+        $Result.Error | Should -Be 'The server is not operational'
+    }
+
+    It 'retries a failed large-page query once with the bounded fallback page size' {
+        Mock Get-ADComputer {
+            if ($ResultPageSize -eq 1000) {
+                throw 'invalid enumeration context'
+            }
+            [PSCustomObject] @{ SamAccountName = 'PC01$' }
+        }
+
+        $Result = Invoke-ADComputerInventoryQuery -Domain 'contoso.com' -Servers @('dc1.contoso.com') -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -MaxAttemptsPerServer 1 -RetryDelaySeconds 0 -PageSize 1000
+
+        $Result.Succeeded | Should -BeTrue
+        $Result.Attempts | Should -HaveCount 2
+        $Result.Attempts[1].PageSize | Should -Be 500
+    }
+}

--- a/Tests/ADComputerInventoryQuery.Tests.ps1
+++ b/Tests/ADComputerInventoryQuery.Tests.ps1
@@ -345,6 +345,28 @@ Describe 'AD computer inventory process isolation' {
         $script:FakeChildKilled | Should -BeTrue
     }
 
+    It 'embeds the child function when no source-layout helper path is supplied' {
+        $script:EncodedChildCommand = $null
+        $FakeProcess = [PSCustomObject] @{ HasExited = $false; Id = 4243; ExitCode = 0 }
+        $FakeProcess | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value {
+            param([int] $Milliseconds)
+            $this.HasExited
+        }
+        $FakeProcess | Add-Member -MemberType ScriptMethod -Name Kill -Value { $this.HasExited = $true }
+        $FakeProcess | Add-Member -MemberType ScriptMethod -Name Dispose -Value {}
+        Mock Start-Process {
+            $script:EncodedChildCommand = $ArgumentList[-1]
+            $FakeProcess
+        }
+        Mock Test-Path { throw 'Stop after command capture' }
+
+        $null = Invoke-ADComputerInventoryAttempt -Server 'dc1.contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') }
+
+        $DecodedCommand = [Text.Encoding]::Unicode.GetString([Convert]::FromBase64String($script:EncodedChildCommand))
+        $DecodedCommand | Should -Match 'function Invoke-ADComputerInventoryChildProcess'
+        $DecodedCommand | Should -Not -Match "\. '.*Invoke-ADComputerInventoryChildProcess\.ps1'"
+    }
+
     It 'kills a child that never completes native AD connection readiness' {
         $ChildPath = Join-Path $TestDrive 'UnreadyChild.ps1'
         @'
@@ -356,14 +378,12 @@ function Invoke-ADComputerInventoryChildProcess {
 }
 '@ | Set-Content -LiteralPath $ChildPath -Encoding UTF8
 
-        $Started = Get-Date
         $Result = Invoke-ADComputerInventoryAttempt -Server 'unavailable.contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -ConnectionTimeoutSeconds 1 -IdleTimeoutSeconds 5 -ChildProcessFunctionPath $ChildPath
 
         $Result.Succeeded | Should -BeFalse
         $Result.TimedOut | Should -BeTrue
         $Result.TimeoutPhase | Should -Be 'Connection'
         $Result.ErrorMessage | Should -Match 'isolated query process was stopped'
-        ((Get-Date) - $Started).TotalSeconds | Should -BeLessThan 5
     }
 
     It 'does not charge child initialization time against the connection timeout' {
@@ -394,13 +414,12 @@ function Invoke-ADComputerInventoryChildProcess {
 }
 '@ | Set-Content -LiteralPath $ChildPath -Encoding UTF8
 
-        $Started = Get-Date
         $Result = Invoke-ADComputerInventoryAttempt -Server 'dc1.contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -ConnectionTimeoutSeconds 5 -InitializationTimeoutSeconds 1 -IdleTimeoutSeconds 5 -ChildProcessFunctionPath $ChildPath
 
         $Result.Succeeded | Should -BeFalse
         $Result.TimedOut | Should -BeTrue
         $Result.TimeoutPhase | Should -Be 'Initialization'
-        ((Get-Date) - $Started).TotalSeconds | Should -BeLessThan 5
+        $Result.ErrorMessage | Should -Match 'isolated query process was stopped'
     }
 
     It 'kills an established child query after the configured idle timeout' {
@@ -416,14 +435,12 @@ function Invoke-ADComputerInventoryChildProcess {
 }
 '@ | Set-Content -LiteralPath $ChildPath -Encoding UTF8
 
-        $Started = Get-Date
         $Result = Invoke-ADComputerInventoryAttempt -Server 'dc1.contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -ConnectionTimeoutSeconds 5 -IdleTimeoutSeconds 1 -ChildProcessFunctionPath $ChildPath
 
         $Result.Succeeded | Should -BeFalse
         $Result.TimedOut | Should -BeTrue
         $Result.TimeoutPhase | Should -Be 'Query'
         $Result.ErrorMessage | Should -Match 'isolated query process was stopped'
-        ((Get-Date) - $Started).TotalSeconds | Should -BeLessThan 5
     }
 
     It 'keeps a burst-shaped result stream alive across progress-marker throttle lag' {
@@ -477,5 +494,30 @@ function Invoke-ADComputerInventoryChildProcess {
         $Result.Computers[0].servicePrincipalName | Should -Be @('HOST/PC01')
         $Result.Computers[0].LastLogonDate | Should -BeOfType ([DateTime])
         $Result.Computers[0].ProtectedFromAccidentalDeletion | Should -BeTrue
+    }
+
+    It 'runs inventory setup even when ambient WhatIf is enabled' {
+        $ChildPath = Join-Path $TestDrive 'WhatIfChild.ps1'
+        @'
+function Invoke-ADComputerInventoryChildProcess {
+    param([string] $ConfigurationPath)
+    $Configuration = Import-Clixml -LiteralPath $ConfigurationPath
+    [System.IO.File]::WriteAllText($Configuration.InitializationPath, 'Initialized')
+    [System.IO.File]::WriteAllText($Configuration.ReadyPath, 'Ready')
+    [System.IO.File]::WriteAllText($Configuration.ProgressPath, '0')
+    [System.IO.File]::WriteAllText($Configuration.SuccessPath, '0')
+}
+'@ | Set-Content -LiteralPath $ChildPath -Encoding UTF8
+
+        $PreviousWhatIfPreference = $WhatIfPreference
+        try {
+            $WhatIfPreference = $true
+            $Result = Invoke-ADComputerInventoryAttempt -Server 'dc1.contoso.com' -QueryParameters @{ Filter = '*'; Properties = @('SamAccountName') } -ConnectionTimeoutSeconds 5 -IdleTimeoutSeconds 5 -ChildProcessFunctionPath $ChildPath
+        } finally {
+            $WhatIfPreference = $PreviousWhatIfPreference
+        }
+
+        $Result.Succeeded | Should -BeTrue -Because $Result.ErrorMessage
+        $Result.TimedOut | Should -BeFalse
     }
 }

--- a/Tests/ADComputerInventoryQuery.Tests.ps1
+++ b/Tests/ADComputerInventoryQuery.Tests.ps1
@@ -475,7 +475,7 @@ function Invoke-ADComputerInventoryChildProcess {
     [System.IO.File]::WriteAllText($Configuration.InitializationPath, 'Initialized')
     [System.IO.File]::WriteAllText($Configuration.ReadyPath, 'Ready')
     [System.IO.File]::WriteAllText($Configuration.ProgressPath, '1')
-    [PSCustomObject] [ordered] @{
+    [PSCustomObject] @{
         Name = 'PC01'; DNSHostName = 'pc01.contoso.com'; SamAccountName = 'PC01$'; DistinguishedName = 'CN=PC01,DC=contoso,DC=com'
         Enabled = $true; OperatingSystem = 'Windows'; OperatingSystemVersion = '10.0'; LastLogonDateBinary = (Get-Date).ToBinary()
         PasswordLastSetBinary = (Get-Date).ToBinary(); PasswordExpired = $false; ServicePrincipalNameJson = '["HOST/PC01"]'

--- a/Tests/ADComputerReportData.Tests.ps1
+++ b/Tests/ADComputerReportData.Tests.ps1
@@ -47,7 +47,7 @@ BeforeAll {
 Describe 'AD computer report serialization' {
     It 'writes every row across bounded chunks without internal-only properties' {
         $Rows = 1..5 | ForEach-Object {
-            [PSCustomObject] [ordered] @{
+            [PSCustomObject] @{
                 SamAccountName             = "PC$_`$"
                 Description                = if ($_ -eq 3) { '<retired>' } else { "Computer $_" }
                 Enabled                    = $true
@@ -87,7 +87,7 @@ Describe 'AD computer report serialization' {
 
     It 'preserves the JavaScript-store newline conversion used by PSWriteHTML' {
         $Rows = @(
-            [PSCustomObject] [ordered] @{
+            [PSCustomObject] @{
                 SamAccountName = 'PC1$'
                 Description    = "First line`r`nSecond line"
             }

--- a/Tests/ADComputerReportData.Tests.ps1
+++ b/Tests/ADComputerReportData.Tests.ps1
@@ -1,0 +1,51 @@
+BeforeAll {
+    . "$PSScriptRoot\TestHelpers.ps1"
+    Import-Module PSSharedGoods -Force -ErrorAction Stop
+    . (Get-CleanupMonsterPath 'Private/Export-ADComputerReportData.ps1')
+    . (Get-CleanupMonsterPath 'Private/Merge-ADComputerHTMLReportData.ps1')
+}
+
+Describe 'AD computer report serialization' {
+    It 'writes every row across bounded chunks without internal-only properties' {
+        $Rows = 1..5 | ForEach-Object {
+            [PSCustomObject] [ordered] @{
+                SamAccountName             = "PC$_`$"
+                Description                = if ($_ -eq 3) { '<retired>' } else { "Computer $_" }
+                Enabled                    = $true
+                ServicePrincipalName       = @("HOST/PC$_", "WSMAN/PC$_")
+                TimeOnPendingList           = 10
+                TimeToLeavePendingList      = 20
+                DistinguishedNameAfterMove = 'OU=Moved,DC=contoso,DC=com'
+            }
+        }
+        $DataPath = Join-Path $TestDrive 'computers.json'
+
+        $Result = Export-ADComputerReportData -Computers $Rows -FilePath $DataPath -ChunkSize 2
+        $Parsed = Get-Content -LiteralPath $DataPath -Raw | ConvertFrom-Json
+
+        $Result.Count | Should -Be 5
+        $Parsed | Should -HaveCount 5
+        $Parsed[0].SamAccountName | Should -Be 'PC1$'
+        $Parsed[4].SamAccountName | Should -Be 'PC5$'
+        $Parsed[0].Enabled | Should -Be 'True'
+        $Parsed[0].ServicePrincipalName | Should -Be 'HOST/PC1, WSMAN/PC1'
+        $Parsed[2].Description | Should -BeIn @('<retired>', '&lt;retired&gt;')
+        $Parsed[0].PSObject.Properties.Name | Should -Not -Contain 'TimeOnPendingList'
+        (Get-Content -LiteralPath $DataPath -Raw) | Should -Not -Match '"Description":"<retired>"'
+    }
+
+    It 'streams the complete JSON array into one self-contained HTML file' {
+        $StagingPath = Join-Path $TestDrive 'staging.html'
+        $DataPath = Join-Path $TestDrive 'computers.json'
+        $OutputPath = Join-Path $TestDrive 'report.html'
+        Set-Content -LiteralPath $StagingPath -Value '<html><script>var CleanupMonsterADComputers = [{"SamAccountName":"sample$"}];</script><body>report</body></html>' -Encoding UTF8
+        Set-Content -LiteralPath $DataPath -Value '[{"SamAccountName":"PC1$"},{"SamAccountName":"PC2$"}]' -Encoding UTF8
+
+        Merge-ADComputerHTMLReportData -StagingHtmlPath $StagingPath -DataFilePath $DataPath -OutputPath $OutputPath -DataStoreID CleanupMonsterADComputers
+        $Html = Get-Content -LiteralPath $OutputPath -Raw
+
+        $Html | Should -Match 'var CleanupMonsterADComputers = \[{"SamAccountName":"PC1\$"},{"SamAccountName":"PC2\$"}\]\s*;'
+        $Html | Should -Not -Match 'sample\$'
+        $Html | Should -Match '<body>report</body>'
+    }
+}

--- a/Tests/ADComputerReportData.Tests.ps1
+++ b/Tests/ADComputerReportData.Tests.ps1
@@ -1,6 +1,7 @@
 BeforeAll {
     . "$PSScriptRoot\TestHelpers.ps1"
     . (Get-CleanupMonsterPath 'Private/Export-ADComputerReportData.ps1')
+    . (Get-CleanupMonsterPath 'Private/Find-JavaScriptArrayAssignment.ps1')
     . (Get-CleanupMonsterPath 'Private/Merge-ADComputerHTMLReportData.ps1')
 
     # PSSharedGoods is an external module boundary and is not installed in the
@@ -129,5 +130,23 @@ Describe 'AD computer report serialization' {
         $Html | Should -Match (([regex]::Escape("var CleanupMonsterADComputers = $ReplacementJson")) + '\s*;')
         $Html | Should -Not -Match 'sample\$'
         $Html | Should -Match '<body>report</body>'
+    }
+
+    It 'skips assignment-like text in an earlier JavaScript datastore' {
+        $StagingPath = Join-Path $TestDrive 'preceding-store-staging.html'
+        $DataPath = Join-Path $TestDrive 'preceding-store-computers.json'
+        $OutputPath = Join-Path $TestDrive 'preceding-store-report.html'
+        $EarlierStore = '[{"Description":"var CleanupMonsterADComputers = []; must remain"}]'
+        $SampleJson = '[{"SamAccountName":"sample$"}]'
+        $ReplacementJson = '[{"SamAccountName":"PC1$"}]'
+        Set-Content -LiteralPath $StagingPath -Value "<html><script>var CleanupMonsterHistory = $EarlierStore; var CleanupMonsterADComputers = $SampleJson;</script><body>report</body></html>" -Encoding UTF8
+        Set-Content -LiteralPath $DataPath -Value $ReplacementJson -Encoding UTF8
+
+        Merge-ADComputerHTMLReportData -StagingHtmlPath $StagingPath -DataFilePath $DataPath -OutputPath $OutputPath -DataStoreID CleanupMonsterADComputers
+        $Html = Get-Content -LiteralPath $OutputPath -Raw
+
+        $Html | Should -Match ([regex]::Escape($EarlierStore))
+        $Html | Should -Match (([regex]::Escape("var CleanupMonsterADComputers = $ReplacementJson")) + '\s*;')
+        $Html | Should -Not -Match 'sample\$'
     }
 }

--- a/Tests/ADComputerReportData.Tests.ps1
+++ b/Tests/ADComputerReportData.Tests.ps1
@@ -80,13 +80,15 @@ Describe 'AD computer report serialization' {
         $StagingPath = Join-Path $TestDrive 'delimiter-staging.html'
         $DataPath = Join-Path $TestDrive 'delimiter-computers.json'
         $OutputPath = Join-Path $TestDrive 'delimiter-report.html'
-        Set-Content -LiteralPath $StagingPath -Value '<html><script>var CleanupMonsterADComputers = [{"SamAccountName":"sample$","Description":"contains ]; delimiter"}];</script><body>report</body></html>' -Encoding UTF8
-        Set-Content -LiteralPath $DataPath -Value '[{"SamAccountName":"PC1$","Description":"also contains ]; delimiter"}]' -Encoding UTF8
+        $SampleJson = '[{"SamAccountName":"sample$","Description":"contains ]; delimiter and var CleanupMonsterADComputers = [ plus \\server and \"quote\""}]'
+        $ReplacementJson = '[{"SamAccountName":"PC1$","Description":"also contains ]; delimiter and var CleanupMonsterADComputers = [ plus \\server and \"quote\""}]'
+        Set-Content -LiteralPath $StagingPath -Value "<html><script>var CleanupMonsterADComputers = $SampleJson;</script><body>report</body></html>" -Encoding UTF8
+        Set-Content -LiteralPath $DataPath -Value $ReplacementJson -Encoding UTF8
 
         Merge-ADComputerHTMLReportData -StagingHtmlPath $StagingPath -DataFilePath $DataPath -OutputPath $OutputPath -DataStoreID CleanupMonsterADComputers
         $Html = Get-Content -LiteralPath $OutputPath -Raw
 
-        $Html | Should -Match 'var CleanupMonsterADComputers = \[\{"SamAccountName":"PC1\$","Description":"also contains \]; delimiter"\}\]\s*;'
+        $Html | Should -Match (([regex]::Escape("var CleanupMonsterADComputers = $ReplacementJson")) + '\s*;')
         $Html | Should -Not -Match 'sample\$'
         $Html | Should -Match '<body>report</body>'
     }

--- a/Tests/ADComputerReportData.Tests.ps1
+++ b/Tests/ADComputerReportData.Tests.ps1
@@ -13,6 +13,7 @@ Describe 'AD computer report serialization' {
                 Description                = if ($_ -eq 3) { '<retired>' } else { "Computer $_" }
                 Enabled                    = $true
                 ServicePrincipalName       = @("HOST/PC$_", "WSMAN/PC$_")
+                WhenCreated                = [DateTime] '2024-01-02T03:04:05'
                 TimeOnPendingList           = 10
                 TimeToLeavePendingList      = 20
                 DistinguishedNameAfterMove = 'OU=Moved,DC=contoso,DC=com'
@@ -29,9 +30,35 @@ Describe 'AD computer report serialization' {
         $Parsed[4].SamAccountName | Should -Be 'PC5$'
         $Parsed[0].Enabled | Should -Be 'True'
         $Parsed[0].ServicePrincipalName | Should -Be 'HOST/PC1, WSMAN/PC1'
+        [string] $Parsed[0].WhenCreated | Should -Be $Rows[0].WhenCreated.ToString('')
         $Parsed[2].Description | Should -BeIn @('<retired>', '&lt;retired&gt;')
         $Parsed[0].PSObject.Properties.Name | Should -Not -Contain 'TimeOnPendingList'
         (Get-Content -LiteralPath $DataPath -Raw) | Should -Not -Match '"Description":"<retired>"'
+    }
+
+    It 'writes a valid empty JSON array when no domain returns computers' {
+        $DataPath = Join-Path $TestDrive 'empty-computers.json'
+
+        $Result = Export-ADComputerReportData -Computers @() -FilePath $DataPath
+
+        $Result.Count | Should -Be 0
+        $Result.Sample | Should -BeNullOrEmpty
+        Get-Content -LiteralPath $DataPath -Raw | Should -Be '[]'
+    }
+
+    It 'preserves the JavaScript-store newline conversion used by PSWriteHTML' {
+        $Rows = @(
+            [PSCustomObject] [ordered] @{
+                SamAccountName = 'PC1$'
+                Description    = "First line`r`nSecond line"
+            }
+        )
+        $DataPath = Join-Path $TestDrive 'multiline-computers.json'
+
+        Export-ADComputerReportData -Computers $Rows -FilePath $DataPath | Out-Null
+        $Parsed = Get-Content -LiteralPath $DataPath -Raw | ConvertFrom-Json
+
+        $Parsed[0].Description | Should -BeIn @('First line<br>Second line', 'First line&lt;br&gt;Second line')
     }
 
     It 'streams the complete JSON array into one self-contained HTML file' {
@@ -45,6 +72,21 @@ Describe 'AD computer report serialization' {
         $Html = Get-Content -LiteralPath $OutputPath -Raw
 
         $Html | Should -Match 'var CleanupMonsterADComputers = \[{"SamAccountName":"PC1\$"},{"SamAccountName":"PC2\$"}\]\s*;'
+        $Html | Should -Not -Match 'sample\$'
+        $Html | Should -Match '<body>report</body>'
+    }
+
+    It 'does not terminate the sample assignment at a delimiter inside JSON text' {
+        $StagingPath = Join-Path $TestDrive 'delimiter-staging.html'
+        $DataPath = Join-Path $TestDrive 'delimiter-computers.json'
+        $OutputPath = Join-Path $TestDrive 'delimiter-report.html'
+        Set-Content -LiteralPath $StagingPath -Value '<html><script>var CleanupMonsterADComputers = [{"SamAccountName":"sample$","Description":"contains ]; delimiter"}];</script><body>report</body></html>' -Encoding UTF8
+        Set-Content -LiteralPath $DataPath -Value '[{"SamAccountName":"PC1$","Description":"also contains ]; delimiter"}]' -Encoding UTF8
+
+        Merge-ADComputerHTMLReportData -StagingHtmlPath $StagingPath -DataFilePath $DataPath -OutputPath $OutputPath -DataStoreID CleanupMonsterADComputers
+        $Html = Get-Content -LiteralPath $OutputPath -Raw
+
+        $Html | Should -Match 'var CleanupMonsterADComputers = \[\{"SamAccountName":"PC1\$","Description":"also contains \]; delimiter"\}\]\s*;'
         $Html | Should -Not -Match 'sample\$'
         $Html | Should -Match '<body>report</body>'
     }

--- a/Tests/ADComputerReportData.Tests.ps1
+++ b/Tests/ADComputerReportData.Tests.ps1
@@ -1,8 +1,46 @@
 BeforeAll {
     . "$PSScriptRoot\TestHelpers.ps1"
-    Import-Module PSSharedGoods -Force -ErrorAction Stop
     . (Get-CleanupMonsterPath 'Private/Export-ADComputerReportData.ps1')
     . (Get-CleanupMonsterPath 'Private/Merge-ADComputerHTMLReportData.ps1')
+
+    # PSSharedGoods is an external module boundary and is not installed in the
+    # source-test CI job. This fake preserves the formatting contract exercised
+    # by the report serializer; a generated report is validated separately.
+    function ConvertTo-PrettyObject {
+        param(
+            [Array] $Object,
+            [string[]] $PropertyName,
+            [switch] $Force,
+            [switch] $BoolAsString,
+            [switch] $ArrayJoin,
+            [string] $ArrayJoinString,
+            [AllowEmptyString()]
+            [string] $DateTimeFormat,
+            [System.Collections.IDictionary] $NewLineFormat,
+            [System.Collections.IDictionary] $NewLineFormatProperty
+        )
+
+        foreach ($Item in $Object) {
+            $Converted = [ordered] @{}
+            foreach ($Property in $PropertyName) {
+                $Value = $Item.$Property
+                if ($null -eq $Value) {
+                    $Converted[$Property] = ''
+                } elseif ($Value -is [DateTime]) {
+                    $Converted[$Property] = $Value.ToString($DateTimeFormat)
+                } elseif ($Value -is [bool] -and $BoolAsString) {
+                    $Converted[$Property] = [string] $Value
+                } elseif ($Value -is [System.Collections.IList] -and $ArrayJoin) {
+                    $Converted[$Property] = $Value -join $ArrayJoinString
+                } elseif ($Value -is [string]) {
+                    $Converted[$Property] = $Value.Replace([System.Environment]::NewLine, $NewLineFormat.NewLineCarriage).Replace("`n", $NewLineFormat.NewLine).Replace("`r", $NewLineFormat.Carriage)
+                } else {
+                    $Converted[$Property] = $Value
+                }
+            }
+            [PSCustomObject] $Converted
+        }
+    }
 }
 
 Describe 'AD computer report serialization' {

--- a/Tests/Invoke-ADComputersCleanup.Tests.ps1
+++ b/Tests/Invoke-ADComputersCleanup.Tests.ps1
@@ -201,6 +201,7 @@ Describe 'Invoke-ADComputersCleanup' {
 
     It 'suppresses every write when a domain inventory fails by default' {
         $script:CapturedReportOnly = $null
+        $script:CapturedHtmlReportOnly = $null
         Mock Get-InitialADComputers -MockWith {
             param([hashtable] $Report)
 
@@ -239,10 +240,14 @@ Describe 'Invoke-ADComputersCleanup' {
         Mock Request-ADComputersMove {
             $script:CapturedReportOnly = $ReportOnly
         }
+        Mock New-HTMLProcessedComputers {
+            $script:CapturedHtmlReportOnly = $ReportOnly
+        }
 
         Invoke-ADComputersCleanup -Move -MoveTargetOrganizationalUnit 'OU=Disabled,DC=contoso,DC=com' -Suppress | Out-Null
 
         $script:CapturedReportOnly | Should -BeTrue
+        $script:CapturedHtmlReportOnly | Should -BeFalse
     }
 
     It 'allows writes only after explicitly selecting successful-domain continuation' {

--- a/Tests/Invoke-ADComputersCleanup.Tests.ps1
+++ b/Tests/Invoke-ADComputersCleanup.Tests.ps1
@@ -49,6 +49,7 @@ BeforeAll {
             ComputerKeys         = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
             SuccessfulDomains    = @('contoso.com')
             FailedDomains        = @()
+            PendingStateRollback = [ordered] @{}
         }
     }
     function Get-InitialADComputers {
@@ -382,5 +383,81 @@ Describe 'Invoke-ADComputersCleanup' {
 
         $Result.PendingDeletion.Contains('OLD-SUCCESS$@contoso.com') | Should -BeFalse
         $Result.PendingDeletion.Contains('OLD-FAILED$@child.contoso.com') | Should -BeTrue
+    }
+
+    It 'keeps persisted pending and history state unchanged when inventory fails closed' {
+        $ExistingHistory = [PSCustomObject] @{ SamAccountName = 'HISTORY$'; Action = 'Move'; ActionStatus = $true }
+        Mock Import-ComputersData {
+            param($Export)
+
+            $Export.History = @($ExistingHistory)
+            [ordered] @{
+                'PENDING$@contoso.com' = [PSCustomObject] @{
+                    SamAccountName    = 'PENDING$'
+                    DomainName        = 'contoso.com'
+                    DistinguishedName = 'CN=PENDING,DC=contoso,DC=com'
+                    ActionStatus      = $true
+                }
+            }
+        }
+        Mock Get-InitialADComputers -MockWith {
+            param(
+                [hashtable] $Report,
+                [System.Collections.IDictionary] $ProcessedComputers
+            )
+
+            $PendingStateRollback = [ordered] @{
+                'PENDING$@contoso.com' = $ProcessedComputers['PENDING$@contoso.com'].PSObject.Copy()
+            }
+            $ProcessedComputers.Remove('PENDING$@contoso.com')
+            $Candidate = [PSCustomObject] @{
+                SamAccountName = 'MOVE-ME$'
+                DomainName     = 'contoso.com'
+                Action         = 'Move'
+            }
+            $Report['contoso.com'] = [ordered] @{
+                QueryStatus          = 'Succeeded'
+                QueryError           = $null
+                Server               = 'dc1.contoso.com'
+                AttemptedServers     = @('dc1.contoso.com')
+                QueryAttempts        = 1
+                ComputerCount        = 1
+                Computers            = @($Candidate)
+                ComputersToBeDisabled = 0
+                ComputersToBeMoved   = 1
+                ComputersToBeDeleted = 0
+            }
+            $Report['child.contoso.com'] = [ordered] @{
+                QueryStatus          = 'Failed'
+                QueryError           = 'server unavailable'
+                Server               = $null
+                AttemptedServers     = @('dc1.child.contoso.com')
+                QueryAttempts        = 3
+                ComputerCount        = 0
+                Computers            = @()
+                ComputersToBeDisabled = 0
+                ComputersToBeMoved   = 0
+                ComputersToBeDeleted = 0
+            }
+
+            [PSCustomObject] @{
+                Succeeded            = $false
+                SafetyLimitSatisfied = $true
+                ComputerKeys         = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                SuccessfulDomains    = @('contoso.com')
+                FailedDomains        = @('child.contoso.com')
+                PendingStateRollback = $PendingStateRollback
+            }
+        }
+        Mock Request-ADComputersMove {
+            [PSCustomObject] @{ SamAccountName = 'MOVE-ME$'; Action = 'Move'; ActionStatus = $null }
+        }
+
+        $Result = Invoke-ADComputersCleanup -Move -MoveTargetOrganizationalUnit 'OU=Disabled,DC=contoso,DC=com'
+
+        $Result.PendingDeletion.Contains('PENDING$@contoso.com') | Should -BeTrue
+        $Result.CurrentRun | Should -BeNullOrEmpty
+        $Result.History | Should -HaveCount 1
+        $Result.History[0].SamAccountName | Should -Be 'HISTORY$'
     }
 }

--- a/Tests/Invoke-ADComputersCleanup.Tests.ps1
+++ b/Tests/Invoke-ADComputersCleanup.Tests.ps1
@@ -42,6 +42,15 @@ BeforeAll {
     function Import-ComputersData { [ordered] @{} }
     function Get-InitialGraphComputers { @{ AzureAD = @{}; Intune = @{} } }
     function Get-InitialJamfComputers { @{} }
+    function New-TestInventoryResult {
+        [PSCustomObject] @{
+            Succeeded            = $true
+            SafetyLimitSatisfied = $true
+            ComputerKeys         = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            SuccessfulDomains    = @('contoso.com')
+            FailedDomains        = @()
+        }
+    }
     function Get-InitialADComputers {
         param(
             [hashtable] $Report,
@@ -51,19 +60,50 @@ BeforeAll {
         )
 
         $Report['contoso.com'] = [ordered] @{
+            QueryStatus          = 'Succeeded'
+            QueryError           = $null
             Server                = 'dc1.contoso.com'
+            AttemptedServers      = @('dc1.contoso.com')
+            QueryAttempts         = 1
+            ComputerCount         = 0
             Computers             = @()
             ComputersToBeDisabled = 0
             ComputersToBeMoved    = 0
             ComputersToBeDeleted  = 0
         }
 
-        [ordered] @{}
+        New-TestInventoryResult
     }
     function Request-ADComputersDisable { @() }
-    function Request-ADComputersMove { @() }
+    function Request-ADComputersMove {
+        param(
+            $Report,
+            $WhatIfMove,
+            $WhatIf,
+            $MoveLimit,
+            $ReportOnly,
+            $Today,
+            $ProcessedComputers,
+            $TargetOrganizationalUnit,
+            $DontWriteToEventLog,
+            $Delete,
+            $DoNotAddToPendingList,
+            $RemoveProtectedFromAccidentalDeletionFlag
+        )
+        @()
+    }
     function Request-ADComputersDelete { @() }
     function New-ADComputersStatistics { @{} }
+    function Export-ADComputerReportData {
+        param($Computers, $FilePath)
+
+        [PSCustomObject] @{
+            FilePath    = $FilePath
+            Count       = @($Computers).Count
+            Sample      = $null
+            DataStoreID = 'CleanupMonsterADComputers'
+        }
+    }
     function New-HTMLProcessedComputers {}
     function New-EmailBodyComputers { param($CurrentRun) '' }
 }
@@ -76,14 +116,19 @@ Describe 'Invoke-ADComputersCleanup' {
             )
 
             $Report['contoso.com'] = [ordered] @{
+                QueryStatus          = 'Succeeded'
+                QueryError           = $null
                 Server                = 'dc1.contoso.com'
+                AttemptedServers      = @('dc1.contoso.com')
+                QueryAttempts         = 1
+                ComputerCount         = 0
                 Computers             = @()
                 ComputersToBeDisabled = 0
                 ComputersToBeMoved    = 1
                 ComputersToBeDeleted  = 0
             }
 
-            [ordered] @{}
+            New-TestInventoryResult
         }
         Mock Request-ADComputersMove {}
 
@@ -99,14 +144,19 @@ Describe 'Invoke-ADComputersCleanup' {
             )
 
             $Report['contoso.com'] = [ordered] @{
+                QueryStatus          = 'Succeeded'
+                QueryError           = $null
                 Server                = 'dc1.contoso.com'
+                AttemptedServers      = @('dc1.contoso.com')
+                QueryAttempts         = 1
+                ComputerCount         = 0
                 Computers             = @()
                 ComputersToBeDisabled = 1
                 ComputersToBeMoved    = 0
                 ComputersToBeDeleted  = 0
             }
 
-            [ordered] @{}
+            New-TestInventoryResult
         }
         Mock Request-ADComputersDisable {}
 
@@ -125,14 +175,19 @@ Describe 'Invoke-ADComputersCleanup' {
             )
 
             $Report['contoso.com'] = [ordered] @{
+                QueryStatus          = 'Succeeded'
+                QueryError           = $null
                 Server                = 'dc1.contoso.com'
+                AttemptedServers      = @('dc1.contoso.com')
+                QueryAttempts         = 1
+                ComputerCount         = 0
                 Computers             = @()
                 ComputersToBeDisabled = 0
                 ComputersToBeMoved    = 1
                 ComputersToBeDeleted  = 0
             }
 
-            [ordered] @{}
+            New-TestInventoryResult
         }
         Mock Request-ADComputersMove {
             $script:CapturedMoveWhatIf = $WhatIfMove
@@ -142,5 +197,185 @@ Describe 'Invoke-ADComputersCleanup' {
 
         Assert-MockCalled Request-ADComputersMove -Times 1 -Exactly
         $script:CapturedMoveWhatIf | Should -BeTrue
+    }
+
+    It 'suppresses every write when a domain inventory fails by default' {
+        $script:CapturedReportOnly = $null
+        Mock Get-InitialADComputers -MockWith {
+            param([hashtable] $Report)
+
+            $Report['contoso.com'] = [ordered] @{
+                QueryStatus          = 'Succeeded'
+                QueryError           = $null
+                Server               = 'dc1.contoso.com'
+                AttemptedServers     = @('dc1.contoso.com')
+                QueryAttempts        = 1
+                ComputerCount        = 0
+                Computers            = @()
+                ComputersToBeDisabled = 0
+                ComputersToBeMoved   = 0
+                ComputersToBeDeleted = 0
+            }
+            $Report['child.contoso.com'] = [ordered] @{
+                QueryStatus          = 'Failed'
+                QueryError           = 'server unavailable'
+                Server               = $null
+                AttemptedServers     = @('dc1.child.contoso.com')
+                QueryAttempts        = 3
+                ComputerCount        = 0
+                Computers            = @()
+                ComputersToBeDisabled = 0
+                ComputersToBeMoved   = 0
+                ComputersToBeDeleted = 0
+            }
+
+            [PSCustomObject] @{
+                Succeeded         = $false
+                ComputerKeys      = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                SuccessfulDomains = @('contoso.com')
+                FailedDomains     = @('child.contoso.com')
+            }
+        }
+        Mock Request-ADComputersMove {
+            $script:CapturedReportOnly = $ReportOnly
+        }
+
+        Invoke-ADComputersCleanup -Move -MoveTargetOrganizationalUnit 'OU=Disabled,DC=contoso,DC=com' -Suppress | Out-Null
+
+        $script:CapturedReportOnly | Should -BeTrue
+    }
+
+    It 'allows writes only after explicitly selecting successful-domain continuation' {
+        $script:CapturedReportOnly = $null
+        Mock Get-InitialADComputers -MockWith {
+            param([hashtable] $Report)
+
+            $Report['contoso.com'] = [ordered] @{
+                QueryStatus          = 'Succeeded'
+                QueryError           = $null
+                Server               = 'dc1.contoso.com'
+                AttemptedServers     = @('dc1.contoso.com')
+                QueryAttempts        = 1
+                ComputerCount        = 0
+                Computers            = @()
+                ComputersToBeDisabled = 0
+                ComputersToBeMoved   = 1
+                ComputersToBeDeleted = 0
+            }
+            $Report['child.contoso.com'] = [ordered] @{
+                QueryStatus          = 'Failed'
+                QueryError           = 'server unavailable'
+                Server               = $null
+                AttemptedServers     = @('dc1.child.contoso.com')
+                QueryAttempts        = 3
+                ComputerCount        = 0
+                Computers            = @()
+                ComputersToBeDisabled = 0
+                ComputersToBeMoved   = 0
+                ComputersToBeDeleted = 0
+            }
+
+            [PSCustomObject] @{
+                Succeeded         = $false
+                ComputerKeys      = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                SuccessfulDomains = @('contoso.com')
+                FailedDomains     = @('child.contoso.com')
+            }
+        }
+        Mock Request-ADComputersMove {
+            $script:CapturedReportOnly = $ReportOnly
+        }
+
+        Invoke-ADComputersCleanup -Move -MoveTargetOrganizationalUnit 'OU=Disabled,DC=contoso,DC=com' -DomainFailureAction ContinueSuccessfulDomains -Suppress | Out-Null
+
+        $script:CapturedReportOnly | Should -BeFalse
+    }
+
+    It 'suppresses writes when the successful-domain count is below the AD safety limit' {
+        $script:CapturedReportOnly = $null
+        Mock Get-InitialADComputers -MockWith {
+            param([hashtable] $Report)
+
+            $Report['contoso.com'] = [ordered] @{
+                QueryStatus          = 'Succeeded'
+                QueryError           = $null
+                Server               = 'dc1.contoso.com'
+                AttemptedServers      = @('dc1.contoso.com')
+                QueryAttempts         = 1
+                ComputerCount         = 0
+                Computers             = @()
+                ComputersToBeDisabled = 0
+                ComputersToBeMoved    = 1
+                ComputersToBeDeleted  = 0
+            }
+
+            $Result = New-TestInventoryResult
+            $Result.SafetyLimitSatisfied = $false
+            $Result
+        }
+        Mock Request-ADComputersMove {
+            $script:CapturedReportOnly = $ReportOnly
+        }
+
+        Invoke-ADComputersCleanup -Move -MoveTargetOrganizationalUnit 'OU=Disabled,DC=contoso,DC=com' -SafetyADLimit 300000 -DomainFailureAction ContinueSuccessfulDomains -Suppress | Out-Null
+
+        $script:CapturedReportOnly | Should -BeTrue
+    }
+
+    It 'never prunes pending entries that belong to a failed domain' {
+        Mock Import-ComputersData {
+            [ordered] @{
+                'OLD-SUCCESS$@contoso.com' = [PSCustomObject] @{
+                    SamAccountName    = 'OLD-SUCCESS$'
+                    DomainName        = 'contoso.com'
+                    DistinguishedName = 'CN=OLD-SUCCESS,DC=contoso,DC=com'
+                }
+                'OLD-FAILED$@child.contoso.com' = [PSCustomObject] @{
+                    SamAccountName    = 'OLD-FAILED$'
+                    DomainName        = 'child.contoso.com'
+                    DistinguishedName = 'CN=OLD-FAILED,DC=child,DC=contoso,DC=com'
+                }
+            }
+        }
+        Mock Get-InitialADComputers -MockWith {
+            param([hashtable] $Report)
+
+            $Report['contoso.com'] = [ordered] @{
+                QueryStatus          = 'Succeeded'
+                QueryError           = $null
+                Server               = 'dc1.contoso.com'
+                AttemptedServers     = @('dc1.contoso.com')
+                QueryAttempts        = 1
+                ComputerCount        = 0
+                Computers            = @()
+                ComputersToBeDisabled = 0
+                ComputersToBeMoved   = 0
+                ComputersToBeDeleted = 0
+            }
+            $Report['child.contoso.com'] = [ordered] @{
+                QueryStatus          = 'Failed'
+                QueryError           = 'server unavailable'
+                Server               = $null
+                AttemptedServers     = @('dc1.child.contoso.com')
+                QueryAttempts        = 3
+                ComputerCount        = 0
+                Computers            = @()
+                ComputersToBeDisabled = 0
+                ComputersToBeMoved   = 0
+                ComputersToBeDeleted = 0
+            }
+
+            [PSCustomObject] @{
+                Succeeded         = $false
+                ComputerKeys      = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                SuccessfulDomains = @('contoso.com')
+                FailedDomains     = @('child.contoso.com')
+            }
+        }
+
+        $Result = Invoke-ADComputersCleanup -Move -MoveTargetOrganizationalUnit 'OU=Disabled,DC=contoso,DC=com' -DomainFailureAction ContinueSuccessfulDomains -DataStorePath (Join-Path $TestDrive 'state.xml') -ReportPath (Join-Path $TestDrive 'report.html')
+
+        $Result.PendingDeletion.Contains('OLD-SUCCESS$@contoso.com') | Should -BeFalse
+        $Result.PendingDeletion.Contains('OLD-FAILED$@child.contoso.com') | Should -BeTrue
     }
 }

--- a/Tests/Invoke-ADComputersCleanup.Tests.ps1
+++ b/Tests/Invoke-ADComputersCleanup.Tests.ps1
@@ -57,8 +57,13 @@ BeforeAll {
             [hashtable] $Report,
             [bool] $Disable,
             [bool] $Delete,
-            [bool] $Move
+            [bool] $Move,
+            [int] $ADQueryConnectionTimeout,
+            [int] $ADQueryIdleTimeout
         )
+
+        $script:CapturedADQueryConnectionTimeout = $ADQueryConnectionTimeout
+        $script:CapturedADQueryIdleTimeout = $ADQueryIdleTimeout
 
         $Report['contoso.com'] = [ordered] @{
             QueryStatus          = 'Succeeded'
@@ -110,6 +115,16 @@ BeforeAll {
 }
 
 Describe 'Invoke-ADComputersCleanup' {
+    It 'passes the bounded AD connection and idle timeouts to inventory discovery' {
+        $script:CapturedADQueryConnectionTimeout = $null
+        $script:CapturedADQueryIdleTimeout = $null
+
+        Invoke-ADComputersCleanup -Disable -ReportOnly -ADQueryConnectionTimeout 17 -ADQueryIdleTimeout 45 -Suppress | Out-Null
+
+        $script:CapturedADQueryConnectionTimeout | Should -Be 17
+        $script:CapturedADQueryIdleTimeout | Should -Be 45
+    }
+
     It 'allows move-only runs to reach the move request' {
         Mock Get-InitialADComputers -MockWith {
             param(

--- a/Tests/Move-Workflow.Tests.ps1
+++ b/Tests/Move-Workflow.Tests.ps1
@@ -1,5 +1,6 @@
 BeforeAll {
     . "$PSScriptRoot\TestHelpers.ps1"
+    . (Get-CleanupMonsterPath 'Private/Save-ADComputerPendingStateEntry.ps1')
     . (Get-CleanupMonsterPath 'Private/Get-ADComputersToProcess.ps1')
     . (Get-CleanupMonsterPath 'Private/Request-ADComputersMove.ps1')
 
@@ -27,6 +28,40 @@ BeforeAll {
 }
 
 Describe 'Move workflow helpers' {
+    It 'journals only pending entries changed during discovery' {
+        $computer = [PSCustomObject] @{
+            SamAccountName       = 'PC1$'
+            DomainName           = 'contoso.com'
+            DistinguishedName    = 'CN=PC1,OU=Workstations,DC=contoso,DC=com'
+            DNSHostName          = 'pc1.contoso.com'
+            Enabled              = $true
+            OperatingSystem      = 'Windows 11'
+            ServicePrincipalName = @()
+            Action               = 'Not required'
+        }
+        $processedComputers = [ordered] @{
+            'PC1$@contoso.com' = [PSCustomObject] @{
+                SamAccountName    = 'PC1$'
+                DistinguishedName = $computer.DistinguishedName
+                ActionStatus      = $true
+            }
+            'PC2$@contoso.com' = [PSCustomObject] @{
+                SamAccountName    = 'PC2$'
+                DistinguishedName = 'CN=PC2,OU=Workstations,DC=contoso,DC=com'
+                ActionStatus      = $true
+            }
+        }
+        $rollback = [ordered] @{}
+
+        $count = Get-ADComputersToProcess -Type Disable -Computers @($computer) -ActionIf @{} -Exclusions @() -ProcessedComputers $processedComputers -PendingStateRollback $rollback
+
+        $count | Should -Be 1
+        $processedComputers.Keys | Should -Not -Contain 'PC1$@contoso.com'
+        $processedComputers.Keys | Should -Contain 'PC2$@contoso.com'
+        $rollback.Keys | Should -Be @('PC1$@contoso.com')
+        $rollback['PC1$@contoso.com'].ActionStatus | Should -BeTrue
+    }
+
     It 'honors MoveListProcessedMoreThan when staging move candidates' {
         $computer = [PSCustomObject] @{
             SamAccountName       = 'PC1$'


### PR DESCRIPTION
## Summary

- reduce AD cleanup memory pressure by normalizing streamed AD results once and serializing the complete DataTables dataset in bounded chunks
- run each real AD inventory query in an isolated, killable Windows PowerShell process so a dead or stalled domain controller cannot block the whole multi-domain run indefinitely
- separate bounded child/module initialization from a configurable 15-second DC connection timeout and 120-second no-result-progress timeout, while retaining ordered manual controllers, detected fallbacks, retries, and smaller-page recovery
- keep slow or burst-shaped responsive queries alive with time-throttled progress markers and a matching bounded signaling allowance, without writing a progress file for every computer
- embed the child query function in the encoded process command so merged single-file module packages do not depend on the source `Private` folder
- keep inventory setup active under ambient `-WhatIf` while preserving dry-run behavior for every cleanup action
- fail domains closed when explicit per-domain Filter or SearchBase configuration is missing or blank, preventing accidental whole-domain scope broadening
- keep the report self-contained while adding domain inventory status and preserving existing History and Pending views during fail-closed runs
- fail closed by default when a domain fails or SafetyADLimit is not met; successful-domain continuation remains an explicit opt-in

## Compatibility

Existing TargetServers string and per-domain dictionary forms remain supported, including native domain, host:port, and IPv6-compatible Server values. ADQueryConnectionTimeout and ADQueryIdleTimeout are additive parameters. Cold Windows PowerShell and ActiveDirectory-module startup has its own 60-second internal bound and is not charged against the DC connection timeout. The idle timeout is not a total duration limit, so a large healthy domain can continue as long as results keep arriving. Omitting Filter still means `*`, and omitting SearchBase still uses the domain naming context; explicitly supplied blank or incomplete per-domain dictionaries now fail the affected domain closed. Existing ReportOnly/WhatIf behavior, datastore shape, action limits, AD property projection, and cloud/Autopilot boundaries are preserved. No intentional breaking change is introduced.

## Validation

- 171 Pester tests passed in PowerShell 7.6.4 and Windows PowerShell 5.1
- process-level tests prove separate slow initialization, initialization timeout, connection timeout, ready-then-stalled timeout, caller interruption, retry classification, slow/burst progress, ambient WhatIf inventory, embedded packaged-child execution, and typed transport of successful results
- safety tests prove missing, blank, and empty per-domain filters/search bases cannot silently broaden inventory scope
- the reported XE-S-EUR0001.europe.abb.com endpoint returned its native ADWS connection failure through the isolated path in 1.74 seconds on the validation machine
- independent compatibility review, targeted confirmations, timeout-lifecycle closure review, owner-level audit, and final entire-PR completion review completed with all findings addressed
- generated incomplete-inventory report verified in a real browser, including failed-domain status plus retained History and Pending tabs
- synthetic 300k-row report completed in about 158 seconds with about 4.35 GB peak working set and a 246 MB self-contained HTML file

The 300k measurement is synthetic report-generation evidence, not an authenticated live 300k-object AD query benchmark. The merged-package regression has direct command-construction coverage; a fresh package artifact was not produced locally because the repository's pre-existing build wrapper uses documentation options removed from the installed PSPublishModule version.