### PR TITLE
Fix description updates after moving disabled computers

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -18,7 +18,8 @@ Invoke-ModuleBuild -ModuleName 'CleanupMonster' {
     }
     New-ConfigurationManifest @Manifest
 
-    New-ConfigurationModule -Type RequiredModule -Name 'PSSharedGoods', 'PSWriteHTML', 'PSWriteColor', 'PSEventViewer', 'ADEssentials' -Guid Auto -Version Latest
+    New-ConfigurationModule -Type RequiredModule -Name 'PSSharedGoods', 'PSWriteHTML', 'PSEventViewer', 'ADEssentials' -Guid Auto -Version Latest
+    New-ConfigurationModule -Type RequiredModule -Name 'PSWriteColor' -Guid '0b0ba5c5-ec85-4c2b-a718-874e55a8bc3f' -Version '1.0.3'
     New-ConfigurationModule -Type ExternalModule -Name @(
         'ActiveDirectory', 'Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.Management'
         'Microsoft.WSMan.Management', 'NetTCPIP', 'CimCmdlets'

--- a/CleanupMonster.psd1
+++ b/CleanupMonster.psd1
@@ -30,7 +30,7 @@
         }, @{
             Guid          = '0b0ba5c5-ec85-4c2b-a718-874e55a8bc3f'
             ModuleName    = 'PSWriteColor'
-            ModuleVersion = '1.0.4'
+            ModuleVersion = '1.0.3'
         }, @{
             Guid          = '5df72a79-cdf6-4add-b38d-bcacf26fb7bc'
             ModuleName    = 'PSEventViewer'

--- a/Private/Disable-WinADComputer.ps1
+++ b/Private/Disable-WinADComputer.ps1
@@ -9,18 +9,13 @@
     )
     if ($Success) {
         if ($Success -and $Computer.Enabled -eq $true) {
-            Write-Color -Text "[i] Disabling computer ", $Computer.SamAccountName, ' DN: ', $Computer.DistinguishedName, ' Enabled: ', $Computer.Enabled, ' Operating System: ', $Computer.OperatingSystem, ' LastLogon: ', $Computer.LastLogonDate, " / " , $Computer.LastLogonDays , ' days, PasswordLastSet: ', $Computer.PasswordLastSet, " / ", $Computer.PasswordLastChangedDays, " days" -Color Yellow, Green, Yellow, Green, Yellow, Green, Yellow, Green, Yellow, Green, Yellow, Green, Yellow, Green
+            $DN = Get-ADComputerCurrentDistinguishedName -Computer $Computer
+            Write-Color -Text "[i] Disabling computer ", $Computer.SamAccountName, ' DN: ', $DN, ' Enabled: ', $Computer.Enabled, ' Operating System: ', $Computer.OperatingSystem, ' LastLogon: ', $Computer.LastLogonDate, " / " , $Computer.LastLogonDays , ' days, PasswordLastSet: ', $Computer.PasswordLastSet, " / ", $Computer.PasswordLastChangedDays, " days" -Color Yellow, Green, Yellow, Green, Yellow, Green, Yellow, Green, Yellow, Green, Yellow, Green, Yellow, Green
             try {
-                if ($Computer.DistinguishedNameAfterMove) {
-                    $DN = $Computer.DistinguishedNameAfterMove
-                } else {
-                    $DN = $Computer.DistinguishedName
-                }
-
                 Disable-ADAccount -Identity $DN -Server $Server -WhatIf:$WhatIfDisable -ErrorAction Stop
                 Write-Color -Text "[+] Disabling computer ", $DN, " (WhatIf: $WhatIfDisable) successful." -Color Yellow, Green, Yellow
                 if (-not $DontWriteToEventLog) {
-                    Write-Event -ID 10 -LogName 'Application' -EntryType Information -Category 1000 -Source 'CleanupComputers' -Message "Disabling computer $($Computer.SamAccountName) successful." -AdditionalFields @('Disable', $Computer.SamAccountName, $Computer.DistinguishedName, $Computer.Enabled, $Computer.OperatingSystem, $Computer.LastLogonDate, $Computer.PasswordLastSet, $WhatIfDisable) -WarningAction SilentlyContinue -WarningVariable warnings
+                    Write-Event -ID 10 -LogName 'Application' -EntryType Information -Category 1000 -Source 'CleanupComputers' -Message "Disabling computer $($Computer.SamAccountName) successful." -AdditionalFields @('Disable', $Computer.SamAccountName, $DN, $Computer.Enabled, $Computer.OperatingSystem, $Computer.LastLogonDate, $Computer.PasswordLastSet, $WhatIfDisable) -WarningAction SilentlyContinue -WarningVariable warnings
                 }
                 foreach ($W in $Warnings) {
                     Write-Color -Text "[-] ", "Warning: ", $W -Color Yellow, Cyan, Red
@@ -31,7 +26,7 @@
                 $Success = $false
                 Write-Color -Text "[-] Disabling computer ", $DN, " (WhatIf: $WhatIfDisable) failed. Error: $($_.Exception.Message)" -Color Yellow, Red, Yellow
                 if (-not $DontWriteToEventLog) {
-                    Write-Event -ID 10 -LogName 'Application' -EntryType Error -Category 1001 -Source 'CleanupComputers' -Message "Disabling computer $($Computer.SamAccountName) failed. Error: $($_.Exception.Message)" -AdditionalFields @('Disable', $Computer.SamAccountName, $Computer.DistinguishedName, $Computer.Enabled, $Computer.OperatingSystem, $Computer.LastLogonDate, $Computer.PasswordLastSet, $WhatIfDisable, $($_.Exception.Message)) -WarningAction SilentlyContinue -WarningVariable warnings
+                    Write-Event -ID 10 -LogName 'Application' -EntryType Error -Category 1001 -Source 'CleanupComputers' -Message "Disabling computer $($Computer.SamAccountName) failed. Error: $($_.Exception.Message)" -AdditionalFields @('Disable', $Computer.SamAccountName, $DN, $Computer.Enabled, $Computer.OperatingSystem, $Computer.LastLogonDate, $Computer.PasswordLastSet, $WhatIfDisable, $($_.Exception.Message)) -WarningAction SilentlyContinue -WarningVariable warnings
                 }
                 foreach ($W in $Warnings) {
                     Write-Color -Text "[-] ", "Warning: ", $W -Color Yellow, Cyan, Red

--- a/Private/Get-ADComputerCurrentDistinguishedName.ps1
+++ b/Private/Get-ADComputerCurrentDistinguishedName.ps1
@@ -1,0 +1,13 @@
+function Get-ADComputerCurrentDistinguishedName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Computer
+    )
+
+    if ($Computer.DistinguishedNameAfterMove) {
+        $Computer.DistinguishedNameAfterMove
+    } else {
+        $Computer.DistinguishedName
+    }
+}

--- a/Private/Request-ADComputersDisable.ps1
+++ b/Private/Request-ADComputersDisable.ps1
@@ -58,29 +58,25 @@
                     $Success = Disable-WinADComputer -Success $Success -WhatIfDisable:$WhatIfDisable -DontWriteToEventLog:$DontWriteToEventLog -Computer $Computer -Server $Server
                 }
                 if ($Success) {
-                    $ComputerIdentity = if (-not [string]::IsNullOrWhiteSpace($Computer.DistinguishedNameAfterMove)) {
-                        $Computer.DistinguishedNameAfterMove
-                    } else {
-                        $Computer.DistinguishedName
-                    }
+                    $CurrentDistinguishedName = Get-ADComputerCurrentDistinguishedName -Computer $Computer
                     if ($DisableModifyDescription -eq $true) {
                         $DisableModifyDescriptionText = "Disabled by a script, LastLogon $($Computer.LastLogonDate) ($($DisableOnlyIf.LastLogonDateMoreThan)), PasswordLastSet $($Computer.PasswordLastSet) ($($DisableOnlyIf.PasswordLastSetMoreThan))"
                         try {
-                            Set-ADComputer -Identity $ComputerIdentity -Description $DisableModifyDescriptionText -WhatIf:$WhatIfDisable -ErrorAction Stop -Server $Server
-                            Write-Color -Text "[+] ", "Setting description on disabled computer ", $ComputerIdentity, " (WhatIf: $WhatIfDisable) successful. Set to: ", $DisableModifyDescriptionText -Color Yellow, Green, Yellow, Green, Yellow
+                            Set-ADComputer -Identity $CurrentDistinguishedName -Description $DisableModifyDescriptionText -WhatIf:$WhatIfDisable -ErrorAction Stop -Server $Server
+                            Write-Color -Text "[+] ", "Setting description on disabled computer ", $CurrentDistinguishedName, " (WhatIf: $WhatIfDisable) successful. Set to: ", $DisableModifyDescriptionText -Color Yellow, Green, Yellow, Green, Yellow
                         } catch {
                             $Computer.ActionComment = $Computer.ActionComment + [System.Environment]::NewLine + $_.Exception.Message
-                            Write-Color -Text "[-] ", "Setting description on disabled computer ", $ComputerIdentity, " (WhatIf: $WhatIfDisable) failed. Error: $($_.Exception.Message)" -Color Yellow, Red, Yellow
+                            Write-Color -Text "[-] ", "Setting description on disabled computer ", $CurrentDistinguishedName, " (WhatIf: $WhatIfDisable) failed. Error: $($_.Exception.Message)" -Color Yellow, Red, Yellow
                         }
                     }
                     if ($DisableModifyAdminDescription) {
                         $DisableModifyAdminDescriptionText = "Disabled by a script, LastLogon $($Computer.LastLogonDate) ($($DisableOnlyIf.LastLogonDateMoreThan)), PasswordLastSet $($Computer.PasswordLastSet) ($($DisableOnlyIf.PasswordLastSetMoreThan))"
                         try {
-                            Set-ADObject -Identity $ComputerIdentity -Replace @{ AdminDescription = $DisableModifyAdminDescriptionText } -WhatIf:$WhatIfDisable -ErrorAction Stop -Server $Server
-                            Write-Color -Text "[+] ", "Setting admin description on disabled computer ", $ComputerIdentity, " (WhatIf: $WhatIfDisable) successful. Set to: ", $DisableModifyAdminDescriptionText -Color Yellow, Green, Yellow, Green, Yellow
+                            Set-ADObject -Identity $CurrentDistinguishedName -Replace @{ AdminDescription = $DisableModifyAdminDescriptionText } -WhatIf:$WhatIfDisable -ErrorAction Stop -Server $Server
+                            Write-Color -Text "[+] ", "Setting admin description on disabled computer ", $CurrentDistinguishedName, " (WhatIf: $WhatIfDisable) successful. Set to: ", $DisableModifyAdminDescriptionText -Color Yellow, Green, Yellow, Green, Yellow
                         } catch {
-                            $Computer.ActionComment + [System.Environment]::NewLine + $_.Exception.Message
-                            Write-Color -Text "[-] ", "Setting admin description on disabled computer ", $ComputerIdentity, " (WhatIf: $WhatIfDisable) failed. Error: $($_.Exception.Message)" -Color Yellow, Red, Yellow
+                            $Computer.ActionComment = $Computer.ActionComment + [System.Environment]::NewLine + $_.Exception.Message
+                            Write-Color -Text "[-] ", "Setting admin description on disabled computer ", $CurrentDistinguishedName, " (WhatIf: $WhatIfDisable) failed. Error: $($_.Exception.Message)" -Color Yellow, Red, Yellow
                         }
                     }
                 }

--- a/Private/Request-ADComputersDisable.ps1
+++ b/Private/Request-ADComputersDisable.ps1
@@ -58,24 +58,29 @@
                     $Success = Disable-WinADComputer -Success $Success -WhatIfDisable:$WhatIfDisable -DontWriteToEventLog:$DontWriteToEventLog -Computer $Computer -Server $Server
                 }
                 if ($Success) {
+                    $ComputerIdentity = if (-not [string]::IsNullOrWhiteSpace($Computer.DistinguishedNameAfterMove)) {
+                        $Computer.DistinguishedNameAfterMove
+                    } else {
+                        $Computer.DistinguishedName
+                    }
                     if ($DisableModifyDescription -eq $true) {
                         $DisableModifyDescriptionText = "Disabled by a script, LastLogon $($Computer.LastLogonDate) ($($DisableOnlyIf.LastLogonDateMoreThan)), PasswordLastSet $($Computer.PasswordLastSet) ($($DisableOnlyIf.PasswordLastSetMoreThan))"
                         try {
-                            Set-ADComputer -Identity $Computer.DistinguishedName -Description $DisableModifyDescriptionText -WhatIf:$WhatIfDisable -ErrorAction Stop -Server $Server
-                            Write-Color -Text "[+] ", "Setting description on disabled computer ", $Computer.DistinguishedName, " (WhatIf: $WhatIfDisable) successful. Set to: ", $DisableModifyDescriptionText -Color Yellow, Green, Yellow, Green, Yellow
+                            Set-ADComputer -Identity $ComputerIdentity -Description $DisableModifyDescriptionText -WhatIf:$WhatIfDisable -ErrorAction Stop -Server $Server
+                            Write-Color -Text "[+] ", "Setting description on disabled computer ", $ComputerIdentity, " (WhatIf: $WhatIfDisable) successful. Set to: ", $DisableModifyDescriptionText -Color Yellow, Green, Yellow, Green, Yellow
                         } catch {
                             $Computer.ActionComment = $Computer.ActionComment + [System.Environment]::NewLine + $_.Exception.Message
-                            Write-Color -Text "[-] ", "Setting description on disabled computer ", $Computer.DistinguishedName, " (WhatIf: $WhatIfDisable) failed. Error: $($_.Exception.Message)" -Color Yellow, Red, Yellow
+                            Write-Color -Text "[-] ", "Setting description on disabled computer ", $ComputerIdentity, " (WhatIf: $WhatIfDisable) failed. Error: $($_.Exception.Message)" -Color Yellow, Red, Yellow
                         }
                     }
                     if ($DisableModifyAdminDescription) {
                         $DisableModifyAdminDescriptionText = "Disabled by a script, LastLogon $($Computer.LastLogonDate) ($($DisableOnlyIf.LastLogonDateMoreThan)), PasswordLastSet $($Computer.PasswordLastSet) ($($DisableOnlyIf.PasswordLastSetMoreThan))"
                         try {
-                            Set-ADObject -Identity $Computer.DistinguishedName -Replace @{ AdminDescription = $DisableModifyAdminDescriptionText } -WhatIf:$WhatIfDisable -ErrorAction Stop -Server $Server
-                            Write-Color -Text "[+] ", "Setting admin description on disabled computer ", $Computer.DistinguishedName, " (WhatIf: $WhatIfDisable) successful. Set to: ", $DisableModifyAdminDescriptionText -Color Yellow, Green, Yellow, Green, Yellow
+                            Set-ADObject -Identity $ComputerIdentity -Replace @{ AdminDescription = $DisableModifyAdminDescriptionText } -WhatIf:$WhatIfDisable -ErrorAction Stop -Server $Server
+                            Write-Color -Text "[+] ", "Setting admin description on disabled computer ", $ComputerIdentity, " (WhatIf: $WhatIfDisable) successful. Set to: ", $DisableModifyAdminDescriptionText -Color Yellow, Green, Yellow, Green, Yellow
                         } catch {
                             $Computer.ActionComment + [System.Environment]::NewLine + $_.Exception.Message
-                            Write-Color -Text "[-] ", "Setting admin description on disabled computer ", $Computer.DistinguishedName, " (WhatIf: $WhatIfDisable) failed. Error: $($_.Exception.Message)" -Color Yellow, Red, Yellow
+                            Write-Color -Text "[-] ", "Setting admin description on disabled computer ", $ComputerIdentity, " (WhatIf: $WhatIfDisable) failed. Error: $($_.Exception.Message)" -Color Yellow, Red, Yellow
                         }
                     }
                 }

--- a/Tests/Disable-WinADComputer.Tests.ps1
+++ b/Tests/Disable-WinADComputer.Tests.ps1
@@ -1,5 +1,6 @@
 Describe 'Disable-WinADComputer' {
     BeforeAll {
+        . "$PSScriptRoot/../Private/Get-ADComputerCurrentDistinguishedName.ps1"
         . "$PSScriptRoot/../Private/Disable-WinADComputer.ps1"
     }
 
@@ -7,6 +8,7 @@ Describe 'Disable-WinADComputer' {
         $computer = [pscustomobject]@{
             SamAccountName                   = 'TEST$'
             DistinguishedName                = 'CN=Test,CN=Computers,DC=example,DC=com'
+            DistinguishedNameAfterMove       = $null
             Enabled                          = $true
             OperatingSystem                  = 'Windows'
             LastLogonDate                    = Get-Date
@@ -20,11 +22,61 @@ Describe 'Disable-WinADComputer' {
         function Write-Color { param([Parameter(ValueFromRemainingArguments)][object[]]$Args) }
         function Write-Event { param([Parameter(ValueFromRemainingArguments)][object[]]$Args) }
 
-        function Disable-ADAccount { param([Parameter(ValueFromRemainingArguments)][object[]]$Args) $global:DisableCalled = $true }
+        function Disable-ADAccount {
+            [CmdletBinding(SupportsShouldProcess)]
+            param($Identity, $Server)
+
+            $global:DisableCalled = $true
+            $global:DisabledIdentity = $Identity
+        }
 
         Disable-WinADComputer -Success $true -Computer $computer -Server 'server' -WhatIfDisable:$false -DontWriteToEventLog | Out-Null
 
         $global:FlagRemoved | Should -Be $false
         $global:DisableCalled | Should -Be $true
+        $global:DisabledIdentity | Should -Be $computer.DistinguishedName
+    }
+
+    It 'uses the post-move distinguished name for disabling and event data' {
+        $movedDistinguishedName = 'CN=Test,OU=Disabled,DC=example,DC=com'
+        $computer = [pscustomobject]@{
+            SamAccountName             = 'TEST$'
+            DistinguishedName          = 'CN=Test,CN=Computers,DC=example,DC=com'
+            DistinguishedNameAfterMove = $movedDistinguishedName
+            Enabled                    = $true
+            OperatingSystem            = 'Windows'
+            LastLogonDate              = Get-Date
+            LastLogonDays              = 0
+            PasswordLastSet            = Get-Date
+            PasswordLastChangedDays    = 0
+        }
+        $script:DisabledIdentity = $null
+        $script:DisableEventFields = $null
+        function Write-Color { param([Parameter(ValueFromRemainingArguments)][object[]]$Args) }
+        function Disable-ADAccount {
+            [CmdletBinding(SupportsShouldProcess)]
+            param($Identity, $Server)
+
+            $script:DisabledIdentity = $Identity
+        }
+        function Write-Event {
+            [CmdletBinding()]
+            param(
+                $ID,
+                $LogName,
+                $EntryType,
+                $Category,
+                $Source,
+                $Message,
+                $AdditionalFields
+            )
+
+            $script:DisableEventFields = $AdditionalFields
+        }
+
+        Disable-WinADComputer -Success $true -Computer $computer -Server 'server' | Out-Null
+
+        $script:DisabledIdentity | Should -Be $movedDistinguishedName
+        $script:DisableEventFields[2] | Should -Be $movedDistinguishedName
     }
 }

--- a/Tests/Request-ADComputersDisable.Tests.ps1
+++ b/Tests/Request-ADComputersDisable.Tests.ps1
@@ -1,11 +1,20 @@
 BeforeAll {
     . "$PSScriptRoot\TestHelpers.ps1"
     . (Get-CleanupMonsterPath 'Private/Get-ADComputersToProcess.ps1')
+    . (Get-CleanupMonsterPath 'Private/Get-ADComputerCurrentDistinguishedName.ps1')
     . (Get-CleanupMonsterPath 'Private/Request-ADComputersDisable.ps1')
 
     function Write-Color { param([Parameter(ValueFromRemainingArguments = $true)] $Text, [object[]] $Color) }
     function Disable-WinADComputer {}
     function Move-WinADComputer {}
+    function Set-ADComputer {
+        [CmdletBinding(SupportsShouldProcess)]
+        param($Identity, $Description, $Server)
+    }
+    function Set-ADObject {
+        [CmdletBinding(SupportsShouldProcess)]
+        param($Identity, $Replace, $Server)
+    }
 }
 
 Describe 'Request-ADComputersDisable pending state' {
@@ -92,6 +101,74 @@ Describe 'Request-ADComputersDisable pending state' {
 
         $processedComputers.Keys | Should -Contain 'PC3$@contoso.com'
         $processedComputers['PC3$@contoso.com'].ActionStatus | Should -BeTrue
+    }
+
+    It 'updates both descriptions through the post-move distinguished name' {
+        $originalDistinguishedName = 'CN=PC4,OU=Workstations,DC=contoso,DC=com'
+        $movedDistinguishedName = 'CN=PC4,OU=Disabled,DC=contoso,DC=com'
+        $script:SetADComputerIdentity = $null
+        $script:SetADObjectIdentity = $null
+        Mock Disable-WinADComputer { $true }
+        Mock Move-WinADComputer {
+            param($Success, $Computer)
+
+            $Computer.DistinguishedNameAfterMove = $movedDistinguishedName
+            $Success
+        }
+        Mock Set-ADComputer { $script:SetADComputerIdentity = $Identity }
+        Mock Set-ADObject { $script:SetADObjectIdentity = $Identity }
+
+        $processedComputers = [ordered] @{}
+        $computer = [PSCustomObject] @{
+            SamAccountName             = 'PC4$'
+            DistinguishedName          = $originalDistinguishedName
+            DistinguishedNameAfterMove = $null
+            LastLogonDate              = (Get-Date).AddDays(-90)
+            PasswordLastSet            = (Get-Date).AddDays(-90)
+            Action                     = 'Disable'
+            ActionStatus               = $null
+            ActionDate                 = $null
+            ActionComment              = $null
+        }
+        $report = [ordered] @{
+            'contoso.com' = [ordered] @{
+                Server    = 'dc1.contoso.com'
+                Computers = @($computer)
+            }
+        }
+
+        Request-ADComputersDisable -DisableAndMove $true -DisableMoveTargetOrganizationalUnit @{ 'contoso.com' = 'OU=Disabled,DC=contoso,DC=com' } -Report $report -ProcessedComputers $processedComputers -DisableOnlyIf @{} -DisableModifyDescription -DisableModifyAdminDescription -DisableLimit 1 -Today (Get-Date) | Out-Null
+
+        $script:SetADComputerIdentity | Should -Be $movedDistinguishedName
+        $script:SetADObjectIdentity | Should -Be $movedDistinguishedName
+    }
+
+    It 'records admin-description update failures in the action comment' {
+        Mock Disable-WinADComputer { $true }
+        Mock Set-ADObject { throw 'Directory update failed' }
+
+        $processedComputers = [ordered] @{}
+        $computer = [PSCustomObject] @{
+            SamAccountName             = 'PC5$'
+            DistinguishedName          = 'CN=PC5,OU=Workstations,DC=contoso,DC=com'
+            DistinguishedNameAfterMove = $null
+            LastLogonDate              = (Get-Date).AddDays(-90)
+            PasswordLastSet            = (Get-Date).AddDays(-90)
+            Action                     = 'Disable'
+            ActionStatus               = $null
+            ActionDate                 = $null
+            ActionComment              = $null
+        }
+        $report = [ordered] @{
+            'contoso.com' = [ordered] @{
+                Server    = 'dc1.contoso.com'
+                Computers = @($computer)
+            }
+        }
+
+        Request-ADComputersDisable -Report $report -ProcessedComputers $processedComputers -DisableOnlyIf @{} -DisableModifyAdminDescription -DisableLimit 1 -Today (Get-Date) | Out-Null
+
+        $computer.ActionComment | Should -Match 'Directory update failed'
     }
 
     It 'does not promote pending records that were not successful real actions' {


### PR DESCRIPTION
Fixes #57.

After a computer is moved, description and `adminDescription` updates now use its post-move distinguished name. The same current-DN resolution is used when disabling in `MoveAndDisable` order so command output and event data identify the object consistently.

This also:

- records `adminDescription` update failures in `ActionComment`
- keeps the PSWriteColor requirement on the published 1.0.3 release so manifest imports work
- adds regression coverage for moved and non-moved computers